### PR TITLE
Refactor INCLUDE_ASM

### DIFF
--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -1,0 +1,19 @@
+#ifndef __INCLUDE_ASM_H__
+#define __INCLUDE_ASM_H__
+
+#define STRINGIFY_(x) #x
+#define STRINGIFY(x) STRINGIFY_(x)
+
+#if !defined(SPLAT) && !defined(__CTX__)
+#ifndef INCLUDE_ASM
+#define INCLUDE_ASM(TYPE, FOLDER, NAME, ARGS...) \
+   TYPE NAME(ARGS); \
+  TYPE __attribute__((naked)) NAME(ARGS) { __asm__( ".include \"ver/"STRINGIFY(VERSION)"/asm/nonmatchings/"FOLDER"/"#NAME".s\"\n.set reorder\n.set at"); }
+#endif
+__asm__( ".include \"include/macro.inc\"\n");
+#else
+#define INCLUDE_ASM(TYPE, FOLDER, NAME, ARGS...)
+#endif
+
+
+#endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -2,18 +2,7 @@
 #define _MACROS_H_
 
 #include "common.h"
-
-#define STRINGIFY_(x) #x
-#define STRINGIFY(x) STRINGIFY_(x)
-
-#ifndef SPLAT
-#ifndef INCLUDE_ASM
-#define INCLUDE_ASM(TYPE, FOLDER, NAME, ARGS...) \
-  TYPE __attribute__((naked)) NAME(ARGS) { __asm__( ".include \"include/macro.inc\"\n.include \"ver/"STRINGIFY(VERSION)"/asm/nonmatchings/"FOLDER"/"#NAME".s\"\n.set reorder\n.set at"); }
-#endif
-#else
-#define INCLUDE_ASM(TYPE, FOLDER, NAME, ARGS...)
-#endif
+#include "include_asm.h"
 
 #define ALIGN16(val) (((val) + 0xF) & ~0xF)
 


### PR DESCRIPTION
This only includes the asm macro file once per c file, which helps improve compatibility with newer assemblers. I plan on soon adding support for other move pseudoinstructions so we can match more of libultra, which this paves the way for.