### PR TITLE
Cleaned up some code related to u32->f32 casts

### DIFF
--- a/src/43F0.c
+++ b/src/43F0.c
@@ -506,14 +506,9 @@ s32 advance_rng(void) {
 }
 
 f32 rand_float(void) {
-    s32 temp_v0 = advance_rng() & 0x7FFF;
-    f64 temp_f2 = temp_v0;
+    u32 temp_v0 = advance_rng() & 0x7FFF;
 
-    if (temp_v0 < 0) {
-        temp_f2 += 4294967296.0;
-    }
-
-    return temp_f2 * 3.0517578125e-05;
+    return temp_v0 / 32768.0;
 }
 
 s32 func_80029994(s32 arg0) {

--- a/src/C50A0.c
+++ b/src/C50A0.c
@@ -24,17 +24,13 @@ INCLUDE_ASM(s32, "C50A0", draw_image_with_clipping);
 
 INCLUDE_ASM(s32, "C50A0", draw_tiled_image);
 
-s32 integer_log(s32 number, s32 base) {
+s32 integer_log(s32 number, u32 base) {
     f64 temp_f0;
     f32 fNumber = number;
     s32 ret = 1;
 
     while (TRUE) {
-        temp_f0 = base;
-        if (base < 0) {
-            temp_f0 += 4294967296.0;
-        }
-        fNumber /= (f32)temp_f0;
+        fNumber /= base;
         if (fNumber <= 1.0) {
             return ret;
         }


### PR DESCRIPTION
Any code that looks like
```c
f32 u32_to_f32(u32 num)
{
    s32 num_s = (s32)num;
    f64 num_d = (f64)num_s;
    if (num_s < 0)
    {
        num_d += 4294967296.0;
    }
    return (f32)num_d;
}
```
can be written as
```c
f32 u32_to_f32(u32 num) {
    return (float)num;
}
```