### PR TITLE
Updates for Star Rod 0.4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ assets/
 /logs
 /out
 dump
+*.backup
 
 /tools/Yay0compress
 /tools/n64crc

--- a/tools/splat_ext/PaperMarioNpcSprites.py
+++ b/tools/splat_ext/PaperMarioNpcSprites.py
@@ -138,8 +138,8 @@ class Sprite:
         SpriteSheet = xml.getroot()
 
         true_max_components = 0
-        self.max_components = int(SpriteSheet.get("a"))
-        self.num_variations = int(SpriteSheet.get("b"))
+        self.max_components = int(SpriteSheet.get("a") or SpriteSheet.get("maxComponents")) # ignored
+        self.num_variations = int(SpriteSheet.get("b") or SpriteSheet.get("paletteGroups"))
 
         for Palette in SpriteSheet.findall("./PaletteList/Palette"):
             if read_images:
@@ -147,11 +147,12 @@ class Sprite:
                 img.preamble(True)
                 palette = img.palette(alpha="force")
 
+                palette = palette[0:16]
                 assert len(palette) == 16
 
                 self.palettes.append(palette)
 
-            self.palette_names.append(Palette.get("src").split(".png")[0])
+            self.palette_names.append(Palette.get("name", Palette.get("src").split(".png")[0]))
 
         for Raster in SpriteSheet.findall("./RasterList/Raster"):
             if read_images:
@@ -193,7 +194,8 @@ class Sprite:
             if len(components) > true_max_components:
                 true_max_components = len(components)
 
-        assert self.max_components == true_max_components, f"{true_max_components} component(s) used, but SpriteSheet.a = {self.max_components}"
+        self.max_components = true_max_components
+        #assert self.max_components == true_max_components, f"{true_max_components} component(s) used, but SpriteSheet.a = {self.max_components}"
 
         return self
 


### PR DESCRIPTION
SpriteSheet.xml's `a` and `b` were renamed in Star Rod 0.4.2, although the old names still work, and clover told me to ignore the value of `a` when compiling