### PR TITLE
Fix configure on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ Copy an unmodified Paper Mario (USA) ROM (sha1: `3837f44cda784b466c9a2d99df70d77
 
 Configure the build and extract assets from the base ROM:
 ```sh
-./configure.py
+./configure
 ```
 
 Compile the game:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
             steps {
                 sh 'cp /usr/local/etc/roms/papermario.us.z64 ver/us/baserom.z64'
                 sh 'cp /usr/local/etc/roms/papermario.jp.z64 ver/jp/baserom.z64'
-                sh './configure.py'
+                sh './configure'
             }
         }
         stage('Build') {

--- a/configure
+++ b/configure
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python3 tools/build/configure.py "$@"

--- a/configure.py
+++ b/configure.py
@@ -1,1 +1,0 @@
-tools/build/configure.py

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -420,11 +420,11 @@ if __name__ == "__main__":
     exec_shell(["make", "-C", str(ROOT / args.splat)])
 
     # on macOS, /usr/bin/cpp defaults to clang rather than gcc (but we need gcc's)
-    if args.cpp is None and sys.platform == "darwin" and "Free Software Foundation" not in shell("cpp --version"):
+    if args.cpp is None and sys.platform == "darwin" and "Free Software Foundation" not in exec_shell("cpp --version"):
         print("error: system C preprocessor is not GNU!")
         print("This is a known issue on macOS - only clang's cpp is installed by default.")
         print("Use 'brew' to obtain GNU cpp, then run this script again with the --cpp option, e.g.")
-        print("    ./configure.py --cpp cpp-10")
+        print("    ./configure --cpp cpp-10")
         exit(1)
 
     # default version behaviour is to only do those that exist


### PR DESCRIPTION
Also changed the root-level `configure.py` symlink to a bash script called `configure`. This means we can write `./configure jp` instead of `./configure.py jp` now, which better matches the 'typical' `./configure; make` routine in a lot of projects. It also keeps `configure.py` in `tools/build/` where I think it belongs.