### PR TITLE
Convert DSL scripts into macro syntax

### DIFF
--- a/include/evt.h
+++ b/include/evt.h
@@ -69,7 +69,7 @@ enum {
     EVT_OP_FBUF_PEEK, ///< Args: index, container
     EVT_OP_USE_ARRAY, ///< Args: *s32
     EVT_OP_USE_FLAGS, ///< Args: *s32
-    EVT_OP_NEW_ARRAY, ///< Allocates a new array. Args: length, s32*
+    EVT_OP_MALLOC_ARRAY, ///< Allocates a new array. Args: length, s32*
     EVT_OP_BITWISE_AND, ///< Args: container, expression to bitwise AND with
     EVT_OP_BITWISE_AND_CONST, ///< Args: container, value to bitwise AND with
     EVT_OP_BITWISE_OR, ///< Args: container, expression to bitwise OR with

--- a/src/evt/evt.c
+++ b/src/evt/evt.c
@@ -1540,7 +1540,7 @@ s32 evt_execute_next_command(Evt *script) {
             case EVT_OP_USE_FLAGS:
                 status = evt_handle_set_flag_array(script);
                 break;
-            case EVT_OP_NEW_ARRAY:
+            case EVT_OP_MALLOC_ARRAY:
                 status = evt_handle_allocate_array(script);
                 break;
             case EVT_OP_KILL_THREAD:

--- a/src/world/area_dgb/dgb_05/C3AA10.c
+++ b/src/world/area_dgb/dgb_05/C3AA10.c
@@ -22,111 +22,119 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_05_tattle },
 };
 
-EvtSource N(802414E0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(802414E0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1578)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_80241580) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 16;
-    EVT_VAR(2) = 30;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_03", 2);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80241580) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 16)
+    EVT_SET(EVT_VAR(2), 30)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_03"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_80241634) = SCRIPT({
-    UseDoorSounds(0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 30;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-        }
-    }
-});
+EvtSource N(enterSingleDoor_80241634) = {
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 30)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    if (EVT_STORY_PROGRESS < STORY_CH3_STAR_SPIRIT_RESCUED) {
-        MakeNpcs(1, N(npcGroupList_8024230C));
-    }
-    await N(makeEntities);
-    spawn N(802417F0);
-    ModifyColliderFlags(0, 18, 0x7FFFFE00);
-    EnableModel(20, 0);
-    bind N(exitSingleDoor_80241580) TRIGGER_WALL_PRESS_A 16;
-    spawn N(802414E0);
-    spawn N(enterSingleDoor_80241634);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_IF_LT(EVT_SAVE_VAR(0), -15)
+        EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_8024230C)))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(802417F0))
+    EVT_CALL(ModifyColliderFlags, 0, 18, 0x7FFFFE00)
+    EVT_CALL(EnableModel, 20, 0)
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80241580), TRIGGER_WALL_PRESS_A, 16, 1, 0)
+    EVT_EXEC(N(802414E0))
+    EVT_EXEC(N(enterSingleDoor_80241634))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_17E8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(802417F0) = SCRIPT({
-    N(func_80240000_C3AA10)();
-    func_802CA988(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    N(func_80240030_C3AA40)();
-    EVT_SAVE_FLAG(1047) = 1;
-    GotoMap("dgb_06", 1);
-    sleep 100;
-});
+EvtSource N(802417F0) = {
+    EVT_CALL(N(func_80240000_C3AA10))
+    EVT_CALL(func_802CA988, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(N(func_80240030_C3AA40))
+    EVT_SET(EVT_SAVE_FLAG(1047), 1)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_06"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1868)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    if (EVT_SAVE_FLAG(1047) == 0) {
-        MakeEntity(0x802BCE84, 510, -210, 100, 0, MAKE_ENTITY_END);
-    }
-});
+EvtSource N(makeEntities) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1047), 0)
+        EVT_CALL(MakeEntity, 0x802BCE84, 510, -210, 100, 0, MAKE_ENTITY_END)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_18BC) = {
     0x00000000,
 };
 
-EvtSource N(802418C0) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(802418C0) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(unk_missing_8024197C)[] = {
     0x00390000, 0x00390002, 0x00390003, 0x00390004, 0x0039000C, 0x00390007, 0x00390008, 0x00390011,
@@ -153,13 +161,15 @@ NpcAISettings N(npcAISettings_802419AC) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802419DC) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 10);
-    SetSelfVar(2, 14);
-    SetSelfVar(3, 18);
-    N(func_80240E80_C3B890)(N(npcAISettings_802419AC));
-});
+EvtSource N(npcAI_802419DC) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 10)
+    EVT_CALL(SetSelfVar, 2, 14)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(N(func_80240E80_C3B890), EVT_PTR(N(npcAISettings_802419AC)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80241A4C) = {
     .height = 36,
@@ -170,16 +180,18 @@ NpcSettings N(npcSettings_80241A4C) = {
     .level = 13,
 };
 
-EvtSource N(npcAI_80241A78) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(npcAI_80241A78) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80241B20) = {
     .height = 14,

--- a/src/world/area_dgb/dgb_06/C3D080.c
+++ b/src/world/area_dgb/dgb_06/C3D080.c
@@ -18,113 +18,123 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_06_tattle },
 };
 
-EvtSource N(80240320) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240320) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3B8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_802403C0) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 12;
-    EVT_VAR(2) = 5;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_04", 1);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_802403C0) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 12)
+    EVT_SET(EVT_VAR(2), 5)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_04"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_80240474) = SCRIPT({
-    UseDoorSounds(0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 5;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-        }
-    }
-});
+EvtSource N(enterSingleDoor_80240474) = {
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 5)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(589824);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(1, N(npcGroupList_80240B44));
-    await N(makeEntities);
-    if (EVT_SAVE_FLAG(1047) == 0) {
-        EnableGroup(28, 0);
-    } else {
-        EnableGroup(25, 0);
-    }
-    bind N(exitSingleDoor_802403C0) TRIGGER_WALL_PRESS_A 12;
-    spawn N(80240320);
-    spawn N(enterSingleDoor_80240474);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, 589824)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_80240B44)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1047), 0)
+        EVT_CALL(EnableGroup, 28, 0)
+    EVT_ELSE
+        EVT_CALL(EnableGroup, 25, 0)
+    EVT_END_IF
+    EVT_BIND_TRIGGER(N(exitSingleDoor_802403C0), TRIGGER_WALL_PRESS_A, 12, 1, 0)
+    EVT_EXEC(N(80240320))
+    EVT_EXEC(N(enterSingleDoor_80240474))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/StashVars.inc.c"
 
-EvtSource N(80240624) = SCRIPT({
-    group 0;
-    SetTimeFreezeMode(2);
-    sleep 40;
-    ShowGotItem(EVT_VAR(0), 0, 0);
-    SetTimeFreezeMode(0);
-    return;
-});
+EvtSource N(80240624) = {
+    EVT_SET_GROUP(0)
+    EVT_CALL(SetTimeFreezeMode, 2)
+    EVT_WAIT_FRAMES(40)
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 0, 0)
+    EVT_CALL(SetTimeFreezeMode, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024068C) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    EVT_VAR(0) = EVT_VAR(10);
-    if (EVT_VAR(10) != 0) {
-        await N(80240624);
-    }
-    match EVT_VAR(11) {
-        == 0 {
-            AddItem(EVT_VAR(10), EVT_VAR(0));
-        }
-        == 1 {
-            AddKeyItem(EVT_VAR(10));
-        }
-        == 2 {
-            AddBadge(EVT_VAR(10), EVT_VAR(0));
-        }
-    }
-    sleep 15;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(8024068C) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_EXEC_WAIT(N(80240624))
+    EVT_END_IF
+    EVT_SWITCH(EVT_VAR(11))
+        EVT_CASE_EQ(0)
+            EVT_CALL(AddItem, EVT_VAR(10), EVT_VAR(0))
+        EVT_CASE_EQ(1)
+            EVT_CALL(AddKeyItem, EVT_VAR(10))
+        EVT_CASE_EQ(2)
+            EVT_CALL(AddBadge, EVT_VAR(10), EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024076C) = SCRIPT({
-    EVT_VAR(10) = 19;
-    EVT_VAR(11) = 1;
-    EVT_SAVE_FLAG(1048) = 1;
-    await N(8024068C);
-});
+EvtSource N(8024076C) = {
+    EVT_SET(EVT_VAR(10), 19)
+    EVT_SET(EVT_VAR(11), 1)
+    EVT_SET(EVT_SAVE_FLAG(1048), 1)
+    EVT_EXEC_WAIT(N(8024068C))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EAE30, -300, 50, -200, 0, ITEM_NONE, MAKE_ENTITY_END);
-    AssignFlag(EVT_SAVE_FLAG(1048));
-    AssignScript(N(8024076C));
-    MakeEntity(0x802EA7E0, -125, 60, 175, 0, MAKE_ENTITY_END);
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EAE30, -300, 50, -200, 0, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignFlag, EVT_SAVE_FLAG(1048))
+    EVT_CALL(AssignScript, EVT_PTR(N(8024076C)))
+    EVT_CALL(MakeEntity, 0x802EA7E0, -125, 60, 175, 0, MAKE_ENTITY_END)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_834)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -136,24 +146,26 @@ NpcSettings N(npcSettings_80240840) = {
     .level = 99,
 };
 
-EvtSource N(interact_8024086C) = SCRIPT({
-    if (EVT_AREA_FLAG(4) == 0) {
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_boo_Palette_01_Anim_4, NPC_ANIM_boo_Palette_01_Anim_1, 0, MESSAGE_ID(0x0E,
-                      0x00F0));
-        EVT_AREA_FLAG(4) = 1;
-    } else {
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_boo_Palette_01_Anim_4, NPC_ANIM_boo_Palette_01_Anim_1, 0, MESSAGE_ID(0x0E,
-                      0x00F1));
-        EVT_AREA_FLAG(4) = 0;
-    }
-});
+EvtSource N(interact_8024086C) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(4), 0)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_boo_Palette_01_Anim_4, NPC_ANIM_boo_Palette_01_Anim_1, 0, MESSAGE_ID(0x0E, 0x00F0))
+        EVT_SET(EVT_AREA_FLAG(4), 1)
+    EVT_ELSE
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_boo_Palette_01_Anim_4, NPC_ANIM_boo_Palette_01_Anim_1, 0, MESSAGE_ID(0x0E, 0x00F1))
+        EVT_SET(EVT_AREA_FLAG(4), 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802408FC) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH3_TUBBA_CHASED_MARIO_IN_FOYER) {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-    BindNpcInteract(NPC_SELF, N(interact_8024086C));
-});
+EvtSource N(init_802408FC) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), -26)
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024086C)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80240954) = {
     .id = NPC_BOO,

--- a/src/world/area_dgb/dgb_07/C3DBF0.c
+++ b/src/world/area_dgb/dgb_07/C3DBF0.c
@@ -21,91 +21,97 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_07_tattle },
 };
 
-EvtSource N(80241490) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80241490) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1528)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_80241530) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 6;
-    EVT_VAR(2) = 22;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_02", 2);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80241530) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 6)
+    EVT_SET(EVT_VAR(2), 22)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_02"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_802415E4) = SCRIPT({
-    UseDoorSounds(0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 22;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-        }
-    }
-});
+EvtSource N(enterSingleDoor_802415E4) = {
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 22)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    if (EVT_STORY_PROGRESS < STORY_CH3_STAR_SPIRIT_RESCUED) {
-        MakeNpcs(1, N(npcGroupList_80241E5C));
-    }
-    await N(makeEntities);
-    bind N(exitSingleDoor_80241530) TRIGGER_WALL_PRESS_A 6;
-    spawn N(80241490);
-    spawn N(enterSingleDoor_802415E4);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_IF_LT(EVT_SAVE_VAR(0), -15)
+        EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_80241E5C)))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80241530), TRIGGER_WALL_PRESS_A, 6, 1, 0)
+    EVT_EXEC(N(80241490))
+    EVT_EXEC(N(enterSingleDoor_802415E4))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeItemEntity(ITEM_STAR_PIECE, -220, 75, -210, 17, EVT_SAVE_FLAG(1050));
-    MakeEntity(0x802EAED4, -370, 0, -200, 0, -1, MAKE_ENTITY_END);
-    MakeEntity(0x802EAED4, -410, 0, -200, 0, -1, MAKE_ENTITY_END);
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeItemEntity, ITEM_STAR_PIECE, -220, 75, -210, 17, EVT_SAVE_FLAG(1050))
+    EVT_CALL(MakeEntity, 0x802EAED4, -370, 0, -200, 0, -1, MAKE_ENTITY_END)
+    EVT_CALL(MakeEntity, 0x802EAED4, -410, 0, -200, 0, -1, MAKE_ENTITY_END)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_17E4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(802417F0) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(802417F0) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(extraAnimationList_802418AC)[] = {
     NPC_ANIM_world_clubba_Palette_00_Anim_0,
@@ -140,13 +146,15 @@ NpcAISettings N(npcAISettings_802418DC) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_8024190C) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 10);
-    SetSelfVar(2, 14);
-    SetSelfVar(3, 18);
-    N(func_80240E20_C3EA10)(N(npcAISettings_802418DC));
-});
+EvtSource N(npcAI_8024190C) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 10)
+    EVT_CALL(SetSelfVar, 2, 14)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(N(func_80240E20_C3EA10), EVT_PTR(N(npcAISettings_802418DC)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024197C) = {
     .height = 36,
@@ -157,16 +165,18 @@ NpcSettings N(npcSettings_8024197C) = {
     .level = 13,
 };
 
-EvtSource N(npcAI_802419A8) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(npcAI_802419A8) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80241A50) = {
     .height = 14,

--- a/src/world/area_dgb/dgb_08/C3FDB0.c
+++ b/src/world/area_dgb/dgb_08/C3FDB0.c
@@ -30,95 +30,98 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_08_tattle },
 };
 
-EvtSource N(80243CF0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80243CF0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3D88)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitDoubleDoor_80243D90) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 14;
-    EVT_VAR(2) = 23;
-    EVT_VAR(3) = 25;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_01", 2);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80243D90) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 14)
+    EVT_SET(EVT_VAR(2), 23)
+    EVT_SET(EVT_VAR(3), 25)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_01"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitDoubleDoor_80243E44) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 1;
-    EVT_VAR(1) = 18;
-    EVT_VAR(2) = 18;
-    EVT_VAR(3) = 20;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_01", 4);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80243E44) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_SET(EVT_VAR(1), 18)
+    EVT_SET(EVT_VAR(2), 18)
+    EVT_SET(EVT_VAR(3), 20)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_01"), 4)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 const s32 N(pad_XXXX)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(enterDoubleDoor_80243EF8) = SCRIPT({
-    UseDoorSounds(3);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 23;
-            EVT_VAR(3) = 25;
-            await EnterDoubleDoor;
-        }
-        == 1 {
-            EVT_VAR(2) = 18;
-            EVT_VAR(3) = 20;
-            await EnterDoubleDoor;
-        }
-    }
-});
+EvtSource N(enterDoubleDoor_80243EF8) = {
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 23)
+            EVT_SET(EVT_VAR(3), 25)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+        EVT_CASE_EQ(1)
+            EVT_SET(EVT_VAR(2), 18)
+            EVT_SET(EVT_VAR(3), 20)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_SMASHED_THE_BRIDGES {
-            MakeNpcs(1, N(npcGroupList_80246958));
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            MakeNpcs(1, N(npcGroupList_802469AC));
-        }
-        < STORY_CH6_RETURNED_TO_TOAD_TOWN {
-            MakeNpcs(1, N(npcGroupList_802469C4));
-        }
-    }
-    await N(802469E0);
-    bind N(exitDoubleDoor_80243D90) TRIGGER_WALL_PRESS_A 14;
-    bind N(exitDoubleDoor_80243E44) TRIGGER_WALL_PRESS_A 18;
-    spawn N(80243CF0);
-    spawn N(enterDoubleDoor_80243EF8);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-28)
+            EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_80246958)))
+        EVT_CASE_LT(-16)
+            EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_802469AC)))
+        EVT_CASE_LT(60)
+            EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_802469C4)))
+    EVT_END_SWITCH
+    EVT_EXEC_WAIT(N(802469E0))
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80243D90), TRIGGER_WALL_PRESS_A, 14, 1, 0)
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80243E44), TRIGGER_WALL_PRESS_A, 18, 1, 0)
+    EVT_EXEC(N(80243CF0))
+    EVT_EXEC(N(enterDoubleDoor_80243EF8))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_40FC) = {
     0x00000000,
@@ -137,9 +140,11 @@ NpcAISettings N(npcAI_80244100) = {
     .unk_2C = 1,
 };
 
-EvtSource N(80244130) = SCRIPT({
-    N(func_80240B94_C40944)(N(npcAI_80244100));
-});
+EvtSource N(80244130) = {
+    EVT_CALL(N(func_80240B94_C40944), EVT_PTR(N(npcAI_80244100)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244150) = {
     .height = 90,
@@ -164,22 +169,21 @@ NpcSettings N(npcSettings_802441A8) = {
     .level = 13,
 };
 
-EvtSource N(802441D4) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(802441D4) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(extraAnimationList_80244290)[] = {
     NPC_ANIM_world_clubba_Palette_00_Anim_0,
@@ -214,13 +218,15 @@ NpcAISettings N(npcAISettings_802442C0) = {
     .unk_2C = 3,
 };
 
-EvtSource N(npcAI_802442F0) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 5);
-    SetSelfVar(2, 8);
-    SetSelfVar(3, 12);
-    N(func_802414AC_C4125C)(N(npcAISettings_802442C0));
-});
+EvtSource N(npcAI_802442F0) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 5)
+    EVT_CALL(SetSelfVar, 2, 8)
+    EVT_CALL(SetSelfVar, 3, 12)
+    EVT_CALL(N(func_802414AC_C4125C), EVT_PTR(N(npcAISettings_802442C0)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244360) = {
     .height = 36,
@@ -231,16 +237,18 @@ NpcSettings N(npcSettings_80244360) = {
     .level = 13,
 };
 
-EvtSource N(npcAI_8024438C) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(npcAI_8024438C) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244434) = {
     .height = 14,
@@ -256,10 +264,12 @@ f32 N(D_80244460_C44210)[] = {
     1.5f, 20.0f,
 };
 
-EvtSource N(80244478) = SCRIPT({
-    SetSelfEnemyFlagBits(((0x00100000 | 0x01000000 | 0x02000000 | 0x04000000 | 0x08000000 | 0x10000000 | 0x20000000)), TRUE);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100 | NPC_FLAG_LOCK_ANIMS | NPC_FLAG_NO_Y_MOVEMENT)), TRUE);
-});
+EvtSource N(80244478) = {
+    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_8000000 | NPC_FLAG_10000000 | NPC_FLAG_20000000)), TRUE)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100 | NPC_FLAG_LOCK_ANIMS | NPC_FLAG_NO_Y_MOVEMENT)), TRUE)
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_802444B4) = {
     .moveSpeed = 1.5f,
@@ -276,86 +286,93 @@ NpcAISettings N(npcAISettings_802444B4) = {
 
 const char N(dgb_00_name_hack)[];
 
-EvtSource N(npcAI_802444E4) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -650);
-    SetSelfVar(6, 30);
-    SetSelfVar(1, 600);
-    N(func_802438F0_C436A0)(N(npcAISettings_802444B4));
-    DisablePlayerInput(TRUE);
-    sleep 2;
-20:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    GetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(4), EVT_VAR(2));
-    GetPlayerActionState(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        sleep 1;
-        goto 20;
-    }
-    DisablePlayerPhysics(TRUE);
-    func_802D2B6C();
-    DisablePartnerAI(0);
-    group 0;
-    SetTimeFreezeMode(1);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += 20;
-    EVT_VAR(2) += 2;
-    SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    func_80045838(-1, 759, 0);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_sentinel_Palette_00_Anim_8);
-    sleep 10;
-    SetPlayerAnimation(ANIM_80017);
-    sleep 10;
-    func_80045838(-1, 1838, 0);
-    spawn {
-        loop 100 {
-            GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 1;
-        }
-    }
-    spawn {
-        SetNpcAnimation(NPC_PARTNER, 0x108);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-    }
-    sleep 30;
-    GotoMap(N(dgb_00_name_hack), 2);
-    sleep 100;
-});
+EvtSource N(npcAI_802444E4) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -650)
+    EVT_CALL(SetSelfVar, 6, 30)
+    EVT_CALL(SetSelfVar, 1, 600)
+    EVT_CALL(N(func_802438F0_C436A0), EVT_PTR(N(npcAISettings_802444B4)))
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(2)
+    EVT_LABEL(20)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(4), EVT_VAR(2))
+    EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(20)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(func_802D2B6C)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_SET_GROUP(0)
+    EVT_CALL(SetTimeFreezeMode, 1)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), 20)
+    EVT_ADD(EVT_VAR(2), 2)
+    EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(func_80045838, -1, 759, 0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_sentinel_Palette_00_Anim_8)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetPlayerAnimation, ANIM_80017)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(func_80045838, -1, 1838, 0)
+    EVT_THREAD
+        EVT_LOOP(100)
+            EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x108)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(GotoMap, EVT_PTR(N(dgb_00_name_hack)), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024490C) = SCRIPT({
-    GetOwnerEncounterTrigger(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 1, 2, 4, 6 {
-            GetSelfAnimationFromTable(7, EVT_VAR(0));
-            await 0x800936DC;
-        }
-    }
-});
+EvtSource N(8024490C) = {
+    EVT_CALL(GetOwnerEncounterTrigger, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(1)
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(4)
+        EVT_CASE_OR_EQ(6)
+            EVT_CALL(GetSelfAnimationFromTable, 7, EVT_VAR(0))
+            EVT_EXEC_WAIT(0x800936DC)
+        EVT_END_CASE_GROUP
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244998) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            DoNpcDefeat();
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(80244998) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802449FC) = {
     .height = 38,
@@ -371,117 +388,125 @@ NpcSettings N(npcSettings_80244A28) = {
     .level = 99,
 };
 
-EvtSource N(idle_80244A54) = SCRIPT({
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(0) >= -350) {
-            break loop;
-        }
-        sleep 1;
-    }
-    EVT_SAVE_VAR(203) = 8;
-    EVT_STORY_PROGRESS = STORY_CH3_TUBBA_CHASED_MARIO_IN_HALL;
-    PlaySoundAtCollider(18, 455, 0);
-    MakeLerp(0, 80, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(18, EVT_VAR(0), 0, -1, 0);
-        RotateModel(20, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_A);
-    SetNpcPos(NPC_SELF, -665, 210, 180);
-    SetNpcYaw(NPC_SELF, 90);
-    NpcMoveTo(NPC_SELF, -530, 180, 30);
-    spawn {
-        sleep 20;
-        MakeLerp(80, 0, 10, 0);
-        loop {
-            UpdateLerp();
-            RotateModel(18, EVT_VAR(0), 0, -1, 0);
-            RotateModel(20, EVT_VAR(0), 0, 1, 0);
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        PlaySoundAtCollider(18, 456, 0);
-    }
-    NpcMoveTo(NPC_SELF, -500, 80, 10);
-    BindNpcAI(NPC_SELF, N(npcAI_80244D7C));
-});
+EvtSource N(idle_80244A54) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_GE(EVT_VAR(0), -350)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SET(EVT_SAVE_VAR(203), 8)
+    EVT_SET(EVT_SAVE_VAR(0), -27)
+    EVT_CALL(PlaySoundAtCollider, 18, 455, 0)
+    EVT_CALL(MakeLerp, 0, 80, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 18, EVT_VAR(0), 0, -1, 0)
+        EVT_CALL(RotateModel, 20, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(SetNpcAnimation, 9, NPC_ANIM_world_tubba_Palette_00_Anim_A)
+    EVT_CALL(SetNpcPos, NPC_SELF, -665, 210, 180)
+    EVT_CALL(SetNpcYaw, NPC_SELF, 90)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -530, 180, 30)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(MakeLerp, 80, 0, 10, 0)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(RotateModel, 18, EVT_VAR(0), 0, -1, 0)
+            EVT_CALL(RotateModel, 20, EVT_VAR(0), 0, 1, 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(PlaySoundAtCollider, 18, 456, 0)
+    EVT_END_THREAD
+    EVT_CALL(NpcMoveTo, NPC_SELF, -500, 80, 10)
+    EVT_CALL(BindNpcAI, NPC_SELF, EVT_PTR(N(npcAI_80244D7C)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244D08) = SCRIPT({
-10:
-    GetNpcPos(NPC_WORLD_TUBBA, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(1) > 0) {
-        sleep 1;
-        goto 10;
-    }
-    N(func_80243B98_C43948)();
-});
+EvtSource N(80244D08) = {
+    EVT_LABEL(10)
+    EVT_CALL(GetNpcPos, 9, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_GT(EVT_VAR(1), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_CALL(N(func_80243B98_C43948))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_80244D7C) = SCRIPT({
-    N(func_80243C10_C439C0)();
-    spawn N(80244D08);
-    spawn {
-        loop {
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 4194304);
-            ShakeCam(0, 0, 5, 2.0);
-            sleep 5;
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 4194304);
-            ShakeCam(0, 0, 2, 1.0);
-            sleep 8;
-        }
-    }
-    N(func_80240B94_C40944)(N(npcAI_80244100));
-});
+EvtSource N(npcAI_80244D7C) = {
+    EVT_CALL(N(func_80243C10_C439C0))
+    EVT_EXEC(N(80244D08))
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 4194304)
+            EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(2.0))
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 4194304)
+            EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(1.0))
+            EVT_WAIT_FRAMES(8)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(N(func_80240B94_C40944), EVT_PTR(N(npcAI_80244100)))
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(dgb_01_name_hack)[];
 
-EvtSource N(defeat_80244E58) = SCRIPT({
-    N(UnkFunc1)();
-    GotoMap(N(dgb_01_name_hack), 2);
-    sleep 100;
-});
+EvtSource N(defeat_80244E58) = {
+    EVT_CALL(N(UnkFunc1))
+    EVT_CALL(GotoMap, EVT_PTR(N(dgb_01_name_hack)), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80244E94) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH3_TUBBA_SMASHED_THE_BRIDGES) {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-        SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_4)), TRUE);
-        return;
-    }
-    if (EVT_STORY_PROGRESS >= STORY_CH3_TUBBA_CHASED_MARIO_IN_FOYER) {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-        SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_4)), TRUE);
-        return;
-    }
-    SetNpcScale(NPC_SELF, 1.25, 1.25, 1.25);
-    BindNpcDefeat(NPC_SELF, N(defeat_80244E58));
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            if (EVT_SAVE_VAR(203) != 8) {
-                SetNpcPos(NPC_SELF, 0, -1000, 0);
-                SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_4)), TRUE);
-            } else {
-                SetNpcPos(NPC_SELF, -130, 0, 200);
-                BindNpcIdle(NPC_SELF, N(npcAI_80244D7C));
-            }
-        }
-        == 1 {
-            if (EVT_SAVE_VAR(203) != 8) {
-                BindNpcIdle(NPC_SELF, N(idle_80244A54));
-            } else {
-                SetNpcPos(NPC_SELF, -130, 210, 80);
-                BindNpcIdle(NPC_SELF, N(npcAI_80244D7C));
-            }
-        }
-    }
-});
+EvtSource N(init_80244E94) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), -28)
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_4)), TRUE)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(0), -26)
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_4)), TRUE)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.25), EVT_FIXED(1.25))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244E58)))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_IF_NE(EVT_SAVE_VAR(203), 8)
+                EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+                EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_4)), TRUE)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, NPC_SELF, -130, 0, 200)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_80244D7C)))
+            EVT_END_IF
+        EVT_CASE_EQ(1)
+            EVT_IF_NE(EVT_SAVE_VAR(203), 8)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80244A54)))
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, NPC_SELF, -130, 210, 80)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_80244D7C)))
+            EVT_END_IF
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_802450A0) = {
     .id = NPC_WORLD_TUBBA,
@@ -788,59 +813,65 @@ StaticNpc N(npcGroup_80246020) = {
     },
 };
 
-EvtSource N(idle_80246210) = SCRIPT({
-0:
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7);
-    sleep 30;
-    loop 15 {
-        N(func_80243C50_C43A00)();
-        sleep 60;
-    }
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_C);
-    sleep 20;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7);
-    sleep 30;
-    loop 5 {
-        N(func_80243C50_C43A00)();
-        sleep 60;
-    }
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_C);
-    sleep 15;
-    goto 0;
-});
+EvtSource N(idle_80246210) = {
+    EVT_LABEL(0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7)
+    EVT_WAIT_FRAMES(30)
+    EVT_LOOP(15)
+        EVT_CALL(N(func_80243C50_C43A00))
+        EVT_WAIT_FRAMES(60)
+    EVT_END_LOOP
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_C)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7)
+    EVT_WAIT_FRAMES(30)
+    EVT_LOOP(5)
+        EVT_CALL(N(func_80243C50_C43A00))
+        EVT_WAIT_FRAMES(60)
+    EVT_END_LOOP
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_C)
+    EVT_WAIT_FRAMES(15)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80246310) = SCRIPT({
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_8);
-    PlaySoundAtNpc(NPC_SELF, 0x2F1, 0);
-    sleep 10;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_2);
-    sleep 20;
-    GetNpcYaw(-1, EVT_VAR(0));
-    EVT_VAR(0) += 180;
-    InterpNpcYaw(NPC_SELF, EVT_VAR(0), 0);
-    sleep 10;
-    GetNpcYaw(-1, EVT_VAR(0));
-    EVT_VAR(0) += 180;
-    InterpNpcYaw(NPC_SELF, EVT_VAR(0), 0);
-    sleep 25;
-    GetNpcYaw(-1, EVT_VAR(0));
-    EVT_VAR(0) += 180;
-    InterpNpcYaw(NPC_SELF, EVT_VAR(0), 0);
-    sleep 15;
-    NpcFacePlayer(NPC_SELF, 0);
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_5, NPC_ANIM_world_clubba_Palette_00_Anim_2, 0, MESSAGE_ID(0x0E, 0x00F2));
-    sleep 10;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_6);
-    sleep 10;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7);
-});
+EvtSource N(interact_80246310) = {
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_8)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2F1, 0)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_2)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(GetNpcYaw, -1, EVT_VAR(0))
+    EVT_ADD(EVT_VAR(0), 180)
+    EVT_CALL(InterpNpcYaw, NPC_SELF, EVT_VAR(0), 0)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetNpcYaw, -1, EVT_VAR(0))
+    EVT_ADD(EVT_VAR(0), 180)
+    EVT_CALL(InterpNpcYaw, NPC_SELF, EVT_VAR(0), 0)
+    EVT_WAIT_FRAMES(25)
+    EVT_CALL(GetNpcYaw, -1, EVT_VAR(0))
+    EVT_ADD(EVT_VAR(0), 180)
+    EVT_CALL(InterpNpcYaw, NPC_SELF, EVT_VAR(0), 0)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(NpcFacePlayer, NPC_SELF, 0)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_5, NPC_ANIM_world_clubba_Palette_00_Anim_2, 0, MESSAGE_ID(0x0E, 0x00F2))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_6)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802464C4) = SCRIPT({
-    SetNpcCollisionSize(-1, 36, 30);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7);
-    BindNpcInteract(NPC_SELF, N(interact_80246310));
-    BindNpcIdle(NPC_SELF, N(idle_80246210));
-});
+EvtSource N(init_802464C4) = {
+    EVT_CALL(SetNpcCollisionSize, -1, 36, 30)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_clubba_Palette_00_Anim_7)
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80246310)))
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80246210)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80246528) = {
     .id = NPC_WORLD_CLUBBA6,
@@ -875,14 +906,17 @@ StaticNpc N(npcGroup_80246528) = {
     .tattle = MESSAGE_ID(0x1A, 0x00B6),
 };
 
-EvtSource N(idle_80246718) = SCRIPT({
+EvtSource N(idle_80246718) = {
+    EVT_RETURN
+    EVT_END
+};
 
-});
-
-EvtSource N(init_80246728) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(idle_80246718));
-    SetNpcPos(NPC_SELF, 0, -1000, 0);
-});
+EvtSource N(init_80246728) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80246718)))
+    EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80246768) = {
     .id = NPC_WORLD_CLUBBA7,
@@ -947,9 +981,10 @@ static s32 N(pad_69DC) = {
     0x00000000,
 };
 
-EvtSource N(802469E0) = SCRIPT({
-
-});
+EvtSource N(802469E0) = {
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc24.inc.c"
 

--- a/src/world/area_dgb/dgb_09/C46BE0.c
+++ b/src/world/area_dgb/dgb_09/C46BE0.c
@@ -27,119 +27,127 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_09_tattle },
 };
 
-EvtSource N(80243880) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80243880) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3918)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitDoubleDoor_80243920) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 5;
-    EVT_VAR(2) = 10;
-    EVT_VAR(3) = 12;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_03", 4);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80243920) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 5)
+    EVT_SET(EVT_VAR(2), 10)
+    EVT_SET(EVT_VAR(3), 12)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_03"), 4)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitDoubleDoor_802439D4) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 1;
-    EVT_VAR(1) = 17;
-    EVT_VAR(2) = 17;
-    EVT_VAR(3) = 15;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_01", 3);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_802439D4) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_SET(EVT_VAR(1), 17)
+    EVT_SET(EVT_VAR(2), 17)
+    EVT_SET(EVT_VAR(3), 15)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_01"), 3)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitSingleDoor_80243A88) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 2;
-    EVT_VAR(1) = 9;
-    EVT_VAR(2) = 20;
-    EVT_VAR(3) = 1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_12", 0);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80243A88) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 2)
+    EVT_SET(EVT_VAR(1), 9)
+    EVT_SET(EVT_VAR(2), 20)
+    EVT_SET(EVT_VAR(3), 1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_12"), 0)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80243B3C) = EXIT_WALK_SCRIPT(40,  3, "dgb_10",  0);
 
-EvtSource N(80243B98) = SCRIPT({
-    bind N(exitWalk_80243B3C) TRIGGER_FLOOR_ABOVE 11;
-});
+EvtSource N(80243B98) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80243B3C), TRIGGER_FLOOR_ABOVE, 11, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterWalk_80243BC4) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            UseDoorSounds(3);
-            EVT_VAR(2) = 10;
-            EVT_VAR(3) = 12;
-            await EnterDoubleDoor;
-            spawn N(80243B98);
-        }
-        == 1 {
-            UseDoorSounds(3);
-            EVT_VAR(2) = 17;
-            EVT_VAR(3) = 15;
-            await EnterDoubleDoor;
-            spawn N(80243B98);
-        }
-        == 2 {
-            UseDoorSounds(0);
-            EVT_VAR(2) = 20;
-            EVT_VAR(3) = 1;
-            await EnterSingleDoor;
-            spawn N(80243B98);
-        }
-        == 3 {
-            EVT_VAR(0) = N(80243B98);
-            spawn EnterWalk;
-            sleep 1;
-        }
-    }
-});
+EvtSource N(enterWalk_80243BC4) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(UseDoorSounds, 3)
+            EVT_SET(EVT_VAR(2), 10)
+            EVT_SET(EVT_VAR(3), 12)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+            EVT_EXEC(N(80243B98))
+        EVT_CASE_EQ(1)
+            EVT_CALL(UseDoorSounds, 3)
+            EVT_SET(EVT_VAR(2), 17)
+            EVT_SET(EVT_VAR(3), 15)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+            EVT_EXEC(N(80243B98))
+        EVT_CASE_EQ(2)
+            EVT_CALL(UseDoorSounds, 0)
+            EVT_SET(EVT_VAR(2), 20)
+            EVT_SET(EVT_VAR(3), 1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+            EVT_EXEC(N(80243B98))
+        EVT_CASE_EQ(3)
+            EVT_SET(EVT_VAR(0), EVT_PTR(N(80243B98)))
+            EVT_EXEC(EnterWalk)
+            EVT_WAIT_FRAMES(1)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    if (EVT_STORY_PROGRESS < STORY_CH3_STAR_SPIRIT_RESCUED) {
-        MakeNpcs(1, N(npcGroupList_8024533C));
-    }
-    spawn N(80243F6C);
-    bind N(exitDoubleDoor_80243920) TRIGGER_WALL_PRESS_A 5;
-    bind N(exitDoubleDoor_802439D4) TRIGGER_WALL_PRESS_A 17;
-    bind N(exitSingleDoor_80243A88) TRIGGER_WALL_PRESS_A 9;
-    spawn N(80243880);
-    spawn N(enterWalk_80243BC4);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_IF_LT(EVT_SAVE_VAR(0), -15)
+        EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_8024533C)))
+    EVT_END_IF
+    EVT_EXEC(N(80243F6C))
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80243920), TRIGGER_WALL_PRESS_A, 5, 1, 0)
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_802439D4), TRIGGER_WALL_PRESS_A, 17, 1, 0)
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80243A88), TRIGGER_WALL_PRESS_A, 9, 1, 0)
+    EVT_EXEC(N(80243880))
+    EVT_EXEC(N(enterWalk_80243BC4))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3E4C) = {
     0x00000000,
@@ -147,52 +155,55 @@ static s32 N(pad_3E4C) = {
 
 Vec4f N(triggerCoord_80243E50) = { 300.0f, 0.0f, 88.0f, 0.0f };
 
-EvtSource N(80243E60) = SCRIPT({
-    sleep 2;
-    PlayEffect(0x42, 1, 25, 3, 1, 10, 30, 0, 0, 0, 0, 0, 0, 0);
-    loop 10 {
-        EnableModel(29, 0);
-        EnableModel(25, 1);
-        sleep 1;
-        EnableModel(29, 1);
-        EnableModel(25, 0);
-        sleep 1;
-    }
-    ModifyColliderFlags(0, 13, 0x7FFFFE00);
-    EVT_SAVE_FLAG(1051) = 1;
-    unbind;
-});
+EvtSource N(80243E60) = {
+    EVT_WAIT_FRAMES(2)
+    EVT_CALL(PlayEffect, 0x42, 1, 25, 3, 1, 10, 30, 0, 0, 0, 0, 0, 0, 0)
+    EVT_LOOP(10)
+        EVT_CALL(EnableModel, 29, 0)
+        EVT_CALL(EnableModel, 25, 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(EnableModel, 29, 1)
+        EVT_CALL(EnableModel, 25, 0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+    EVT_SET(EVT_SAVE_FLAG(1051), 1)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243F6C) = SCRIPT({
-    if (EVT_SAVE_FLAG(1051) == 0) {
-        bind N(80243E60) TRIGGER_POINT_BOMB N(triggerCoord_80243E50);
-        EnableModel(29, 0);
-    } else {
-        EnableModel(25, 0);
-        ModifyColliderFlags(0, 13, 0x7FFFFE00);
-    }
-});
+EvtSource N(80243F6C) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1051), 0)
+        EVT_BIND_TRIGGER(N(80243E60), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80243E50)), 1, 0)
+        EVT_CALL(EnableModel, 29, 0)
+    EVT_ELSE
+        EVT_CALL(EnableModel, 25, 0)
+        EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3FF8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80244000) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(80244000) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(extraAnimationList_802440BC)[] = {
     NPC_ANIM_world_clubba_Palette_00_Anim_0,
@@ -227,13 +238,15 @@ NpcAISettings N(npcAISettings_802440EC) = {
     .unk_2C = 3,
 };
 
-EvtSource N(npcAI_8024411C) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 5);
-    SetSelfVar(2, 8);
-    SetSelfVar(3, 12);
-    N(func_8024061C_C471FC)(N(npcAISettings_802440EC));
-});
+EvtSource N(npcAI_8024411C) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 5)
+    EVT_CALL(SetSelfVar, 2, 8)
+    EVT_CALL(SetSelfVar, 3, 12)
+    EVT_CALL(N(func_8024061C_C471FC), EVT_PTR(N(npcAISettings_802440EC)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024418C) = {
     .height = 36,
@@ -259,13 +272,15 @@ NpcAISettings N(npcAISettings_802441B8) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802441E8) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 10);
-    SetSelfVar(2, 14);
-    SetSelfVar(3, 18);
-    N(func_802410D4_C47CB4)(N(npcAISettings_802441B8));
-});
+EvtSource N(npcAI_802441E8) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 10)
+    EVT_CALL(SetSelfVar, 2, 14)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(N(func_802410D4_C47CB4), EVT_PTR(N(npcAISettings_802441B8)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244258) = {
     .height = 36,
@@ -276,16 +291,18 @@ NpcSettings N(npcSettings_80244258) = {
     .level = 13,
 };
 
-EvtSource N(npcAI_80244284) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(npcAI_80244284) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024432C) = {
     .height = 14,
@@ -301,10 +318,12 @@ f32 N(D_80244358_C4AF38)[] = {
     1.5f, 20.0f,
 };
 
-EvtSource N(80244370) = SCRIPT({
-    SetSelfEnemyFlagBits(((0x00100000 | 0x01000000 | 0x02000000 | 0x04000000 | 0x08000000 | 0x10000000 | 0x20000000)), TRUE);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100 | NPC_FLAG_LOCK_ANIMS | NPC_FLAG_NO_Y_MOVEMENT)), TRUE);
-});
+EvtSource N(80244370) = {
+    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_8000000 | NPC_FLAG_10000000 | NPC_FLAG_20000000)), TRUE)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100 | NPC_FLAG_LOCK_ANIMS | NPC_FLAG_NO_Y_MOVEMENT)), TRUE)
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_802443AC) = {
     .moveSpeed = 1.5f,
@@ -321,86 +340,93 @@ NpcAISettings N(npcAISettings_802443AC) = {
 
 const char N(dgb_00_name_hack)[];
 
-EvtSource N(npcAI_802443DC) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -650);
-    SetSelfVar(6, 30);
-    SetSelfVar(1, 600);
-    N(func_80243578_C4A158)(N(npcAISettings_802443AC));
-    DisablePlayerInput(TRUE);
-    sleep 2;
-20:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    GetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(4), EVT_VAR(2));
-    GetPlayerActionState(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        sleep 1;
-        goto 20;
-    }
-    DisablePlayerPhysics(TRUE);
-    func_802D2B6C();
-    DisablePartnerAI(0);
-    group 0;
-    SetTimeFreezeMode(1);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += 20;
-    EVT_VAR(2) += 2;
-    SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    func_80045838(-1, 759, 0);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_sentinel_Palette_00_Anim_8);
-    sleep 10;
-    SetPlayerAnimation(ANIM_80017);
-    sleep 10;
-    func_80045838(-1, 1838, 0);
-    spawn {
-        loop 100 {
-            GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 1;
-        }
-    }
-    spawn {
-        SetNpcAnimation(NPC_PARTNER, 0x108);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-        GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        NpcJump0(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-    }
-    sleep 30;
-    GotoMap(N(dgb_00_name_hack), 2);
-    sleep 100;
-});
+EvtSource N(npcAI_802443DC) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -650)
+    EVT_CALL(SetSelfVar, 6, 30)
+    EVT_CALL(SetSelfVar, 1, 600)
+    EVT_CALL(N(func_80243578_C4A158), EVT_PTR(N(npcAISettings_802443AC)))
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(2)
+    EVT_LABEL(20)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(4), EVT_VAR(2))
+    EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(20)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(func_802D2B6C)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_SET_GROUP(0)
+    EVT_CALL(SetTimeFreezeMode, 1)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), 20)
+    EVT_ADD(EVT_VAR(2), 2)
+    EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(func_80045838, -1, 759, 0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_sentinel_Palette_00_Anim_8)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetPlayerAnimation, ANIM_80017)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(func_80045838, -1, 1838, 0)
+    EVT_THREAD
+        EVT_LOOP(100)
+            EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x108)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(GotoMap, EVT_PTR(N(dgb_00_name_hack)), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244804) = SCRIPT({
-    GetOwnerEncounterTrigger(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 1, 2, 4, 6 {
-            GetSelfAnimationFromTable(7, EVT_VAR(0));
-            await 0x800936DC;
-        }
-    }
-});
+EvtSource N(80244804) = {
+    EVT_CALL(GetOwnerEncounterTrigger, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(1)
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(4)
+        EVT_CASE_OR_EQ(6)
+            EVT_CALL(GetSelfAnimationFromTable, 7, EVT_VAR(0))
+            EVT_EXEC_WAIT(0x800936DC)
+        EVT_END_CASE_GROUP
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244890) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            DoNpcDefeat();
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(80244890) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802448F4) = {
     .height = 38,
@@ -479,13 +505,15 @@ StaticNpc N(npcGroup_80244920)[] = {
     },
 };
 
-EvtSource N(init_80244D00) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 3) {
-        SetNpcPos(NPC_SELF, 240, 0, 88);
-        InterpNpcYaw(NPC_SELF, 270, 0);
-    }
-});
+EvtSource N(init_80244D00) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 3)
+        EVT_CALL(SetNpcPos, NPC_SELF, 240, 0, 88)
+        EVT_CALL(InterpNpcYaw, NPC_SELF, 270, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80244D6C)[] = {
     {

--- a/src/world/area_dgb/dgb_10/C4C390.c
+++ b/src/world/area_dgb/dgb_10/C4C390.c
@@ -13,18 +13,18 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_10_tattle },
 };
 
-EvtSource N(80240250) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240250) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2E8)[] = {
     0x00000000, 0x00000000,
@@ -32,246 +32,270 @@ static s32 N(pad_2E8)[] = {
 
 EvtSource N(exitWalk_802402F0) = EXIT_WALK_SCRIPT(40,  0, "dgb_09",  3);
 
-EvtSource N(8024034C) = SCRIPT({
-    bind N(exitWalk_802402F0) TRIGGER_FLOOR_ABOVE 8;
-});
+EvtSource N(8024034C) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802402F0), TRIGGER_FLOOR_ABOVE, 8, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterWalk_80240378) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(0) = N(8024034C);
-            spawn EnterWalk;
-            sleep 1;
-        }
-        == 1 {
-            UseSettingsFrom(0, 375, 0, -188);
-            SetPanTarget(0, 375, 0, -188);
-            SetCamSpeed(0, 90.0);
-            PanToTarget(0, 0, 1);
-            DisablePlayerInput(TRUE);
-            DisablePlayerPhysics(TRUE);
-            SetPlayerActionState(3);
-            sleep 1;
-            SetPlayerJumpscale(0.7001953125);
-            PlayerJump(375, 0, -188, 20);
-            PanToTarget(0, 0, 0);
-            DisablePlayerPhysics(FALSE);
-            DisablePlayerInput(FALSE);
-            SetPlayerActionState(0);
-            spawn N(8024034C);
-        }
-    }
-});
+EvtSource N(enterWalk_80240378) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(0), EVT_PTR(N(8024034C)))
+            EVT_EXEC(EnterWalk)
+            EVT_WAIT_FRAMES(1)
+        EVT_CASE_EQ(1)
+            EVT_CALL(UseSettingsFrom, 0, 375, 0, -188)
+            EVT_CALL(SetPanTarget, 0, 375, 0, -188)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(DisablePlayerInput, TRUE)
+            EVT_CALL(DisablePlayerPhysics, TRUE)
+            EVT_CALL(SetPlayerActionState, 3)
+            EVT_WAIT_FRAMES(1)
+            EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+            EVT_CALL(PlayerJump, 375, 0, -188, 20)
+            EVT_CALL(PanToTarget, 0, 0, 0)
+            EVT_CALL(DisablePlayerPhysics, FALSE)
+            EVT_CALL(DisablePlayerInput, FALSE)
+            EVT_CALL(SetPlayerActionState, 0)
+            EVT_EXEC(N(8024034C))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    spawn N(80240E68);
-    spawn N(80240250);
-    ModifyColliderFlags(0, 9, 0x7FFFFE00);
-    EnableModel(6, 0);
-    EnableModel(12, 0);
-    EnableModel(18, 0);
-    ModifyColliderFlags(0, 12, 0x7FFFFE00);
-    ModifyColliderFlags(0, 13, 0x7FFFFE00);
-    ModifyColliderFlags(0, 14, 0x7FFFFE00);
-    spawn N(enterWalk_80240378);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80240E68))
+    EVT_EXEC(N(80240250))
+    EVT_CALL(ModifyColliderFlags, 0, 9, 0x7FFFFE00)
+    EVT_CALL(EnableModel, 6, 0)
+    EVT_CALL(EnableModel, 12, 0)
+    EVT_CALL(EnableModel, 18, 0)
+    EVT_CALL(ModifyColliderFlags, 0, 12, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+    EVT_EXEC(N(enterWalk_80240378))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_66C) = {
     0x00000000,
 };
 
-EvtSource N(80240670) = SCRIPT({
-    buf_use EVT_VAR(0);
-    arr_new 6 EVT_VAR(10);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(0) = EVT_VAR(0);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(1) = EVT_VAR(0);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(2) = EVT_VAR(0);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(3) = EVT_VAR(0);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(4) = EVT_VAR(0);
-    buf_read EVT_VAR(0);
-    EVT_ARRAY(5) = EVT_VAR(0);
-    EVT_VAR(0) = EVT_VAR(10);
-    bind N(80240770) TRIGGER_FLOOR_TOUCH 0xF4ACD480; // TODO: what is this id? see also below TODO
-});
+EvtSource N(80240670) = {
+    EVT_USE_BUF(EVT_VAR(0))
+    EVT_MALLOC_ARRAY(6, EVT_VAR(10))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(0), EVT_VAR(0))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(1), EVT_VAR(0))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(2), EVT_VAR(0))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(3), EVT_VAR(0))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(4), EVT_VAR(0))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(5), EVT_VAR(0))
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_BIND_TRIGGER(N(80240770), TRIGGER_FLOOR_TOUCH, EVT_ARRAY(0), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240770) = SCRIPT({
-    arr_use EVT_VAR(0);
-    N(func_80240000_C4C390)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    loop 5 {
-        ModifyColliderFlags(1, EVT_ARRAY(0), 0x7FFFFE00);
-        EnableModel(EVT_ARRAY(1), 1);
-        sleep 1;
-        ModifyColliderFlags(0, EVT_ARRAY(0), 0x7FFFFE00);
-        EnableModel(EVT_ARRAY(1), 0);
-        sleep 1;
-    }
-    if (EVT_ARRAY(5) != 0) {
-        await 0xF4ACD485; // TODO: what is this?
-    }
-});
+EvtSource N(80240770) = {
+    EVT_USE_ARRAY(EVT_VAR(0))
+    EVT_CALL(N(func_80240000_C4C390))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_LOOP(5)
+        EVT_CALL(ModifyColliderFlags, 1, EVT_ARRAY(0), 0x7FFFFE00)
+        EVT_CALL(EnableModel, EVT_ARRAY(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(ModifyColliderFlags, 0, EVT_ARRAY(0), 0x7FFFFE00)
+        EVT_CALL(EnableModel, EVT_ARRAY(1), 0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_IF_NE(EVT_ARRAY(5), 0)
+        EVT_EXEC_WAIT(EVT_ARRAY(5))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240860) = SCRIPT({
-    buf_use EVT_VAR(0);
-    arr_new 6 EVT_VAR(9);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(0) = EVT_VAR(1);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(1) = EVT_VAR(1);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(2) = EVT_VAR(1);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(3) = EVT_VAR(1);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(4) = EVT_VAR(1);
-    buf_read EVT_VAR(1);
-    EVT_ARRAY(5) = EVT_VAR(1);
-    ParentColliderToModel(EVT_ARRAY(1), EVT_ARRAY(0));
-0:
-1:
-    GetPlayerActionState(EVT_VAR(10));
-    if (EVT_VAR(10) == 13) {
-        goto 2;
-    }
-    if (EVT_VAR(10) == 15) {
-        goto 2;
-    }
-    sleep 1;
-    goto 0;
-2:
-    GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    sleep 1;
-    if (EVT_VAR(2) != EVT_ARRAY(3)) {
-        goto 2;
-    }
-    N(func_802400A0_C4C430)();
-    if (EVT_VAR(0) == 1) {
-        await N(80240AF4);
-    }
-    if (EVT_VAR(0) == 2) {
-        await N(80240CB8);
-    }
-3:
-    GetPlayerActionState(EVT_VAR(0));
-    sleep 1;
-    if (EVT_VAR(0) == 13) {
-        goto 3;
-    }
-    if (EVT_VAR(0) == 15) {
-        goto 3;
-    }
-    goto 0;
-});
+EvtSource N(80240860) = {
+    EVT_USE_BUF(EVT_VAR(0))
+    EVT_MALLOC_ARRAY(6, EVT_VAR(9))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(0), EVT_VAR(1))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(1), EVT_VAR(1))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(2), EVT_VAR(1))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(3), EVT_VAR(1))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(4), EVT_VAR(1))
+    EVT_BUF_READ1(EVT_VAR(1))
+    EVT_SET(EVT_ARRAY(5), EVT_VAR(1))
+    EVT_CALL(ParentColliderToModel, EVT_ARRAY(1), EVT_ARRAY(0))
+    EVT_LABEL(0)
+    EVT_LABEL(1)
+    EVT_CALL(GetPlayerActionState, EVT_VAR(10))
+    EVT_IF_EQ(EVT_VAR(10), 13)
+        EVT_GOTO(2)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(10), 15)
+        EVT_GOTO(2)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_LABEL(2)
+    EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_NE(EVT_VAR(2), EVT_ARRAY(3))
+        EVT_GOTO(2)
+    EVT_END_IF
+    EVT_CALL(N(func_802400A0_C4C430))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_EXEC_WAIT(N(80240AF4))
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 2)
+        EVT_EXEC_WAIT(N(80240CB8))
+    EVT_END_IF
+    EVT_LABEL(3)
+    EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(0), 13)
+        EVT_GOTO(3)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 15)
+        EVT_GOTO(3)
+    EVT_END_IF
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240AF4) = SCRIPT({
-    arr_use EVT_VAR(9);
-    GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-    MakeLerp(0, 5, 3, 1);
-2:
-    UpdateLerp();
-    TranslateModel(EVT_ARRAY(0), 0, EVT_VAR(0), 0);
-    EVT_VAR(5) = EVT_VAR(3);
-    EVT_VAR(5) += EVT_VAR(0);
-    SetPlayerPos(EVT_VAR(2), EVT_VAR(5), EVT_VAR(4));
-    UpdateColliderTransform(EVT_ARRAY(1));
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 2;
-    }
-    MakeLerp(5, 0, 3, 1);
-3:
-    UpdateLerp();
-    TranslateModel(EVT_ARRAY(0), 0, EVT_VAR(0), 0);
-    EVT_VAR(5) = EVT_VAR(3);
-    EVT_VAR(5) += EVT_VAR(0);
-    SetPlayerPos(EVT_VAR(2), EVT_VAR(5), EVT_VAR(4));
-    UpdateColliderTransform(EVT_ARRAY(1));
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 3;
-    }
-});
+EvtSource N(80240AF4) = {
+    EVT_USE_ARRAY(EVT_VAR(9))
+    EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+    EVT_CALL(MakeLerp, 0, 5, 3, 1)
+    EVT_LABEL(2)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(TranslateModel, EVT_ARRAY(0), 0, EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(5), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(5), EVT_VAR(0))
+    EVT_CALL(SetPlayerPos, EVT_VAR(2), EVT_VAR(5), EVT_VAR(4))
+    EVT_CALL(UpdateColliderTransform, EVT_ARRAY(1))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(2)
+    EVT_END_IF
+    EVT_CALL(MakeLerp, 5, 0, 3, 1)
+    EVT_LABEL(3)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(TranslateModel, EVT_ARRAY(0), 0, EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(5), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(5), EVT_VAR(0))
+    EVT_CALL(SetPlayerPos, EVT_VAR(2), EVT_VAR(5), EVT_VAR(4))
+    EVT_CALL(UpdateColliderTransform, EVT_ARRAY(1))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(3)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240CB8) = SCRIPT({
-    arr_use EVT_VAR(9);
-    MakeItemEntity(EVT_ARRAY(5), EVT_ARRAY(2), EVT_ARRAY(3), EVT_ARRAY(4), 3, 0);
-    EVT_VAR(2) = 0;
-    MakeLerp(0, 150, 19, 4);
-2:
-    UpdateLerp();
-    TranslateModel(EVT_ARRAY(0), 0, EVT_VAR(0), 0);
-    EVT_VAR(2) += 45;
-    RotateModel(EVT_ARRAY(0), EVT_VAR(2), 1, 0, 0);
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 2;
-    }
-    MakeLerp(150, 0, 19, 4);
-3:
-    UpdateLerp();
-    TranslateModel(EVT_ARRAY(0), 0, EVT_VAR(0), 0);
-    EVT_VAR(2) += 45;
-    RotateModel(EVT_ARRAY(0), EVT_VAR(2), 1, 0, 0);
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 3;
-    }
-});
+EvtSource N(80240CB8) = {
+    EVT_USE_ARRAY(EVT_VAR(9))
+    EVT_CALL(MakeItemEntity, EVT_ARRAY(5), EVT_ARRAY(2), EVT_ARRAY(3), EVT_ARRAY(4), 3, 0)
+    EVT_SET(EVT_VAR(2), 0)
+    EVT_CALL(MakeLerp, 0, 150, 19, 4)
+    EVT_LABEL(2)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(TranslateModel, EVT_ARRAY(0), 0, EVT_VAR(0), 0)
+    EVT_ADD(EVT_VAR(2), 45)
+    EVT_CALL(RotateModel, EVT_ARRAY(0), EVT_VAR(2), 1, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(2)
+    EVT_END_IF
+    EVT_CALL(MakeLerp, 150, 0, 19, 4)
+    EVT_LABEL(3)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(TranslateModel, EVT_ARRAY(0), 0, EVT_VAR(0), 0)
+    EVT_ADD(EVT_VAR(2), 45)
+    EVT_CALL(RotateModel, EVT_ARRAY(0), EVT_VAR(2), 1, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(3)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240E68) = SCRIPT({
-    N(func_8024013C_C4C4CC)();
-    func_802CA988(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    N(func_802401C0_C4C550)();
-    func_802D2B6C();
-    GotoMap("dgb_11", EVT_VAR(0));
-    sleep 100;
-});
+EvtSource N(80240E68) = {
+    EVT_CALL(N(func_8024013C_C4C4CC))
+    EVT_CALL(func_802CA988, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(N(func_802401C0_C4C550))
+    EVT_CALL(func_802D2B6C)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_11"), EVT_VAR(0))
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_EDC) = {
     0x00000000,
 };
 
-EvtSource N(80240EE0) = SCRIPT({
-    EVT_SAVE_FLAG(1052) = 1;
-});
+EvtSource N(80240EE0) = {
+    EVT_SET(EVT_SAVE_FLAG(1052), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240F00) = SCRIPT({
-    EVT_SAVE_FLAG(1053) = 1;
-});
+EvtSource N(80240F00) = {
+    EVT_SET(EVT_SAVE_FLAG(1053), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240F20) = SCRIPT({
-    EVT_SAVE_FLAG(1054) = 1;
-});
+EvtSource N(80240F20) = {
+    EVT_SET(EVT_SAVE_FLAG(1054), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    if (EVT_SAVE_FLAG(1052) == 0) {
-        MakeEntity(0x802BCE84, 500, 0, -100, 0, MAKE_ENTITY_END);
-        AssignScript(N(80240EE0));
-    }
-    if (EVT_SAVE_FLAG(1053) == 0) {
-        MakeEntity(0x802BCE84, 500, 0, -250, 0, MAKE_ENTITY_END);
-        AssignScript(N(80240F00));
-    }
-    if (EVT_SAVE_FLAG(1054) == 0) {
-        MakeEntity(0x802BCE84, 375, 0, -250, 0, MAKE_ENTITY_END);
-        AssignScript(N(80240F20));
-    }
-});
+EvtSource N(makeEntities) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1052), 0)
+        EVT_CALL(MakeEntity, 0x802BCE84, 500, 0, -100, 0, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80240EE0)))
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(1053), 0)
+        EVT_CALL(MakeEntity, 0x802BCE84, 500, 0, -250, 0, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80240F00)))
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(1054), 0)
+        EVT_CALL(MakeEntity, 0x802BCE84, 375, 0, -250, 0, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80240F20)))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 ApiStatus N(func_80240000_C4C390)(Evt* script, s32 isInitialCall) {
     PlayerStatus* playerStatus = &gPlayerStatus;

--- a/src/world/area_dgb/dgb_11/C4D3E0.c
+++ b/src/world/area_dgb/dgb_11/C4D3E0.c
@@ -17,192 +17,202 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_11_tattle },
 };
 
-EvtSource N(802400D0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(802400D0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_168)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_80240170) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 11;
-    EVT_VAR(2) = 21;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_02", 3);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80240170) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 11)
+    EVT_SET(EVT_VAR(2), 21)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_02"), 3)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_80240224) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            UseDoorSounds(0);
-            EVT_VAR(2) = 21;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-            return;
-        }
-        == 1 {
-            UseSettingsFrom(0, 500, 0, -100);
-            SetPanTarget(0, 500, 0, -100);
-            EVT_VAR(3) = 1;
-        }
-        == 2 {
-            UseSettingsFrom(0, 500, 75, -250);
-            SetPanTarget(0, 500, 75, -250);
-            EVT_VAR(3) = 75;
-        }
-        == 3 {
-            SetZoneEnabled(5, 0);
-            UseSettingsFrom(0, 375, 0, -175);
-            SetPanTarget(0, 375, 0, -175);
-            EVT_AREA_FLAG(2) = 1;
-            EVT_VAR(3) = 1;
-        }
-    }
-    DisablePlayerInput(TRUE);
-    InterpPlayerYaw(180, 0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(1) <= EVT_VAR(3)) {
-            break loop;
-        }
-        sleep 1;
-    }
-    PanToTarget(0, 0, 0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(enterSingleDoor_80240224) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(UseDoorSounds, 0)
+            EVT_SET(EVT_VAR(2), 21)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+            EVT_RETURN
+        EVT_CASE_EQ(1)
+            EVT_CALL(UseSettingsFrom, 0, 500, 0, -100)
+            EVT_CALL(SetPanTarget, 0, 500, 0, -100)
+            EVT_SET(EVT_VAR(3), 1)
+        EVT_CASE_EQ(2)
+            EVT_CALL(UseSettingsFrom, 0, 500, 75, -250)
+            EVT_CALL(SetPanTarget, 0, 500, 75, -250)
+            EVT_SET(EVT_VAR(3), 75)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetZoneEnabled, 5, 0)
+            EVT_CALL(UseSettingsFrom, 0, 375, 0, -175)
+            EVT_CALL(SetPanTarget, 0, 375, 0, -175)
+            EVT_SET(EVT_AREA_FLAG(2), 1)
+            EVT_SET(EVT_VAR(3), 1)
+    EVT_END_SWITCH
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(InterpPlayerYaw, 180, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_LE(EVT_VAR(1), EVT_VAR(3))
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    spawn N(802400D0);
-    bind N(exitSingleDoor_80240170) TRIGGER_WALL_PRESS_A 11;
-    spawn N(enterSingleDoor_80240224);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(802400D0))
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80240170), TRIGGER_WALL_PRESS_A, 11, 1, 0)
+    EVT_EXEC(N(enterSingleDoor_80240224))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_56C) = {
     0x00000000,
 };
 
-EvtSource N(80240570) = SCRIPT({
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(1) >= EVT_VAR(3)) {
-        EVT_VAR(1) = EVT_VAR(3);
-    }
-    SetCamTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    sleep 1;
-    goto 0;
-});
+EvtSource N(80240570) = {
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_GE(EVT_VAR(1), EVT_VAR(3))
+        EVT_SET(EVT_VAR(1), EVT_VAR(3))
+    EVT_END_IF
+    EVT_CALL(SetCamTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240600) = SCRIPT({
-    PlayerJump(375, 270, -250, 20);
-});
+EvtSource N(80240600) = {
+    EVT_CALL(PlayerJump, 375, 270, -250, 20)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024062C) = SCRIPT({
-    if (EVT_AREA_FLAG(3) == 1) {
-        return;
-    }
-    EVT_AREA_FLAG(3) = 1;
-    DisablePlayerInput(TRUE);
-    SetZoneEnabled(5, 0);
-    if (EVT_AREA_FLAG(2) == 0) {
-        if (EVT_SAVE_FLAG(1054) == 0) {
-            DisablePlayerPhysics(TRUE);
-            SetPlayerActionState(3);
-            sleep 1;
-            EVT_VAR(3) = 500;
-            EVT_VAR(10) = spawn N(80240570);
-            SetPlayerJumpscale(0.7001953125);
-            EVT_VAR(11) = spawn N(80240600);
-            loop {
-                sleep 1;
-                GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                if (EVT_VAR(1) >= 165) {
-                    break loop;
-                }
-            }
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPlayerPos(EVT_VAR(0), 165, EVT_VAR(2));
-            kill EVT_VAR(11);
-            SetPlayerAnimation(0x80015);
-            ShakeCam(0, 0, 20, 1.0);
-            sleep 10;
-            SetPlayerAnimation(ANIM_10002);
-            SetPlayerJumpscale(0.0);
-            PlayerJump1(375, 25, -250, 10);
-            N(func_80240000_C4D3E0)();
-            PlaySoundAtPlayer(8326, 0);
-            SetPlayerJumpscale(0.7001953125);
-            PlayerJump(375, 0, -175, 15);
-            kill EVT_VAR(10);
-            SetPlayerActionState(0);
-            sleep 2;
-            SetZoneEnabled(5, 1);
-            DisablePlayerPhysics(FALSE);
-            DisablePlayerInput(FALSE);
-            EVT_AREA_FLAG(3) = 0;
-        } else {
-            DisablePlayerPhysics(TRUE);
-            SetPlayerActionState(3);
-            sleep 1;
-            spawn {
-                sleep 8;
-                GotoMap("dgb_10", 1);
-                sleep 100;
-            }
-            EVT_VAR(3) = 500;
-            EVT_VAR(10) = spawn N(80240570);
-            SetPlayerJumpscale(0.7001953125);
-            PlayerJump(375, 270, -250, 20);
-            EVT_AREA_FLAG(3) = 0;
-        }
-    } else {
-        SetPlayerActionState(3);
-        sleep 1;
-        EVT_VAR(3) = 25;
-        SetPlayerJumpscale(0.7001953125);
-        PlayerJump(375, 0, -175, 15);
-        EVT_AREA_FLAG(2) = 0;
-        kill EVT_VAR(10);
-        SetPlayerActionState(0);
-        sleep 2;
-        SetZoneEnabled(5, 1);
-        DisablePlayerInput(FALSE);
-        EVT_AREA_FLAG(3) = 0;
-    }
-});
+EvtSource N(8024062C) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(3), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_AREA_FLAG(3), 1)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(SetZoneEnabled, 5, 0)
+    EVT_IF_EQ(EVT_AREA_FLAG(2), 0)
+        EVT_IF_EQ(EVT_SAVE_FLAG(1054), 0)
+            EVT_CALL(DisablePlayerPhysics, TRUE)
+            EVT_CALL(SetPlayerActionState, 3)
+            EVT_WAIT_FRAMES(1)
+            EVT_SET(EVT_VAR(3), 500)
+            EVT_EXEC_GET_TID(N(80240570), EVT_VAR(10))
+            EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+            EVT_EXEC_GET_TID(N(80240600), EVT_VAR(11))
+            EVT_LOOP(0)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_IF_GE(EVT_VAR(1), 165)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+            EVT_END_LOOP
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPlayerPos, EVT_VAR(0), 165, EVT_VAR(2))
+            EVT_KILL_THREAD(EVT_VAR(11))
+            EVT_CALL(SetPlayerAnimation, 524309)
+            EVT_CALL(ShakeCam, 0, 0, 20, EVT_FIXED(1.0))
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.0))
+            EVT_CALL(PlayerJump1, 375, 25, -250, 10)
+            EVT_CALL(N(func_80240000_C4D3E0))
+            EVT_CALL(PlaySoundAtPlayer, 8326, 0)
+            EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+            EVT_CALL(PlayerJump, 375, 0, -175, 15)
+            EVT_KILL_THREAD(EVT_VAR(10))
+            EVT_CALL(SetPlayerActionState, 0)
+            EVT_WAIT_FRAMES(2)
+            EVT_CALL(SetZoneEnabled, 5, 1)
+            EVT_CALL(DisablePlayerPhysics, FALSE)
+            EVT_CALL(DisablePlayerInput, FALSE)
+            EVT_SET(EVT_AREA_FLAG(3), 0)
+        EVT_ELSE
+            EVT_CALL(DisablePlayerPhysics, TRUE)
+            EVT_CALL(SetPlayerActionState, 3)
+            EVT_WAIT_FRAMES(1)
+            EVT_THREAD
+                EVT_WAIT_FRAMES(8)
+                EVT_CALL(GotoMap, EVT_PTR("dgb_10"), 1)
+                EVT_WAIT_FRAMES(100)
+            EVT_END_THREAD
+            EVT_SET(EVT_VAR(3), 500)
+            EVT_EXEC_GET_TID(N(80240570), EVT_VAR(10))
+            EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+            EVT_CALL(PlayerJump, 375, 270, -250, 20)
+            EVT_SET(EVT_AREA_FLAG(3), 0)
+        EVT_END_IF
+    EVT_ELSE
+        EVT_CALL(SetPlayerActionState, 3)
+        EVT_WAIT_FRAMES(1)
+        EVT_SET(EVT_VAR(3), 25)
+        EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+        EVT_CALL(PlayerJump, 375, 0, -175, 15)
+        EVT_SET(EVT_AREA_FLAG(2), 0)
+        EVT_KILL_THREAD(EVT_VAR(10))
+        EVT_CALL(SetPlayerActionState, 0)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(SetZoneEnabled, 5, 1)
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_SET(EVT_AREA_FLAG(3), 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeItemEntity(ITEM_D_DOWN_JUMP, 250, 75, -100, 17, EVT_SAVE_FLAG(1055));
-    MakeEntity(0x802EAA30, 375, 0, -250, 0, MAKE_ENTITY_END);
-    AssignScript(N(8024062C));
-    EVT_MAP_VAR(0) = EVT_VAR(0);
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeItemEntity, ITEM_D_DOWN_JUMP, 250, 75, -100, 17, EVT_SAVE_FLAG(1055))
+    EVT_CALL(MakeEntity, 0x802EAA30, 375, 0, -250, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignScript, EVT_PTR(N(8024062C)))
+    EVT_SET(EVT_MAP_VAR(0), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
 ApiStatus N(func_80240000_C4D3E0)(Evt* script, s32 isInitialCall) {
     Entity* entity = get_entity_by_index(evt_get_variable(NULL, 0xFD050F80));

--- a/src/world/area_dgb/dgb_12/C4DEF0.c
+++ b/src/world/area_dgb/dgb_12/C4DEF0.c
@@ -13,111 +13,118 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_12_tattle },
 };
 
-EvtSource N(80240310) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240310) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3A8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_802403B0) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 8;
-    EVT_VAR(2) = 14;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_09", 2);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_802403B0) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 8)
+    EVT_SET(EVT_VAR(2), 14)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_09"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_80240464) = SCRIPT({
-    UseDoorSounds(0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 14;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-        }
-    }
-});
+EvtSource N(enterSingleDoor_80240464) = {
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 14)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    spawn N(802405E0);
-    spawn N(80240310);
-    bind N(exitSingleDoor_802403B0) TRIGGER_WALL_PRESS_A 8;
-    spawn N(enterSingleDoor_80240464);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(802405E0))
+    EVT_EXEC(N(80240310))
+    EVT_BIND_TRIGGER(N(exitSingleDoor_802403B0), TRIGGER_WALL_PRESS_A, 8, 1, 0)
+    EVT_EXEC(N(enterSingleDoor_80240464))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_802405C0)[] = {
     0x00000005, 0xC3FB8000, 0x00000000, 0xC27C0000, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(802405E0) = SCRIPT({
-    group 239;
-    ModifyColliderFlags(3, 12, 0x00000002);
-    ModifyColliderFlags(3, 0, 0x00000002);
-    ModifyColliderFlags(3, 14, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_802405C0));
-    }
-    sleep 50;
-    TranslateModel(19, 0, 0, 0);
-    ParentColliderToModel(12, 19);
-    loop {
-        spawn {
-            sleep 2;
-            ModifyColliderFlags(0, 0, 0x7FFFFE00);
-        }
-        MakeLerp(0, -35, 15, 0);
-        loop {
-            UpdateLerp();
-            TranslateModel(19, 0, EVT_VAR(0), 0);
-            UpdateColliderTransform(12);
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        sleep 60;
-        PlaySoundAtCollider(0, 8339, 0);
-        spawn {
-            ModifyColliderFlags(1, 0, 0x7FFFFE00);
-        }
-        MakeLerp(-35, 0, 4, 0);
-        loop {
-            UpdateLerp();
-            TranslateModel(19, 0, EVT_VAR(0), 0);
-            UpdateColliderTransform(12);
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        sleep 35;
-    }
-});
+EvtSource N(802405E0) = {
+    EVT_SET_GROUP(239)
+    EVT_CALL(ModifyColliderFlags, 3, 12, 0x00000002)
+    EVT_CALL(ModifyColliderFlags, 3, 0, 0x00000002)
+    EVT_CALL(ModifyColliderFlags, 3, 14, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_802405C0)))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(50)
+    EVT_CALL(TranslateModel, 19, 0, 0, 0)
+    EVT_CALL(ParentColliderToModel, 12, 19)
+    EVT_LOOP(0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(2)
+            EVT_CALL(ModifyColliderFlags, 0, 0, 0x7FFFFE00)
+        EVT_END_THREAD
+        EVT_CALL(MakeLerp, 0, -35, 15, 0)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(TranslateModel, 19, 0, EVT_VAR(0), 0)
+            EVT_CALL(UpdateColliderTransform, 12)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(60)
+        EVT_CALL(PlaySoundAtCollider, 0, 8339, 0)
+        EVT_THREAD
+            EVT_CALL(ModifyColliderFlags, 1, 0, 0x7FFFFE00)
+        EVT_END_THREAD
+        EVT_CALL(MakeLerp, -35, 0, 4, 0)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(TranslateModel, 19, 0, EVT_VAR(0), 0)
+            EVT_CALL(UpdateColliderTransform, 12)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(35)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_868)[] = {
     0x00000000, 0x00000000,
@@ -125,48 +132,53 @@ static s32 N(pad_868)[] = {
 
 #include "world/common/StashVars.inc.c"
 
-EvtSource N(80240874) = SCRIPT({
-    group 0;
-    SetTimeFreezeMode(TIME_FREEZE_FULL);
-    sleep 40;
-    ShowGotItem(EVT_VAR(0), 0, 0);
-    SetTimeFreezeMode(TIME_FREEZE_NORMAL);
-    return;
-});
+EvtSource N(80240874) = {
+    EVT_SET_GROUP(0)
+    EVT_CALL(SetTimeFreezeMode, 2)
+    EVT_WAIT_FRAMES(40)
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 0, 0)
+    EVT_CALL(SetTimeFreezeMode, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802408DC) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    EVT_VAR(0) = EVT_VAR(10);
-    if (EVT_VAR(10) != 0) {
-        await N(80240874);
-    }
-    match EVT_VAR(11) {
-        == 0 {
-            AddItem(EVT_VAR(10), EVT_VAR(0));
-        }
-        == 1 {
-            AddKeyItem(EVT_VAR(10));
-        }
-        == 2 {
-            AddBadge(EVT_VAR(10), EVT_VAR(0));
-        }
-    }
-    sleep 15;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(802408DC) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_EXEC_WAIT(N(80240874))
+    EVT_END_IF
+    EVT_SWITCH(EVT_VAR(11))
+        EVT_CASE_EQ(0)
+            EVT_CALL(AddItem, EVT_VAR(10), EVT_VAR(0))
+        EVT_CASE_EQ(1)
+            EVT_CALL(AddKeyItem, EVT_VAR(10))
+        EVT_CASE_EQ(2)
+            EVT_CALL(AddBadge, EVT_VAR(10), EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802409BC) = SCRIPT({
-    EVT_VAR(10) = 19;
-    EVT_VAR(11) = 1;
-    EVT_SAVE_FLAG(1057) = 1;
-    await N(802408DC);
-});
+EvtSource N(802409BC) = {
+    EVT_SET(EVT_VAR(10), 19)
+    EVT_SET(EVT_VAR(11), 1)
+    EVT_SET(EVT_SAVE_FLAG(1057), 1)
+    EVT_EXEC_WAIT(N(802408DC))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EAE30, -225, 0, -245, 0, ITEM_NONE, MAKE_ENTITY_END);
-    AssignFlag(EVT_SAVE_FLAG(1057));
-    AssignScript(N(802409BC));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EAE30, -225, 0, -245, 0, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignFlag, EVT_SAVE_FLAG(1057))
+    EVT_CALL(AssignScript, EVT_PTR(N(802409BC)))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/GetItemName.inc.c"
 

--- a/src/world/area_dgb/dgb_13/C4E960.c
+++ b/src/world/area_dgb/dgb_13/C4E960.c
@@ -12,18 +12,18 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_13_tattle },
 };
 
-EvtSource N(80240050) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240050) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_E8)[] = {
     0x00000000, 0x00000000,
@@ -31,104 +31,122 @@ static s32 N(pad_E8)[] = {
 
 EvtSource N(exitWalk_802400F0) = EXIT_WALK_SCRIPT(26,  0, "dgb_03",  5);
 
-EvtSource N(8024014C) = SCRIPT({
-    bind N(exitWalk_802400F0) TRIGGER_FLOOR_ABOVE 5;
-});
+EvtSource N(8024014C) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802400F0), TRIGGER_FLOOR_ABOVE, 5, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(80240270);
-    ModifyColliderFlags(0, 6, 0x7FFFFE00);
-    await N(80240680);
-    spawn N(80240050);
-    EVT_VAR(0) = N(8024014C);
-    spawn EnterWalk;
-    sleep 1;
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(80240270))
+    EVT_CALL(ModifyColliderFlags, 0, 6, 0x7FFFFE00)
+    EVT_EXEC_WAIT(N(80240680))
+    EVT_EXEC(N(80240050))
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(8024014C)))
+    EVT_EXEC(EnterWalk)
+    EVT_WAIT_FRAMES(1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240270) = SCRIPT({
-    MakeItemEntity(ITEM_MEGA_RUSH, -910, 50, -206, 17, EVT_SAVE_FLAG(1058));
-    MakeItemEntity(ITEM_COIN, -530, 55, -190, 17, EVT_SAVE_FLAG(1059));
-    MakeItemEntity(ITEM_COIN, -510, 55, -175, 17, EVT_SAVE_FLAG(1060));
-    MakeItemEntity(ITEM_COIN, -510, 55, -205, 17, EVT_SAVE_FLAG(1061));
-    MakeItemEntity(ITEM_COIN, -490, 55, -160, 17, EVT_SAVE_FLAG(1062));
-    MakeItemEntity(ITEM_COIN, -490, 55, -190, 17, EVT_SAVE_FLAG(1063));
-    MakeItemEntity(ITEM_COIN, -490, 55, -220, 17, EVT_SAVE_FLAG(1064));
-});
+EvtSource N(80240270) = {
+    EVT_CALL(MakeItemEntity, ITEM_MEGA_RUSH, -910, 50, -206, 17, EVT_SAVE_FLAG(1058))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -530, 55, -190, 17, EVT_SAVE_FLAG(1059))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -510, 55, -175, 17, EVT_SAVE_FLAG(1060))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -510, 55, -205, 17, EVT_SAVE_FLAG(1061))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -490, 55, -160, 17, EVT_SAVE_FLAG(1062))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -490, 55, -190, 17, EVT_SAVE_FLAG(1063))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, -490, 55, -220, 17, EVT_SAVE_FLAG(1064))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_37C) = {
     0x00000000,
 };
 
-EvtSource N(80240380) = SCRIPT({
-    MakeLerp(0, 30, 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateGroup(47, 0, 0, EVT_VAR(0));
-        UpdateColliderTransform(13);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80240380) = {
+    EVT_CALL(MakeLerp, 0, 30, 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateGroup, 47, 0, 0, EVT_VAR(0))
+        EVT_CALL(UpdateColliderTransform, 13)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240424) = SCRIPT({
-    MakeLerp(30, 0, 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateGroup(47, 0, 0, EVT_VAR(0));
-        UpdateColliderTransform(13);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80240424) = {
+    EVT_CALL(MakeLerp, 30, 0, 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateGroup, 47, 0, 0, EVT_VAR(0))
+        EVT_CALL(UpdateColliderTransform, 13)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802404C8) = SCRIPT({
-    MakeLerp(0, 30, 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateGroup(53, 0, 0, EVT_VAR(0));
-        UpdateColliderTransform(17);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(802404C8) = {
+    EVT_CALL(MakeLerp, 0, 30, 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateGroup, 53, 0, 0, EVT_VAR(0))
+        EVT_CALL(UpdateColliderTransform, 17)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024056C) = SCRIPT({
-    MakeLerp(30, 0, 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateGroup(53, 0, 0, EVT_VAR(0));
-        UpdateColliderTransform(17);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(8024056C) = {
+    EVT_CALL(MakeLerp, 30, 0, 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateGroup, 53, 0, 0, EVT_VAR(0))
+        EVT_CALL(UpdateColliderTransform, 17)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240610) = SCRIPT({
-    if (EVT_MAP_VAR(0) == 0) {
-        await N(80240380);
-        EVT_MAP_VAR(0) = 1;
-    } else {
-        await N(80240424);
-        EVT_MAP_VAR(0) = 0;
-    }
-    unbind;
-});
+EvtSource N(80240610) = {
+    EVT_IF_EQ(EVT_MAP_VAR(0), 0)
+        EVT_EXEC_WAIT(N(80240380))
+        EVT_SET(EVT_MAP_VAR(0), 1)
+    EVT_ELSE
+        EVT_EXEC_WAIT(N(80240424))
+        EVT_SET(EVT_MAP_VAR(0), 0)
+    EVT_END_IF
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240680) = SCRIPT({
-    ParentColliderToModel(13, 44);
-    bind N(80240610) TRIGGER_WALL_PRESS_A 13;
-});
+EvtSource N(80240680) = {
+    EVT_CALL(ParentColliderToModel, 13, 44)
+    EVT_BIND_TRIGGER(N(80240610), TRIGGER_WALL_PRESS_A, 13, 1, 0)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_dgb/dgb_14/C4F030.c
+++ b/src/world/area_dgb/dgb_14/C4F030.c
@@ -13,95 +13,103 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_14_tattle },
 };
 
-EvtSource N(80240060) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240060) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_F8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitDoubleDoor_80240100) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 1;
-    EVT_VAR(1) = 14;
-    EVT_VAR(2) = 24;
-    EVT_VAR(3) = 22;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_03", 3);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80240100) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_SET(EVT_VAR(1), 14)
+    EVT_SET(EVT_VAR(2), 24)
+    EVT_SET(EVT_VAR(3), 22)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_03"), 3)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitDoubleDoor_802401B4) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 18;
-    EVT_VAR(2) = 19;
-    EVT_VAR(3) = 17;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_15", 0);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_802401B4) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 18)
+    EVT_SET(EVT_VAR(2), 19)
+    EVT_SET(EVT_VAR(3), 17)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_15"), 0)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterDoubleDoor_80240268) = SCRIPT({
-    UseDoorSounds(3);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 24;
-            EVT_VAR(3) = 22;
-            await EnterDoubleDoor;
-        }
-        == 1 {
-            DisablePlayerInput(TRUE);
-            EVT_VAR(2) = 19;
-            EVT_VAR(3) = 17;
-            await EnterDoubleDoor;
-            if (EVT_AREA_FLAG(1) == 1) {
-                sleep 5;
-                SetPlayerAnimation(ANIM_8001D);
-                sleep 20;
-                SetPlayerAnimation(ANIM_10002);
-            }
-            DisablePlayerInput(FALSE);
-        }
-    }
-});
+EvtSource N(enterDoubleDoor_80240268) = {
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 24)
+            EVT_SET(EVT_VAR(3), 22)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+        EVT_CASE_EQ(1)
+            EVT_CALL(DisablePlayerInput, TRUE)
+            EVT_SET(EVT_VAR(2), 19)
+            EVT_SET(EVT_VAR(3), 17)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+            EVT_IF_EQ(EVT_AREA_FLAG(1), 1)
+                EVT_WAIT_FRAMES(5)
+                EVT_CALL(SetPlayerAnimation, ANIM_8001D)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_END_IF
+            EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    spawn N(80240060);
-    bind N(exitDoubleDoor_80240100) TRIGGER_WALL_PRESS_A 14;
-    bind N(exitDoubleDoor_802401B4) TRIGGER_WALL_PRESS_A 18;
-    spawn N(enterDoubleDoor_80240268);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80240060))
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80240100), TRIGGER_WALL_PRESS_A, 14, 1, 0)
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_802401B4), TRIGGER_WALL_PRESS_A, 18, 1, 0)
+    EVT_EXEC(N(enterDoubleDoor_80240268))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_47C) = {
     0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA564, 500, 60, 75, 0, ITEM_MAPLE_SYRUP, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1065));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA564, 500, 60, 75, 0, 163, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1065))
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_dgb/dgb_15/C4F510.c
+++ b/src/world/area_dgb/dgb_15/C4F510.c
@@ -19,22 +19,22 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_15_tattle },
 };
 
-EvtSource N(802418E0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            if (EVT_SAVE_VAR(203) == 15) {
-                SetMusicTrack(0, SONG_TUBBA_BLUBBA_THEME, 0, 8);
-            } else {
-                SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-            }
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(802418E0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_IF_EQ(EVT_SAVE_VAR(203), 15)
+                EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_BLUBBA_THEME, 0, 8)
+            EVT_ELSE
+                EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+            EVT_END_IF
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_19B4)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -45,121 +45,129 @@ s32 N(itemList_802419C0)[] = {
     ITEM_NONE,
 };
 
-EvtSource N(exitDoubleDoor_802419C8) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 19;
-    EVT_VAR(2) = 12;
-    EVT_VAR(3) = 14;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_14", 1);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_802419C8) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 19)
+    EVT_SET(EVT_VAR(2), 12)
+    EVT_SET(EVT_VAR(3), 14)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_14"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitDoubleDoor_80241A7C) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 1;
-    EVT_VAR(1) = 10;
-    EVT_VAR(2) = 19;
-    EVT_VAR(3) = 17;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_17", 0);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80241A7C) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_SET(EVT_VAR(1), 10)
+    EVT_SET(EVT_VAR(2), 19)
+    EVT_SET(EVT_VAR(3), 17)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_17"), 0)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitSingleDoor_80241B30) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 2;
-    EVT_VAR(1) = 6;
-    EVT_VAR(2) = 22;
-    EVT_VAR(3) = 1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_16", 0);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80241B30) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 2)
+    EVT_SET(EVT_VAR(1), 6)
+    EVT_SET(EVT_VAR(2), 22)
+    EVT_SET(EVT_VAR(3), 1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_16"), 0)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 const s32 N(pad_XXXX)[] = { 0, 0 };
 
-EvtSource N(80241BE4) = SCRIPT({
-    bind N(exitDoubleDoor_802419C8) TRIGGER_WALL_PRESS_A 19;
-    bind N(exitSingleDoor_80241B30) TRIGGER_WALL_PRESS_A 6;
-    if (EVT_SAVE_FLAG(1066) == 0) {
-        bind_padlock N(80242AD0) TRIGGER_WALL_PRESS_A entity(0) N(itemList_802419C0);
-    } else {
-        bind N(exitDoubleDoor_80241A7C) TRIGGER_WALL_PRESS_A 10;
-    }
-});
+EvtSource N(80241BE4) = {
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_802419C8), TRIGGER_WALL_PRESS_A, 19, 1, 0)
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80241B30), TRIGGER_WALL_PRESS_A, 6, 1, 0)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1066), 0)
+        EVT_BIND_PADLOCK(N(80242AD0), TRIGGER_WALL_PRESS_A, EVT_ENTITY_INDEX(0), EVT_PTR(N(itemList_802419C0)), 0, 1)
+    EVT_ELSE
+        EVT_BIND_TRIGGER(N(exitDoubleDoor_80241A7C), TRIGGER_WALL_PRESS_A, 10, 1, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterSingleDoor_80241C88) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            UseDoorSounds(3);
-            EVT_VAR(2) = 12;
-            EVT_VAR(3) = 14;
-            await EnterDoubleDoor;
-        }
-        == 1 {
-            UseDoorSounds(3);
-            EVT_VAR(2) = 19;
-            EVT_VAR(3) = 17;
-            await EnterDoubleDoor;
-        }
-        == 2 {
-            UseDoorSounds(0);
-            EVT_VAR(2) = 22;
-            EVT_VAR(3) = 1;
-            await EnterSingleDoor;
-        }
-    }
-    spawn N(80241BE4);
-});
+EvtSource N(enterSingleDoor_80241C88) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(UseDoorSounds, 3)
+            EVT_SET(EVT_VAR(2), 12)
+            EVT_SET(EVT_VAR(3), 14)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+        EVT_CASE_EQ(1)
+            EVT_CALL(UseDoorSounds, 3)
+            EVT_SET(EVT_VAR(2), 19)
+            EVT_SET(EVT_VAR(3), 17)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+        EVT_CASE_EQ(2)
+            EVT_CALL(UseDoorSounds, 0)
+            EVT_SET(EVT_VAR(2), 22)
+            EVT_SET(EVT_VAR(3), 1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_EXEC(N(80241BE4))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    EVT_AREA_FLAG(1) = 0;
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    if (EVT_SAVE_FLAG(1068) == 0) {
-        MakeNpcs(1, N(npcGroupList_80242AB0));
-    }
-    await N(makeEntities);
-    spawn N(802418E0);
-    spawn N(enterSingleDoor_80241C88);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_SET(EVT_AREA_FLAG(1), 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1068), 0)
+        EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_80242AB0)))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(802418E0))
+    EVT_EXEC(N(enterSingleDoor_80241C88))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1E94)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80241EA0) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(80241EA0) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(unk_missing_80241F5C)[] = {
     0x00390000, 0x00390002, 0x00390003, 0x00390004, 0x0039000C, 0x00390007, 0x00390008, 0x00390011,
@@ -171,29 +179,33 @@ s32 N(D_80241F8C_C5149C)[] = {
     0x0000000C, 0x42DC0000, 0x42B40000, 0x00000003,
 };
 
-EvtSource N(80241FBC) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 5);
-    SetSelfVar(2, 8);
-    SetSelfVar(3, 12);
-    N(func_8024061C_C4FB2C)(N(D_80241F8C_C5149C));
-});
+EvtSource N(80241FBC) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 5)
+    EVT_CALL(SetSelfVar, 2, 8)
+    EVT_CALL(SetSelfVar, 3, 12)
+    EVT_CALL(N(func_8024061C_C4FB2C), EVT_PTR(N(D_80241F8C_C5149C)))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(unk_missing_8024202C)[] = {
     0x00000000, 0x00240022, 0x00000000, 0x00000000, N(80241FBC), 0x80077F70, 0x00000000, 0x8007809C,
     0x00000000, 0x00000000, 0x000D0000,
 };
 
-EvtSource N(80242058) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(80242058) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(unk_missing_80242100)[] = {
     0x00000000, 0x000E0012, 0x00000000, 0x00000000, N(80242058), 0x00000000, 0x00000000, N(80241EA0),
@@ -213,97 +225,100 @@ s32 N(unk_missing_80242158)[] = {
     0x00000000, 0x00000000, 0x000D0000,
 };
 
-EvtSource N(80242184) = SCRIPT({
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        GetNpcPos(NPC_WORLD_TUBBA, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        EVT_VAR(1) -= EVT_VAR(0);
-        if (EVT_VAR(1) < 150) {
-            break loop;
-        }
-        sleep 1;
-    }
-    EVT_SAVE_FLAG(1067) = 1;
-    EVT_AREA_FLAG(1) = 1;
-});
+EvtSource N(80242184) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(GetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_SUB(EVT_VAR(1), EVT_VAR(0))
+        EVT_IF_LT(EVT_VAR(1), 150)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SET(EVT_SAVE_FLAG(1067), 1)
+    EVT_SET(EVT_AREA_FLAG(1), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242238) = SCRIPT({
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(0) >= -1150) {
-            break loop;
-        }
-        sleep 1;
-    }
-    DisablePlayerInput(TRUE);
-    SetMusicTrack(0, SONG_TUBBA_BLUBBA_THEME, 0, 8);
-    sleep 15;
-    spawn {
-        UseSettingsFrom(0, -50, 0, 180);
-        SetCamSpeed(0, 2.0);
-        SetPanTarget(0, -50, 0, 180);
-        PanToTarget(0, 0, 1);
-    }
-    EVT_SAVE_VAR(203) = 15;
-    SetNpcPos(NPC_SELF, 0, 0, 88);
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_9);
-    SetNpcYaw(NPC_SELF, 270);
-    NpcMoveTo(NPC_SELF, -53, 180, 60);
-    SetMusicTrack(0, SONG_TUBBA_BLUBBA_THEME, 0, 8);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6);
-    sleep 15;
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 0, MESSAGE_ID(0x0E, 0x00F3));
-    sleep 15;
-    spawn {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamSpeed(0, 2.0);
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        WaitForCam(0, 1.0);
-        PanToTarget(0, 0, 0);
-        DisablePlayerInput(FALSE);
-    }
-    BindNpcAI(NPC_SELF, N(npcAI_8024274C));
-});
+EvtSource N(idle_80242238) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_GE(EVT_VAR(0), -1150)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_BLUBBA_THEME, 0, 8)
+    EVT_WAIT_FRAMES(15)
+    EVT_THREAD
+        EVT_CALL(UseSettingsFrom, 0, -50, 0, 180)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(2.0))
+        EVT_CALL(SetPanTarget, 0, -50, 0, 180)
+        EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_END_THREAD
+    EVT_SET(EVT_SAVE_VAR(203), 15)
+    EVT_CALL(SetNpcPos, NPC_SELF, 0, 0, 88)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_tubba_Palette_00_Anim_9)
+    EVT_CALL(SetNpcYaw, NPC_SELF, 270)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -53, 180, 60)
+    EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_BLUBBA_THEME, 0, 8)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 0, MESSAGE_ID(0x0E, 0x00F3))
+    EVT_WAIT_FRAMES(15)
+    EVT_THREAD
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(2.0))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(PanToTarget, 0, 0, 0)
+        EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_END_THREAD
+    EVT_CALL(BindNpcAI, NPC_SELF, EVT_PTR(N(npcAI_8024274C)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802424E8) = SCRIPT({
-    GetNpcPos(NPC_SELF, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8));
-    loop {
-        sleep 1;
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        GetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-        if (EVT_VAR(3) != EVT_VAR(6)) {
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 65538);
-            GetDist2D(EVT_VAR(10), EVT_VAR(0), EVT_VAR(2), EVT_VAR(3), EVT_VAR(5));
-            match EVT_VAR(10) {
-                < 200 {
-                    spawn {
-                        ShakeCam(0, 0, 5, 1.6005859375);
-                        sleep 5;
-                        ShakeCam(0, 0, 2, 0.80078125);
-                    }
-                }
-                < 300 {
-                    spawn {
-                        ShakeCam(0, 0, 5, 0.6005859375);
-                        sleep 5;
-                        ShakeCam(0, 0, 2, 0.30078125);
-                    }
-                }
-                >= 300 {
-                    spawn {
-                        ShakeCam(0, 0, 5, 0.1005859375);
-                        sleep 5;
-                        ShakeCam(0, 0, 2, 0.05078125);
-                    }
-                }
-            }
-            sleep 12;
-        } else {
-        }
-        GetNpcPos(NPC_SELF, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8));
-    }
-});
+EvtSource N(802424E8) = {
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8))
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+        EVT_IF_NE(EVT_VAR(3), EVT_VAR(6))
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 65538)
+            EVT_CALL(GetDist2D, EVT_VAR(10), EVT_VAR(0), EVT_VAR(2), EVT_VAR(3), EVT_VAR(5))
+            EVT_SWITCH(EVT_VAR(10))
+                EVT_CASE_LT(200)
+                    EVT_THREAD
+                        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(1.6))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(0.8))
+                    EVT_END_THREAD
+                EVT_CASE_LT(300)
+                    EVT_THREAD
+                        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.6))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(0.3))
+                    EVT_END_THREAD
+                EVT_CASE_GE(300)
+                    EVT_THREAD
+                        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.1))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(0.05))
+                    EVT_END_THREAD
+            EVT_END_SWITCH
+            EVT_WAIT_FRAMES(12)
+        EVT_ELSE
+        EVT_END_IF
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8))
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_8024271C) = {
     .moveSpeed = 3.0f,
@@ -320,36 +335,42 @@ NpcAISettings N(npcAISettings_8024271C) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_8024274C) = SCRIPT({
-    spawn N(80242184);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_GRAVITY)), TRUE);
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_C);
-    spawn N(802424E8);
-    N(func_80241464_C50974)(N(npcAISettings_8024271C));
-});
+EvtSource N(npcAI_8024274C) = {
+    EVT_EXEC(N(80242184))
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_GRAVITY)), TRUE)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_tubba_Palette_00_Anim_C)
+    EVT_EXEC(N(802424E8))
+    EVT_CALL(N(func_80241464_C50974), EVT_PTR(N(npcAISettings_8024271C)))
+    EVT_RETURN
+    EVT_END
+};
 
 extern const char N(dgb_14_name_hack)[];
 
-EvtSource N(defeat_802427B0) = SCRIPT({
-    N(UnkFunc1)();
-    GotoMap(N(dgb_14_name_hack), 1);
-    sleep 100;
-});
+EvtSource N(defeat_802427B0) = {
+    EVT_CALL(N(UnkFunc1))
+    EVT_CALL(GotoMap, EVT_PTR(N(dgb_14_name_hack)), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802427EC) = SCRIPT({
-    if (EVT_STORY_PROGRESS != STORY_CH3_ARRIVED_AT_TUBBAS_MANOR) {
-        RemoveNpc(NPC_SELF);
-        return;
-    }
-    SetNpcScale(NPC_SELF, 1.25, 1.25, 1.25);
-    if (EVT_SAVE_VAR(203) != 15) {
-        BindNpcIdle(NPC_SELF, N(idle_80242238));
-    } else {
-        SetNpcPos(NPC_SELF, -310, 0, 180);
-        BindNpcIdle(NPC_SELF, N(npcAI_8024274C));
-    }
-    BindNpcDefeat(NPC_SELF, N(defeat_802427B0));
-});
+EvtSource N(init_802427EC) = {
+    EVT_IF_NE(EVT_SAVE_VAR(0), -32)
+        EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.25), EVT_FIXED(1.25))
+    EVT_IF_NE(EVT_SAVE_VAR(203), 15)
+        EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242238)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, -310, 0, 180)
+        EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_8024274C)))
+    EVT_END_IF
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802427B0)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_802428C0) = {
     .id = NPC_WORLD_TUBBA,
@@ -398,44 +419,50 @@ static s32 N(pad_2AC8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80242AD0) = SCRIPT({
-    group 0;
-    suspend group 1;
-    ShowKeyChoicePopup();
-    if (EVT_VAR(0) == 0) {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00D8), 160, 40);
-        CloseChoicePopup();
-        resume group 1;
-        return;
-    }
-    if (EVT_VAR(0) == -1) {
-        CloseChoicePopup();
-        resume group 1;
-        return;
-    }
-    FindKeyItem(19, EVT_VAR(0));
-    RemoveKeyItemAt(EVT_VAR(0));
-    CloseChoicePopup();
-    EVT_SAVE_FLAG(1066) = 1;
-    N(GetEntityPosition)(EVT_MAP_VAR(0), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    PlaySoundAt(0x269, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) = EVT_MAP_VAR(0);
-    N(SetEntityFlags100000)();
-    resume group 1;
-    unbind;
-});
+EvtSource N(80242AD0) = {
+    EVT_SET_GROUP(0)
+    EVT_SUSPEND_GROUP(1)
+    EVT_CALL(ShowKeyChoicePopup)
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00D8), 160, 40)
+        EVT_CALL(CloseChoicePopup)
+        EVT_RESUME_GROUP(1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), -1)
+        EVT_CALL(CloseChoicePopup)
+        EVT_RESUME_GROUP(1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(FindKeyItem, ITEM_TUBBA_CASTLE_KEY, EVT_VAR(0))
+    EVT_CALL(RemoveKeyItemAt, EVT_VAR(0))
+    EVT_CALL(CloseChoicePopup)
+    EVT_SET(EVT_SAVE_FLAG(1066), 1)
+    EVT_CALL(N(GetEntityPosition), EVT_MAP_VAR(0), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(PlaySoundAt, 0x269, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SET(EVT_VAR(0), EVT_MAP_VAR(0))
+    EVT_CALL(N(SetEntityFlags100000))
+    EVT_RESUME_GROUP(1)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242C38) = SCRIPT({
-    bind N(exitDoubleDoor_80241A7C) TRIGGER_WALL_PRESS_A 10;
-});
+EvtSource N(80242C38) = {
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80241A7C), TRIGGER_WALL_PRESS_A, 10, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    if (EVT_SAVE_FLAG(1066) == 0) {
-        MakeEntity(0x802BCD68, 130, 8, 175, -80, MAKE_ENTITY_END);
-        AssignScript(N(80242C38));
-        EVT_MAP_VAR(0) = EVT_VAR(0);
-    }
-});
+EvtSource N(makeEntities) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1066), 0)
+        EVT_CALL(MakeEntity, 0x802BCD68, 130, 8, 175, -80, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80242C38)))
+        EVT_SET(EVT_MAP_VAR(0), EVT_VAR(0))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc6.inc.c"
 

--- a/src/world/area_dgb/dgb_16/C52540.c
+++ b/src/world/area_dgb/dgb_16/C52540.c
@@ -30,98 +30,104 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_16_tattle },
 };
 
-EvtSource N(80241480) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80241480) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1518)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitSingleDoor_80241520) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(0);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 6;
-    EVT_VAR(2) = 16;
-    EVT_VAR(3) = -1;
-    spawn ExitSingleDoor;
-    sleep 17;
-    GotoMap("dgb_15", 2);
-    sleep 100;
-});
+EvtSource N(exitSingleDoor_80241520) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 6)
+    EVT_SET(EVT_VAR(2), 16)
+    EVT_SET(EVT_VAR(3), -1)
+    EVT_EXEC(ExitSingleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_15"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(pad_XXX)[] = { 0, 0 };
 
-EvtSource N(enterSingleDoor_802415D4) = SCRIPT({
-    UseDoorSounds(0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            if (EVT_SAVE_FLAG(1068) == 0) {
-                EVT_SAVE_FLAG(1068) = 1;
-                EVT_SAVE_VAR(203) = 18;
-            }
-            EVT_VAR(2) = 16;
-            EVT_VAR(3) = -1;
-            await EnterSingleDoor;
-        }
-    }
-});
+EvtSource N(enterSingleDoor_802415D4) = {
+    EVT_CALL(UseDoorSounds, 0)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1068), 0)
+                EVT_SET(EVT_SAVE_FLAG(1068), 1)
+                EVT_SET(EVT_SAVE_VAR(203), 18)
+            EVT_END_IF
+            EVT_SET(EVT_VAR(2), 16)
+            EVT_SET(EVT_VAR(3), -1)
+            EVT_EXEC_WAIT(EnterSingleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    if (EVT_STORY_PROGRESS < STORY_CH3_STAR_SPIRIT_RESCUED) {
-        MakeNpcs(1, N(npcGroupList_8024318C));
-    }
-    await N(80241780);
-    spawn N(80241480);
-    bind N(exitSingleDoor_80241520) TRIGGER_WALL_PRESS_A 6;
-    spawn N(enterSingleDoor_802415D4);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_IF_LT(EVT_SAVE_VAR(0), -15)
+        EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_8024318C)))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80241780))
+    EVT_EXEC(N(80241480))
+    EVT_BIND_TRIGGER(N(exitSingleDoor_80241520), TRIGGER_WALL_PRESS_A, 6, 1, 0)
+    EVT_EXEC(N(enterSingleDoor_802415D4))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1774)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80241780) = SCRIPT({
-    MakeItemEntity(ITEM_TUBBA_CASTLE_KEY, -235, 25, -165, 17, EVT_SAVE_FLAG(1069));
-});
+EvtSource N(80241780) = {
+    EVT_CALL(MakeItemEntity, ITEM_TUBBA_CASTLE_KEY, -235, 25, -165, 17, EVT_SAVE_FLAG(1069))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_17B4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(802417C0) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            RemoveNpc(NPC_SELF);
-        }
-        == 2 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-            func_80045900(1);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(802417C0) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+            EVT_CALL(func_80045900, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(extraAnimationList_8024187C)[] = {
     NPC_ANIM_world_clubba_Palette_00_Anim_0,
@@ -156,13 +162,15 @@ NpcAISettings N(npcAISettings_802418AC) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802418DC) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(1, 10);
-    SetSelfVar(2, 14);
-    SetSelfVar(3, 18);
-    N(func_80240E20_C53360)(N(npcAISettings_802418AC));
-});
+EvtSource N(npcAI_802418DC) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 1, 10)
+    EVT_CALL(SetSelfVar, 2, 14)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(N(func_80240E20_C53360), EVT_PTR(N(npcAISettings_802418AC)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024194C) = {
     .height = 36,
@@ -173,16 +181,18 @@ NpcSettings N(npcSettings_8024194C) = {
     .level = 13,
 };
 
-EvtSource N(npcAI_80241978) = SCRIPT({
-    EnableNpcShadow(NPC_SELF, FALSE);
-    SetSelfVar(0, 4);
-    SetSelfVar(1, 32);
-    SetSelfVar(2, 50);
-    SetSelfVar(3, 32);
-    SetSelfVar(4, 3);
-    SetSelfVar(15, 8389);
-    N(UnkFunc7)();
-});
+EvtSource N(npcAI_80241978) = {
+    EVT_CALL(EnableNpcShadow, NPC_SELF, FALSE)
+    EVT_CALL(SetSelfVar, 0, 4)
+    EVT_CALL(SetSelfVar, 1, 32)
+    EVT_CALL(SetSelfVar, 2, 50)
+    EVT_CALL(SetSelfVar, 3, 32)
+    EVT_CALL(SetSelfVar, 4, 3)
+    EVT_CALL(SetSelfVar, 15, 8389)
+    EVT_CALL(N(UnkFunc7))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80241A20) = {
     .height = 14,

--- a/src/world/area_dgb/dgb_17/C55A60.c
+++ b/src/world/area_dgb/dgb_17/C55A60.c
@@ -13,93 +13,103 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_17_tattle },
 };
 
-EvtSource N(80240060) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(80240060) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_F8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitDoubleDoor_80240100) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 7;
-    EVT_VAR(2) = 14;
-    EVT_VAR(3) = 16;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_15", 1);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80240100) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 7)
+    EVT_SET(EVT_VAR(2), 14)
+    EVT_SET(EVT_VAR(3), 16)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_15"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(exitDoubleDoor_802401B4) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 1;
-    EVT_VAR(1) = 11;
-    EVT_VAR(2) = 21;
-    EVT_VAR(3) = 19;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_01", 5);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_802401B4) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_SET(EVT_VAR(1), 11)
+    EVT_SET(EVT_VAR(2), 21)
+    EVT_SET(EVT_VAR(3), 19)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_01"), 5)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240268) = SCRIPT({
-    bind N(exitDoubleDoor_80240100) TRIGGER_WALL_PRESS_A 7;
-    bind N(exitDoubleDoor_802401B4) TRIGGER_WALL_PRESS_A 11;
-});
+EvtSource N(80240268) = {
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80240100), TRIGGER_WALL_PRESS_A, 7, 1, 0)
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_802401B4), TRIGGER_WALL_PRESS_A, 11, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterDoubleDoor_802402B0) = SCRIPT({
-    GetLoadType(EVT_VAR(1));
-    if (EVT_VAR(1) == 1) {
-        spawn EnterSavePoint;
-        spawn N(80240268);
-        return;
-    }
-    UseDoorSounds(3);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 14;
-            EVT_VAR(3) = 16;
-            await EnterDoubleDoor;
-        }
-        == 1 {
-            EVT_VAR(2) = 21;
-            EVT_VAR(3) = 19;
-            await EnterDoubleDoor;
-        }
-    }
-    spawn N(80240268);
-});
+EvtSource N(enterDoubleDoor_802402B0) = {
+    EVT_CALL(GetLoadType, EVT_VAR(1))
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_EXEC(EnterSavePoint)
+        EVT_EXEC(N(80240268))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 14)
+            EVT_SET(EVT_VAR(3), 16)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+        EVT_CASE_EQ(1)
+            EVT_SET(EVT_VAR(2), 21)
+            EVT_SET(EVT_VAR(3), 19)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+    EVT_END_SWITCH
+    EVT_EXEC(N(80240268))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamLeadPlayer(0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    spawn N(80240060);
-    spawn N(enterDoubleDoor_802402B0);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80240060))
+    EVT_EXEC(N(enterDoubleDoor_802402B0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802E9A18, -300, 60, 75, 0, MAKE_ENTITY_END);
-    MakeEntity(0x802EA7E0, -450, 60, 75, 0, MAKE_ENTITY_END);
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, EVT_PTR(D_802E9A18), -300, 60, 75, 0, MAKE_ENTITY_END)
+    EVT_CALL(MakeEntity, 0x802EA7E0, -450, 60, 75, 0, MAKE_ENTITY_END)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_dgb/dgb_18/C55F40.c
+++ b/src/world/area_dgb/dgb_18/C55F40.c
@@ -24,62 +24,67 @@ MapConfig N(config) = {
     .tattle = { MSG_dgb_18_tattle },
 };
 
-EvtSource N(802412C0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_WOKE_UP {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-        < STORY_CH3_DEFEATED_TUBBA_BLUBBA {
-            SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_TUBBAS_MANOR, 0, 8);
-        }
-    }
-});
+EvtSource N(802412C0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-29)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+        EVT_CASE_LT(-16)
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_TUBBAS_MANOR, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1358)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(exitDoubleDoor_80241360) = SCRIPT({
-    group 27;
-    DisablePlayerInput(TRUE);
-    UseDoorSounds(3);
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 17;
-    EVT_VAR(2) = 8;
-    EVT_VAR(3) = 10;
-    spawn ExitDoubleDoor;
-    sleep 17;
-    GotoMap("dgb_01", 6);
-    sleep 100;
-});
+EvtSource N(exitDoubleDoor_80241360) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_SET(EVT_VAR(1), 17)
+    EVT_SET(EVT_VAR(2), 8)
+    EVT_SET(EVT_VAR(3), 10)
+    EVT_EXEC(ExitDoubleDoor)
+    EVT_WAIT_FRAMES(17)
+    EVT_CALL(GotoMap, EVT_PTR("dgb_01"), 6)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(enterDoubleDoor_80241414) = SCRIPT({
-    UseDoorSounds(3);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_VAR(2) = 8;
-            EVT_VAR(3) = 10;
-            await EnterDoubleDoor;
-        }
-    }
-});
+EvtSource N(enterDoubleDoor_80241414) = {
+    EVT_CALL(UseDoorSounds, 3)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(2), 8)
+            EVT_SET(EVT_VAR(3), 10)
+            EVT_EXEC_WAIT(EnterDoubleDoor)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_TUBBAS_MANOR;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    MakeNpcs(1, N(npcGroupList_802436B4));
-    await N(makeEntities);
-    spawn N(802412C0);
-    bind N(exitDoubleDoor_80241360) TRIGGER_WALL_PRESS_A 17;
-    spawn N(enterDoubleDoor_80241414);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 15)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(MakeNpcs, 1, EVT_PTR(N(npcGroupList_802436B4)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(802412C0))
+    EVT_BIND_TRIGGER(N(exitDoubleDoor_80241360), TRIGGER_WALL_PRESS_A, 17, 1, 0)
+    EVT_EXEC(N(enterDoubleDoor_80241414))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1578)[] = {
     0x00000000, 0x00000000,
@@ -98,9 +103,11 @@ NpcAISettings N(npcAISettings_80241580) = {
     .unk_2C = 1,
 };
 
-EvtSource N(802415B0) = SCRIPT({
-    N(func_80240B94_C56AD4)(N(npcAISettings_80241580));
-});
+EvtSource N(802415B0) = {
+    EVT_CALL(N(func_80240B94_C56AD4), EVT_PTR(N(npcAISettings_80241580)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802415D0) = {
     .height = 90,
@@ -125,448 +132,453 @@ NpcSettings N(npcSettings_80241628) = {
     .level = 13,
 };
 
-EvtSource N(idle_80241654) = SCRIPT({
-10:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    sleep 1;
-    if (EVT_VAR(0) < 700) {
-        goto 10;
-    }
-    if (EVT_VAR(2) > 185) {
-        goto 10;
-    }
-    DisablePlayerInput(TRUE);
-    sleep 10;
-    spawn {
-        sleep 10;
-        InterpPlayerYaw(270, 0);
-    }
-    FadeOutMusic(0, 500);
-    loop 3 {
-        SetPlayerAnimation(ANIM_8001E);
-        PlaySoundAt(SOUND_20F6, 0, 382, 0, 218);
-        ShakeCam(0, 0, 5, 1.0);
-        sleep 20;
-        SetPlayerAnimation(ANIM_10002);
-        sleep 10;
-    }
-    loop 2 {
-        InterpPlayerYaw(270, 0);
-        sleep 10;
-        InterpPlayerYaw(90, 0);
-        sleep 10;
-    }
-    UseSettingsFrom(0, -40, 0, 180);
-    SetCamSpeed(0, 90.0);
-    SetPanTarget(0, -40, 0, 180);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SetPlayerPos(740, 0, 180);
-    SetNpcPos(NPC_PARTNER, 765, 0, 180);
-    InterpPlayerYaw(270, 0);
-    InterpNpcYaw(NPC_PARTNER, 270, 0);
-    SetPlayerAnimation(ANIM_8000C);
-    PlaySoundAtCollider(17, 455, 0);
-    MakeLerp(0, 80, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(8, EVT_VAR(0), 0, -1, 0);
-        RotateModel(10, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    spawn {
-        loop 3 {
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 0);
-            ShakeCam(0, 0, 5, 0.30078125);
-            sleep 5;
-        }
-    }
-    SetMusicTrack(0, SONG_TUBBA_BLUBBA_THEME, 0, 8);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_9);
-    SetNpcPos(NPC_SELF, -210, 0, 180);
-    NpcMoveTo(NPC_SELF, -60, 180, 30);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6);
-    spawn {
-        MakeLerp(80, 0, 10, 0);
-        loop {
-            UpdateLerp();
-            RotateModel(8, EVT_VAR(0), 0, -1, 0);
-            RotateModel(10, EVT_VAR(0), 0, 1, 0);
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        PlaySoundAtCollider(17, 456, 0);
-    }
-    sleep 20;
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 5, MESSAGE_ID(0x0E, 0x00F4));
-    sleep 20;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_9);
-    SetSelfVar(0, 0);
-    spawn {
-        loop {
-            GetSelfVar(0, EVT_VAR(0));
-            if (EVT_VAR(0) == 1) {
-                break loop;
-            }
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 0);
-            ShakeCam(0, 0, 5, 0.30078125);
-            sleep 9;
-            GetSelfVar(0, EVT_VAR(0));
-            if (EVT_VAR(0) == 1) {
-                break loop;
-            }
-            PlaySoundAtNpc(NPC_SELF, SOUND_20F6, 0);
-            ShakeCam(0, 0, 2, 0.150390625);
-            sleep 12;
-        }
-    }
-    spawn {
-        loop {
-            GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 1;
-            GetSelfVar(0, EVT_VAR(0));
-            if (EVT_VAR(0) == 1) {
-                break loop;
-            }
-        }
-    }
-    SetNpcSpeed(NPC_SELF, 4.0);
-    NpcMoveTo(NPC_SELF, 45, 215, 0);
-    NpcMoveTo(NPC_SELF, 140, 245, 0);
-    NpcMoveTo(NPC_SELF, 615, 245, 0);
-    SetSelfVar(0, 1);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6);
-    sleep 15;
-    sleep 20;
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 5, MESSAGE_ID(0x0E, 0x00F5));
-    sleep 20;
-    spawn {
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_14);
-        sleep 5;
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_15);
-        sleep 5;
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_16);
-        sleep 5;
-    }
-    sleep 5;
-    SetNpcJumpscale(NPC_SELF, 0.7001953125);
-    NpcJump0(NPC_SELF, 600, 50, 115, 20);
-    spawn {
-        ShakeCam(0, 0, 5, 0.30078125);
-    }
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_5);
-    SetNpcScale(NPC_SELF, 1.25, 1.2001953125, 1.25);
-    sleep 1;
-    SetNpcScale(NPC_SELF, 1.3505859375, 1.150390625, 1.25);
-    sleep 1;
-    SetNpcScale(NPC_SELF, 1.4501953125, 1.05078125, 1.25);
-    sleep 1;
-    SetNpcScale(NPC_SELF, 1.3505859375, 1.150390625, 1.25);
-    sleep 1;
-    SetNpcScale(NPC_SELF, 1.25, 1.2001953125, 1.25);
-    sleep 1;
-    GetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    spawn {
-        SetNpcJumpscale(NPC_SELF, 0.5);
-        NpcJump0(NPC_SELF, EVT_VAR(3), 30, EVT_VAR(5), 23);
-    }
-    sleep 2;
-    spawn {
-        MakeLerp(0, 50, 18, 1);
-        loop {
-            UpdateLerp();
-            func_802CDE68(-1, EVT_VAR(0));
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-    }
-    MakeLerp(0, -90, 18, 1);
-    loop {
-        UpdateLerp();
-        SetNpcRotation(NPC_SELF, 0, 0, EVT_VAR(0));
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    spawn {
-        ShakeCam(0, 0, 10, 0.400390625);
-    }
-    sleep 5;
-    FadeOutMusic(0, 1000);
-    SetNpcScale(NPC_SELF, 1.25, 1.25, 1.25);
-    SetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    func_802CDE68(-1, 0);
-    SetNpcRotation(NPC_SELF, 0, 0, 0);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_2);
-    sleep 15;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_24);
-    sleep 30;
-    PlaySoundAtNpc(NPC_SELF, SOUND_2038, 0);
-    sleep 30;
-    spawn {
-        SetSelfVar(1, 0);
-        loop {
-            GetSelfVar(1, EVT_VAR(0));
-            if (EVT_VAR(0) == 1) {
-                break loop;
-            }
-            PlaySoundAtNpc(NPC_SELF, SOUND_2039, 0);
-            RandInt(10, EVT_VAR(1));
-            EVT_VAR(1) += 15;
-            ShowSleepBubble(0, 0, 0, 2, 628, 121, 127, EVT_VAR(1), EVT_VAR(0));
-            sleep 48;
-            PlaySoundAtNpc(NPC_SELF, SOUND_2038, 0);
-            RandInt(10, EVT_VAR(1));
-            EVT_VAR(1) += 10;
-            func_802D8248(EVT_VAR(0), EVT_VAR(1));
-            sleep 30;
-        }
-    }
-    sleep 30;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 2.0);
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    WaitForCam(0, 1.0);
-    PanToTarget(0, 0, 0);
-    EVT_STORY_PROGRESS = STORY_CH3_TUBBA_BEGAN_NAPPING;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(idle_80241654) = {
+    EVT_LABEL(10)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_LT(EVT_VAR(0), 700)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_IF_GT(EVT_VAR(2), 185)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(10)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(InterpPlayerYaw, 270, 0)
+    EVT_END_THREAD
+    EVT_CALL(FadeOutMusic, 0, 500)
+    EVT_LOOP(3)
+        EVT_CALL(SetPlayerAnimation, ANIM_8001E)
+        EVT_CALL(PlaySoundAt, SOUND_20F6, 0, 382, 0, 218)
+        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(1.0))
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(SetPlayerAnimation, ANIM_10002)
+        EVT_WAIT_FRAMES(10)
+    EVT_END_LOOP
+    EVT_LOOP(2)
+        EVT_CALL(InterpPlayerYaw, 270, 0)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(InterpPlayerYaw, 90, 0)
+        EVT_WAIT_FRAMES(10)
+    EVT_END_LOOP
+    EVT_CALL(UseSettingsFrom, 0, -40, 0, 180)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(SetPanTarget, 0, -40, 0, 180)
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SetPlayerPos, 740, 0, 180)
+    EVT_CALL(SetNpcPos, NPC_PARTNER, 765, 0, 180)
+    EVT_CALL(InterpPlayerYaw, 270, 0)
+    EVT_CALL(InterpNpcYaw, NPC_PARTNER, 270, 0)
+    EVT_CALL(SetPlayerAnimation, ANIM_8000C)
+    EVT_CALL(PlaySoundAtCollider, 17, 455, 0)
+    EVT_CALL(MakeLerp, 0, 80, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 8, EVT_VAR(0), 0, -1, 0)
+        EVT_CALL(RotateModel, 10, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_THREAD
+        EVT_LOOP(3)
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 0)
+            EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.3))
+            EVT_WAIT_FRAMES(5)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_BLUBBA_THEME, 0, 8)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_9)
+    EVT_CALL(SetNpcPos, NPC_SELF, -210, 0, 180)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -60, 180, 30)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6)
+    EVT_THREAD
+        EVT_CALL(MakeLerp, 80, 0, 10, 0)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(RotateModel, 8, EVT_VAR(0), 0, -1, 0)
+            EVT_CALL(RotateModel, 10, EVT_VAR(0), 0, 1, 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(PlaySoundAtCollider, 17, 456, 0)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 5, MESSAGE_ID(0x0E, 0x00F4))
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_9)
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 0)
+            EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.3))
+            EVT_WAIT_FRAMES(9)
+            EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_20F6, 0)
+            EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(0.15))
+            EVT_WAIT_FRAMES(12)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+            EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(SetNpcSpeed, NPC_SELF, EVT_FIXED(4.0))
+    EVT_CALL(NpcMoveTo, NPC_SELF, 45, 215, 0)
+    EVT_CALL(NpcMoveTo, NPC_SELF, 140, 245, 0)
+    EVT_CALL(NpcMoveTo, NPC_SELF, 615, 245, 0)
+    EVT_CALL(SetSelfVar, 0, 1)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_6)
+    EVT_WAIT_FRAMES(15)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_10, NPC_ANIM_world_tubba_Palette_00_Anim_6, 5, MESSAGE_ID(0x0E, 0x00F5))
+    EVT_WAIT_FRAMES(20)
+    EVT_THREAD
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_14)
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_15)
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_16)
+        EVT_WAIT_FRAMES(5)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(0.7))
+    EVT_CALL(NpcJump0, NPC_SELF, 600, 50, 115, 20)
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.3))
+    EVT_END_THREAD
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_5)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.2), EVT_FIXED(1.25))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.35), EVT_FIXED(1.15), EVT_FIXED(1.25))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.45), EVT_FIXED(1.05), EVT_FIXED(1.25))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.35), EVT_FIXED(1.15), EVT_FIXED(1.25))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.2), EVT_FIXED(1.25))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_THREAD
+        EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(0.5))
+        EVT_CALL(NpcJump0, NPC_SELF, EVT_VAR(3), 30, EVT_VAR(5), 23)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(2)
+    EVT_THREAD
+        EVT_CALL(MakeLerp, 0, 50, 18, 1)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(func_802CDE68, -1, EVT_VAR(0))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, -90, 18, 1)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(SetNpcRotation, NPC_SELF, 0, 0, EVT_VAR(0))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 10, EVT_FIXED(0.4))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(FadeOutMusic, 0, 1000)
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.25), EVT_FIXED(1.25))
+    EVT_CALL(SetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(func_802CDE68, -1, 0)
+    EVT_CALL(SetNpcRotation, NPC_SELF, 0, 0, 0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_2)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_24)
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2038, 0)
+    EVT_WAIT_FRAMES(30)
+    EVT_THREAD
+        EVT_CALL(SetSelfVar, 1, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetSelfVar, 1, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2039, 0)
+            EVT_CALL(RandInt, 10, EVT_VAR(1))
+            EVT_ADD(EVT_VAR(1), 15)
+            EVT_CALL(ShowSleepBubble, 0, 0, 0, 2, 628, 121, 127, EVT_VAR(1), EVT_VAR(0))
+            EVT_WAIT_FRAMES(48)
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2038, 0)
+            EVT_CALL(RandInt, 10, EVT_VAR(1))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_CALL(func_802D8248, EVT_VAR(0), EVT_VAR(1))
+            EVT_WAIT_FRAMES(30)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(2.0))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_SET(EVT_SAVE_VAR(0), -30)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242494) = SCRIPT({
-    SetNpcScale(NPC_SELF, 1.25, 1.25, 1.25);
-    SetNpcPos(NPC_SELF, 600, 50, 115);
-    func_802CDE68(-1, 0);
-    SetNpcRotation(NPC_SELF, 0, 0, 0);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_2);
-    sleep 15;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_24);
-    sleep 30;
-    PlaySoundAtNpc(NPC_SELF, SOUND_2038, 0);
-    sleep 30;
-    spawn {
-        SetSelfVar(1, 0);
-        loop {
-            GetSelfVar(1, EVT_VAR(0));
-            if (EVT_VAR(0) == 1) {
-                break loop;
-            }
-            PlaySoundAtNpc(NPC_SELF, SOUND_2039, 0);
-            RandInt(10, EVT_VAR(1));
-            EVT_VAR(1) += 15;
-            ShowSleepBubble(0, 0, 0, 2, 628, 121, 127, EVT_VAR(1), EVT_VAR(0));
-            sleep 48;
-            PlaySoundAtNpc(NPC_SELF, SOUND_2038, 0);
-            RandInt(10, EVT_VAR(1));
-            EVT_VAR(1) += 10;
-            func_802D8248(EVT_VAR(0), EVT_VAR(1));
-            sleep 30;
-        }
-    }
-});
+EvtSource N(idle_80242494) = {
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.25), EVT_FIXED(1.25))
+    EVT_CALL(SetNpcPos, NPC_SELF, 600, 50, 115)
+    EVT_CALL(func_802CDE68, -1, 0)
+    EVT_CALL(SetNpcRotation, NPC_SELF, 0, 0, 0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_2)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_24)
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2038, 0)
+    EVT_WAIT_FRAMES(30)
+    EVT_THREAD
+        EVT_CALL(SetSelfVar, 1, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetSelfVar, 1, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2039, 0)
+            EVT_CALL(RandInt, 10, EVT_VAR(1))
+            EVT_ADD(EVT_VAR(1), 15)
+            EVT_CALL(ShowSleepBubble, 0, 0, 0, 2, 628, 121, 127, EVT_VAR(1), EVT_VAR(0))
+            EVT_WAIT_FRAMES(48)
+            EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2038, 0)
+            EVT_CALL(RandInt, 10, EVT_VAR(1))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_CALL(func_802D8248, EVT_VAR(0), EVT_VAR(1))
+            EVT_WAIT_FRAMES(30)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_802426B0) = SCRIPT({
-    group 11;
-    PlaySoundAtNpc(NPC_SELF, SOUND_2039, 0);
-    ShowSleepBubble(0, 0, 50, 2, 552, 111, 128, 30, EVT_VAR(0));
-    sleep 360;
-    func_802D8248(EVT_VAR(0), 20);
-    SetNpcVar(-1, 1, 2);
-    sleep 20;
-    PlaySoundAtNpc(NPC_SELF, SOUND_2F1, 0);
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_19);
-    sleep 30;
-    spawn {
-        NpcJump0(NPC_SELF, 650, 0, 250, 25);
-    }
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1A);
-    sleep 10;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1B);
-    sleep 12;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1C);
-    sleep 5;
-    BindNpcAI(NPC_WORLD_TUBBA, N(npcAI_80242834));
-});
+EvtSource N(npcAI_802426B0) = {
+    EVT_SET_GROUP(11)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2039, 0)
+    EVT_CALL(ShowSleepBubble, 0, 0, 50, 2, 552, 111, 128, 30, EVT_VAR(0))
+    EVT_WAIT_FRAMES(360)
+    EVT_CALL(func_802D8248, EVT_VAR(0), 20)
+    EVT_CALL(SetNpcVar, -1, 1, 2)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2F1, 0)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_19)
+    EVT_WAIT_FRAMES(30)
+    EVT_THREAD
+        EVT_CALL(NpcJump0, NPC_SELF, 650, 0, 250, 25)
+    EVT_END_THREAD
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1A)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1B)
+    EVT_WAIT_FRAMES(12)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_tubba_Palette_00_Anim_1C)
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(BindNpcAI, 0, EVT_PTR(N(npcAI_80242834)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_80242834) = SCRIPT({
-    group 11;
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_D);
-    spawn {
-        loop {
-            ShakeCam(0, 0, 5, 2.0);
-            sleep 5;
-            ShakeCam(0, 0, 2, 1.0);
-            sleep 8;
-        }
-    }
-    N(func_80240B94_C56AD4)(N(npcAISettings_80241580));
-});
+EvtSource N(npcAI_80242834) = {
+    EVT_SET_GROUP(11)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_tubba_Palette_00_Anim_D)
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(2.0))
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(ShakeCam, 0, 0, 2, EVT_FIXED(1.0))
+            EVT_WAIT_FRAMES(8)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(N(func_80240B94_C56AD4), EVT_PTR(N(npcAISettings_80241580)))
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(dgb_01_name_hack)[];
 
-EvtSource N(defeat_802428E8) = SCRIPT({
-    N(UnkFunc1)();
-    GotoMap(N(dgb_01_name_hack), 6);
-    sleep 100;
-});
+EvtSource N(defeat_802428E8) = {
+    EVT_CALL(N(UnkFunc1))
+    EVT_CALL(GotoMap, EVT_PTR(N(dgb_01_name_hack)), 6)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(pad_XXX)[] = { 0, 0 };
 
-EvtSource N(init_80242924) = SCRIPT({
-    SetNpcScale(NPC_SELF, 1.25, 1.25, 1.25);
-    BindNpcDefeat(NPC_SELF, N(defeat_802428E8));
-    match EVT_STORY_PROGRESS {
-        < STORY_CH3_TUBBA_BEGAN_NAPPING {
-            BindNpcIdle(NPC_SELF, N(idle_80241654));
-        }
-        < STORY_CH3_TUBBA_WOKE_UP {
-            BindNpcIdle(NPC_SELF, N(idle_80242494));
-        }
-        < STORY_CH3_TUBBA_SMASHED_THE_BRIDGES {
-            SetNpcPos(NPC_SELF, 245, 0, 250);
-            SetNpcYaw(NPC_SELF, 270);
-            BindNpcIdle(NPC_SELF, N(npcAI_80242834));
-        }
-        < STORY_CH3_TUBBA_CHASED_MARIO_IN_FOYER {
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(init_80242924) = {
+    EVT_CALL(SetNpcScale, NPC_SELF, EVT_FIXED(1.25), EVT_FIXED(1.25), EVT_FIXED(1.25))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802428E8)))
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-30)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80241654)))
+        EVT_CASE_LT(-29)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242494)))
+        EVT_CASE_LT(-28)
+            EVT_CALL(SetNpcPos, NPC_SELF, 245, 0, 250)
+            EVT_CALL(SetNpcYaw, NPC_SELF, 270)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_80242834)))
+        EVT_CASE_LT(-26)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242A24) = SCRIPT({
-    loop {
-        GetSelfVar(0, EVT_VAR(0));
-        if (EVT_VAR(0) == 1) {
-            break loop;
-        }
-        sleep 1;
-    }
-    DisablePlayerInput(TRUE);
-    sleep 40;
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), TRUE);
-    SetNpcPos(NPC_SELF, 845, 0, 140);
-    SetNpcJumpscale(NPC_SELF, 0.80078125);
-    NpcJump1(NPC_SELF, 845, 35, 145, 15);
-    PlayerFaceNpc(-1, 0);
-    sleep 15;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 90.0);
-    SetCamDistance(0, 300);
-    SetCamPosB(0, 800, 245);
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    PanToTarget(0, 0, 1);
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 5, MESSAGE_ID(0x0E, 0x00F6));
-    sleep 15;
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 5, MESSAGE_ID(0x0E, 0x00F7));
-    ShowChoice(1966093);
-    if (EVT_VAR(0) == 0) {
-        ContinueSpeech(-1, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E,
-                       0x00F8));
-    } else {
-        ContinueSpeech(-1, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E,
-                       0x00F9));
-    }
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 4.0);
-    UseSettingsFrom(0, 740, EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 600);
-    SetCamPosB(0, 800, 245);
-    SetPanTarget(0, 740, EVT_VAR(1), EVT_VAR(2));
-    WaitForCam(0, 1.0);
-    spawn {
-        EVT_MAP_FLAG(0) = 0;
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 517, MESSAGE_ID(0x0E, 0x00FA));
-        EVT_MAP_FLAG(0) = 1;
-    }
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    loop {
-        SetCamDistance(0, 550.0);
-        SetCamSpeed(0, 90.0);
-        SetPanTarget(0, 740, EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetCamDistance(0, 600.0);
-        SetCamSpeed(0, 90.0);
-        SetPanTarget(0, 740, EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        if (EVT_MAP_FLAG(0) == 1) {
-            break loop;
-        }
-    }
-    SetMusicTrack(0, SONG_TUBBA_ESCAPE, 0, 8);
-    SetNpcVar(0, 1, 1);
-    sleep 15;
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_25);
-    spawn {
-        loop {
-            GetNpcVar(0, 1, EVT_VAR(0));
-            if (EVT_VAR(0) == 2) {
-                break loop;
-            }
-            RandInt(40, EVT_VAR(0));
-            RandInt(40, EVT_VAR(1));
-            EVT_VAR(0) += 537;
-            EVT_VAR(1) += 110;
-            PlayEffect(0x27, 2, EVT_VAR(0), EVT_VAR(1), 128, 0.30078125, 24, 0, 0, 0, 0, 0, 0, 0);
-            sleep 5;
-        }
-    }
-    sleep 15;
-    SetNpcAnimation(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_5);
-    SpeakToPlayer(NPC_WORLD_TUBBA, NPC_ANIM_world_tubba_Palette_00_Anim_13, NPC_ANIM_world_tubba_Palette_00_Anim_5, 5, MESSAGE_ID(0x0E, 0x00FB));
-    sleep 15;
-    DisablePartnerAI(0);
-    GetCurrentPartnerID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 1 {
-            SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_goombario_normal_talk, NPC_ANIM_world_goombario_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FC));
-        }
-        == 2 {
-            SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_kooper_normal_talk, NPC_ANIM_world_kooper_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FD));
-        }
-        == 3 {
-            SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_bombette_normal_idle_fast, NPC_ANIM_world_bombette_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FE));
-        }
-        == 4 {
-            SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_6, NPC_ANIM_world_parakarry_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x00FF));
-        }
-        == 9 {
-            SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_bow_Palette_00_Anim_4, NPC_ANIM_world_bow_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x0100));
-        }
-    }
-    EnablePartnerAI();
-    sleep 15;
-    BindNpcAI(NPC_WORLD_TUBBA, N(npcAI_802426B0));
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 4.0);
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    WaitForCam(0, 1.0);
-    PanToTarget(0, 0, 0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetNpcJumpscale(NPC_SELF, 1.0);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), TRUE);
-    EVT_VAR(1) -= 10;
-    NpcJump0(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-    SetNpcPos(NPC_SELF, 0, -1000, 0);
-    EVT_STORY_PROGRESS = STORY_CH3_TUBBA_WOKE_UP;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(idle_80242A24) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 1)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(40)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcPos, NPC_SELF, 845, 0, 140)
+    EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(0.8))
+    EVT_CALL(NpcJump1, NPC_SELF, 845, 35, 145, 15)
+    EVT_CALL(PlayerFaceNpc, -1, 0)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(SetCamPosB, 0, 800, 245)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 5, MESSAGE_ID(0x0E, 0x00F6))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 5, MESSAGE_ID(0x0E, 0x00F7))
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x000D))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x00F8))
+    EVT_ELSE
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x00F9))
+    EVT_END_IF
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(UseSettingsFrom, 0, 740, EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 600)
+    EVT_CALL(SetCamPosB, 0, 800, 245)
+    EVT_CALL(SetPanTarget, 0, 740, EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_THREAD
+        EVT_SET(EVT_MAP_FLAG(0), 0)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_yakkey_Palette_00_Anim_2, NPC_ANIM_yakkey_Palette_00_Anim_1, 517, MESSAGE_ID(0x0E, 0x00FA))
+        EVT_SET(EVT_MAP_FLAG(0), 1)
+    EVT_END_THREAD
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_LOOP(0)
+        EVT_CALL(SetCamDistance, 0, EVT_FIXED(550.0))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+        EVT_CALL(SetPanTarget, 0, 740, EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetCamDistance, 0, EVT_FIXED(600.0))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+        EVT_CALL(SetPanTarget, 0, 740, EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_MAP_FLAG(0), 1)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(SetMusicTrack, 0, SONG_TUBBA_ESCAPE, 0, 8)
+    EVT_CALL(SetNpcVar, 0, 1, 1)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_tubba_Palette_00_Anim_25)
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(GetNpcVar, 0, 1, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 2)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_CALL(RandInt, 40, EVT_VAR(0))
+            EVT_CALL(RandInt, 40, EVT_VAR(1))
+            EVT_ADD(EVT_VAR(0), 537)
+            EVT_ADD(EVT_VAR(1), 110)
+            EVT_CALL(PlayEffect, 0x27, 2, EVT_VAR(0), EVT_VAR(1), 128, EVT_FIXED(0.3), 24, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(5)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_tubba_Palette_00_Anim_5)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_tubba_Palette_00_Anim_13, NPC_ANIM_world_tubba_Palette_00_Anim_5, 5, MESSAGE_ID(0x0E, 0x00FB))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(1)
+            EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_goombario_normal_talk, NPC_ANIM_world_goombario_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FC))
+        EVT_CASE_EQ(2)
+            EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_kooper_normal_talk, NPC_ANIM_world_kooper_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FD))
+        EVT_CASE_EQ(3)
+            EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_bombette_normal_idle_fast, NPC_ANIM_world_bombette_normal_idle, 0, MESSAGE_ID(0x0E, 0x00FE))
+        EVT_CASE_EQ(4)
+            EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_6, NPC_ANIM_world_parakarry_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x00FF))
+        EVT_CASE_EQ(9)
+            EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_bow_Palette_00_Anim_4, NPC_ANIM_world_bow_Palette_00_Anim_1, 0, MESSAGE_ID(0x0E, 0x0100))
+    EVT_END_SWITCH
+    EVT_CALL(EnablePartnerAI)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(BindNpcAI, 0, EVT_PTR(N(npcAI_802426B0)))
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(1.0))
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), TRUE)
+    EVT_SUB(EVT_VAR(1), 10)
+    EVT_CALL(NpcJump0, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+    EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_SET(EVT_SAVE_VAR(0), -29)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024329C) = SCRIPT({
-    SetSelfVar(0, 0);
-    BindNpcIdle(NPC_SELF, N(idle_80242A24));
-});
+EvtSource N(init_8024329C) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242A24)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_802432D4) = {
     .id = NPC_WORLD_TUBBA,
@@ -641,47 +653,52 @@ static s32 N(pad_36D8)[] = {
 
 s32** N(D_802436E0_C59620) = NULL; // StashVars.inc.c data
 
-EvtSource N(802436E4) = SCRIPT({
-    group 0;
-    SetTimeFreezeMode(2);
-    sleep 40;
-    ShowGotItem(EVT_VAR(0), 0, 0);
-    SetTimeFreezeMode(0);
-    return;
-});
+EvtSource N(802436E4) = {
+    EVT_SET_GROUP(0)
+    EVT_CALL(SetTimeFreezeMode, 2)
+    EVT_WAIT_FRAMES(40)
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 0, 0)
+    EVT_CALL(SetTimeFreezeMode, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024374C) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    EVT_VAR(0) = EVT_VAR(10);
-    if (EVT_VAR(10) != 0) {
-        await N(802436E4);
-    }
-    match EVT_VAR(11) {
-        == 0 {
-            AddItem(EVT_VAR(10), EVT_VAR(0));
-        }
-        == 1 {
-            AddKeyItem(EVT_VAR(10));
-        }
-        == 2 {
-            AddBadge(EVT_VAR(10), EVT_VAR(0));
-        }
-    }
-    sleep 15;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(8024374C) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_EXEC_WAIT(N(802436E4))
+    EVT_END_IF
+    EVT_SWITCH(EVT_VAR(11))
+        EVT_CASE_EQ(0)
+            EVT_CALL(AddItem, EVT_VAR(10), EVT_VAR(0))
+        EVT_CASE_EQ(1)
+            EVT_CALL(AddKeyItem, EVT_VAR(10))
+        EVT_CASE_EQ(2)
+            EVT_CALL(AddBadge, EVT_VAR(10), EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024382C) = SCRIPT({
-    EVT_SAVE_FLAG(1071) = 1;
-    AddKeyItem(ITEM_MYSTICAL_KEY);
-    SetNpcVar(1, 0, 1);
-});
+EvtSource N(8024382C) = {
+    EVT_SET(EVT_SAVE_FLAG(1071), 1)
+    EVT_CALL(AddKeyItem, ITEM_MYSTICAL_KEY)
+    EVT_CALL(SetNpcVar, 1, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EAE30, 845, 0, 145, -35, ITEM_NONE, MAKE_ENTITY_END);
-    AssignFlag(EVT_SAVE_FLAG(1071));
-    AssignScript(N(8024382C));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EAE30, 845, 0, 145, -35, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignFlag, EVT_SAVE_FLAG(1071))
+    EVT_CALL(AssignScript, EVT_PTR(N(8024382C)))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc24.inc.c"
 

--- a/src/world/area_dro/dro_02/9694C0.c
+++ b/src/world/area_dro/dro_02/9694C0.c
@@ -10,6 +10,7 @@
 #include "sprite/npc/moustafa.h"
 #include "sprite/npc/toad.h"
 #include "sprite/npc/world_merlee.h"
+#include "sprite/npc/world_parakarry.h"
 
 #define UNK_ALPHA_FUNC_NPC 10
 
@@ -92,15 +93,19 @@ MapConfig N(config) = {
 
 // Extraneous END_CASE_MULTI
 #ifdef NON_EQUIVALENT
-EvtSource N(80243AF0) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        2, 3 {}
-        else {
-            SetMusicTrack(0, SONG_DRY_DRY_OUTPOST, 0, 8);
-        }
-    }
-});
+EvtSource N(80243AF0) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(3)
+        EVT_END_CASE_GROUP
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_DRY_DRY_OUTPOST, 0, 8)
+        EVT_END_CASE_GROUP
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 #else
 EvtSource N(80243AF0) = {
     EVT_CMD(EVT_OP_CALL, GetEntryID, EVT_VAR(0)),
@@ -117,23 +122,29 @@ EvtSource N(80243AF0) = {
 };
 #endif
 
-EvtSource N(80243B70) = SCRIPT({
-    SetMusicTrack(0, SONG_TAKING_REST, 0, 8);
-});
+EvtSource N(80243B70) = {
+    EVT_CALL(SetMusicTrack, 0, SONG_TAKING_REST, 0, 8)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243B9C) = SCRIPT({
-    SetMusicTrack(0, SONG_MOUSTAFA_THEME, 0, 8);
-});
+EvtSource N(80243B9C) = {
+    EVT_CALL(SetMusicTrack, 0, SONG_MOUSTAFA_THEME, 0, 8)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3BC8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeItemEntity(ITEM_LETTER08, -135, 160, -245, 17, EVT_SAVE_FLAG(757));
-    MakeEntity(0x802EAB04, 180, 173, -200, 0, ITEM_STOREROOM_KEY, MAKE_ENTITY_END);
-    AssignPanelFlag(EVT_SAVE_FLAG(756));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeItemEntity, ITEM_LETTER08, -135, 160, -245, 17, EVT_SAVE_FLAG(757))
+    EVT_CALL(MakeEntity, 0x802EAB04, 180, 173, -200, 0, 32, MAKE_ENTITY_END)
+    EVT_CALL(AssignPanelFlag, EVT_SAVE_FLAG(756))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3C3C) = {
     0x00000000,
@@ -141,275 +152,301 @@ static s32 N(pad_3C3C) = {
 
 EvtSource N(exitWalk_80243C40) = EXIT_WALK_SCRIPT(60,  0, "dro_01",  1);
 
-EvtSource N(80243C9C) = SCRIPT({
-    bind N(exitWalk_80243C40) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80243C9C) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80243C40), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243CC8) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x017C), 160, 40);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80243CC8) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x017C), 160, 40)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243D10) = SCRIPT({
-    PlaySound(0x80000060);
-    UseSettingsFrom(0, 190, 0, -37);
-    SetPanTarget(0, 190, 0, -37);
-    SetCamDistance(0, 200.0);
-    SetCamPitch(0, 13.0, -10.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    N(UnkFunc27)(2, 0, 3);
-    N(UnkFunc27)(1, -1, 3);
-    N(UnkFunc26)(3, 44, 32, 177, 0, 0, 0, 0, 0, 0);
-    DisablePlayerInput(TRUE);
-    spawn {
-        ShakeCam(0, 0, 300, 0.2001953125);
-    }
-    spawn {
-        sleep 60;
-        GetEntryID(EVT_VAR(0));
-        if (EVT_VAR(0) == 2) {
-            GotoMap("sbk_02", 6);
-        } else {
-            GotoMap("sbk_02", 7);
-        }
-        sleep 100;
-    }
-});
+EvtSource N(80243D10) = {
+    EVT_CALL(PlaySound, 0x80000060)
+    EVT_CALL(UseSettingsFrom, 0, 190, 0, -37)
+    EVT_CALL(SetPanTarget, 0, 190, 0, -37)
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(200.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(13.0), EVT_FIXED(-10.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(N(UnkFunc27), 2, 0, 3)
+    EVT_CALL(N(UnkFunc27), 1, -1, 3)
+    EVT_CALL(N(UnkFunc26), 3, 44, 32, 177, 0, 0, 0, 0, 0, 0)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 300, EVT_FIXED(0.2))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(60)
+        EVT_CALL(GetEntryID, EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 2)
+            EVT_CALL(GotoMap, EVT_PTR("sbk_02"), 6)
+        EVT_ELSE
+            EVT_CALL(GotoMap, EVT_PTR("sbk_02"), 7)
+        EVT_END_IF
+        EVT_WAIT_FRAMES(100)
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_DRY_DRY_OUTPOST;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    MakeNpcs(0, N(npcGroupList_8024EEF4));
-    InitVirtualEntityList();
-    await N(makeEntities);
-    await N(80244C78);
-    spawn N(80243AF0);
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        2, 3 {
-            await N(80243D10);
-        } else {
-            EVT_VAR(0) = N(80243C9C);
-            spawn EnterWalk;
-        }
-    }
-    sleep 1;
-    spawn {
-        SetTexPanner(162, 1);
-        EVT_VAR(0) = 0;
-123:
-        EVT_VAR(0) += 420;
-        if (EVT_VAR(0) > 65536) {
-            EVT_VAR(0) += -65536;
-        }
-        SetTexPanOffset(1, 0, 0, EVT_VAR(0));
-        sleep 1;
-        goto 123;
-    }
-    EVT_MAP_FLAG(0) = 0;
-    bind N(80243CC8) TRIGGER_WALL_PRESS_A 56;
-    spawn {
-        loop {
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            if (EVT_VAR(2) < -200) {
-                EnableGroup(163, 1);
-            } else {
-                EnableGroup(163, 0);
-            }
-            sleep 1;
-        }
-    }
-    SetCamSpeed(0, 1.333984375);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 9)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_8024EEF4)))
+    EVT_CALL(InitVirtualEntityList)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC_WAIT(N(80244C78))
+    EVT_EXEC(N(80243AF0))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(3)
+            EVT_EXEC_WAIT(N(80243D10))
+        EVT_END_CASE_GROUP
+        EVT_CASE_DEFAULT
+            EVT_SET(EVT_VAR(0), EVT_PTR(N(80243C9C)))
+            EVT_EXEC(EnterWalk)
+    EVT_END_SWITCH
+    EVT_WAIT_FRAMES(1)
+    EVT_THREAD
+        EVT_CALL(SetTexPanner, 162, 1)
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_LABEL(123)
+        EVT_ADD(EVT_VAR(0), 420)
+        EVT_IF_GT(EVT_VAR(0), 65536)
+            EVT_ADD(EVT_VAR(0), -65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 1, 0, 0, EVT_VAR(0))
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(123)
+    EVT_END_THREAD
+    EVT_SET(EVT_MAP_FLAG(0), 0)
+    EVT_BIND_TRIGGER(N(80243CC8), TRIGGER_WALL_PRESS_A, 56, 1, 0)
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_IF_LT(EVT_VAR(2), -200)
+                EVT_CALL(EnableGroup, 163, 1)
+            EVT_ELSE
+                EVT_CALL(EnableGroup, 163, 0)
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.333984375))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_41B4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(802441C0) = SCRIPT({
-9:
-    MakeLerp(10, -10, 30, 10);
-10:
-    UpdateLerp();
-    RotateModel(48, EVT_VAR(0), 1, 0, 0);
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 10;
-    }
-    MakeLerp(-10, 10, 30, 10);
-11:
-    UpdateLerp();
-    RotateModel(48, EVT_VAR(0), 1, 0, 0);
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 11;
-    }
-    goto 9;
-});
+EvtSource N(802441C0) = {
+    EVT_LABEL(9)
+    EVT_CALL(MakeLerp, 10, -10, 30, 10)
+    EVT_LABEL(10)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, 48, EVT_VAR(0), 1, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_CALL(MakeLerp, -10, 10, 30, 10)
+    EVT_LABEL(11)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, 48, EVT_VAR(0), 1, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(11)
+    EVT_END_IF
+    EVT_GOTO(9)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802442F0) = SCRIPT({
-    EVT_VAR(0) /= 2;
-    EVT_VAR(0) += 18;
-    RotateModel(21, EVT_VAR(0), 0, 1, 0);
-});
+EvtSource N(802442F0) = {
+    EVT_DIV(EVT_VAR(0), 2)
+    EVT_ADD(EVT_VAR(0), 18)
+    EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(openDoor_80244340) = SCRIPT({
-    RotateModel(108, EVT_VAR(0), 0, -1, 0);
-    RotateModel(110, EVT_VAR(0), 0, 1, 0);
-});
+EvtSource N(openDoor_80244340) = {
+    EVT_CALL(RotateModel, 108, EVT_VAR(0), 0, -1, 0)
+    EVT_CALL(RotateModel, 110, EVT_VAR(0), 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(moveWalls_80244390) = SCRIPT({
-    EVT_VAR(1) = EVT_VAR(0);
-    EVT_VAR(1) /= (float) 50;
-    TranslateModel(104, 0, EVT_VAR(1), 0);
-    TranslateModel(105, 0, EVT_VAR(1), 0);
-    TranslateModel(106, 0, EVT_VAR(1), 0);
-    RotateModel(104, EVT_VAR(0), 1, 0, 0);
-    RotateModel(105, EVT_VAR(0), 1, 0, 0);
-    RotateModel(106, EVT_VAR(0), 1, 0, 0);
-});
+EvtSource N(moveWalls_80244390) = {
+    EVT_SET(EVT_VAR(1), EVT_VAR(0))
+    EVT_DIVF(EVT_VAR(1), 50)
+    EVT_CALL(TranslateModel, 104, 0, EVT_VAR(1), 0)
+    EVT_CALL(TranslateModel, 105, 0, EVT_VAR(1), 0)
+    EVT_CALL(TranslateModel, 106, 0, EVT_VAR(1), 0)
+    EVT_CALL(RotateModel, 104, EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, 105, EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, 106, EVT_VAR(0), 1, 0, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(dropDoor_80244474) = SCRIPT({
-    EVT_VAR(1) = EVT_VAR(0);
-    EVT_VAR(1) /= (float) 50;
-    TranslateModel(108, 0, EVT_VAR(1), 0);
-    TranslateModel(110, 0, EVT_VAR(1), 0);
-    RotateModel(108, EVT_VAR(0), 1, 0, 0);
-    RotateModel(110, EVT_VAR(0), 1, 0, 0);
-});
+EvtSource N(dropDoor_80244474) = {
+    EVT_SET(EVT_VAR(1), EVT_VAR(0))
+    EVT_DIVF(EVT_VAR(1), 50)
+    EVT_CALL(TranslateModel, 108, 0, EVT_VAR(1), 0)
+    EVT_CALL(TranslateModel, 110, 0, EVT_VAR(1), 0)
+    EVT_CALL(RotateModel, 108, EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, 110, EVT_VAR(0), 1, 0, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(openDoor_8024451C) = SCRIPT({
-    RotateModel(62, EVT_VAR(0), 0, 1, 0);
-});
+EvtSource N(openDoor_8024451C) = {
+    EVT_CALL(RotateModel, 62, EVT_VAR(0), 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(moveWalls_8024454C) = SCRIPT({
-    EVT_VAR(1) = EVT_VAR(0);
-    EVT_VAR(1) /= (float) 50;
-    RotateGroup(61, EVT_VAR(0), 0, 0, -1);
-});
+EvtSource N(moveWalls_8024454C) = {
+    EVT_SET(EVT_VAR(1), EVT_VAR(0))
+    EVT_DIVF(EVT_VAR(1), 50)
+    EVT_CALL(RotateGroup, 61, EVT_VAR(0), 0, 0, -1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024459C) = SCRIPT({
-    match EVT_VAR(0) {
-        == 0 {
-            SetCamSpeed(0, 3.0);
-        }
-        == 3 {
-            SetCamSpeed(0, 1.333984375);
-        }
-    }
-});
+EvtSource N(8024459C) = {
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.333984375))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(toggleVis_80244600) = SCRIPT({
-    match EVT_VAR(0) {
-        == 0 {
-            SetGroupEnabled(87, 1);
-            SetCamSpeed(0, 3.0);
-        }
-        == 3 {
-            SetGroupEnabled(87, 0);
-            SetCamSpeed(0, 1.333984375);
-        }
-    }
-});
+EvtSource N(toggleVis_80244600) = {
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetGroupEnabled, 87, 1)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetGroupEnabled, 87, 0)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.333984375))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(toggleVis_8024468C) = SCRIPT({
-    match EVT_VAR(0) {
-        == 0 {
-            SetGroupEnabled(132, 1);
-            SetCamType(0, 0, 0);
-            SetCamDistance(0, 260);
-            SetCamPitch(0, 22, -13);
-            SetCamPosA(0, 0, 290);
-            SetCamPosB(0, 0, -290);
-            SetCamPosC(0, 0, 0);
-            SetPanTarget(0, -395, 140, -150);
-            SetCamSpeed(0, 4.0);
-            PanToTarget(0, 0, 1);
-        }
-        == 2 {
-            SetPanTarget(0, -365, 140, -145);
-            SetCamPitch(0, 20, -7);
-            SetCamDistance(0, 400);
-            SetCamSpeed(0, 4.0);
-            WaitForCam(0, 1.0);
-        }
-        == 3 {
-            SetGroupEnabled(132, 0);
-            PanToTarget(0, 0, 0);
-            SetCamSpeed(0, 1.333984375);
-        }
-    }
-});
+EvtSource N(toggleVis_8024468C) = {
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetGroupEnabled, 132, 1)
+            EVT_CALL(SetCamType, 0, 0, 0)
+            EVT_CALL(SetCamDistance, 0, 260)
+            EVT_CALL(SetCamPitch, 0, 22, -13)
+            EVT_CALL(SetCamPosA, 0, 0, 290)
+            EVT_CALL(SetCamPosB, 0, 0, -290)
+            EVT_CALL(SetCamPosC, 0, 0, 0)
+            EVT_CALL(SetPanTarget, 0, -395, 140, -150)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetPanTarget, 0, -365, 140, -145)
+            EVT_CALL(SetCamPitch, 0, 20, -7)
+            EVT_CALL(SetCamDistance, 0, 400)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetGroupEnabled, 132, 0)
+            EVT_CALL(PanToTarget, 0, 0, 0)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.333984375))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024486C) = SCRIPT({
-    group 0;
-    DisablePlayerInput(TRUE);
-    func_802D2C14(1);
-    PlayerMoveTo(230, 10, 20);
-    ModifyColliderFlags(0, 8, 0x7FFFFE00);
-    PlaySoundAtCollider(8, 449, 0);
-    MakeLerp(18, 80, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(21, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    PlayerMoveTo(230, -70, 15);
-    MakeLerp(80, 18, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(21, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    PlaySoundAtCollider(8, 450, 0);
-    ModifyColliderFlags(1, 8, 0x7FFFFE00);
-    func_802D2C14(0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(8024486C) = {
+    EVT_SET_GROUP(0)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(func_802D2C14, 1)
+    EVT_CALL(PlayerMoveTo, 230, 10, 20)
+    EVT_CALL(ModifyColliderFlags, 0, 8, 0x7FFFFE00)
+    EVT_CALL(PlaySoundAtCollider, 8, 449, 0)
+    EVT_CALL(MakeLerp, 18, 80, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(PlayerMoveTo, 230, -70, 15)
+    EVT_CALL(MakeLerp, 80, 18, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(PlaySoundAtCollider, 8, 450, 0)
+    EVT_CALL(ModifyColliderFlags, 1, 8, 0x7FFFFE00)
+    EVT_CALL(func_802D2C14, 0)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244A68) = SCRIPT({
-    group 0;
-    DisablePlayerInput(TRUE);
-    func_802D2C14(1);
-    PlayerMoveTo(230, -70, 20);
-    ModifyColliderFlags(0, 10, 0x7FFFFE00);
-    PlaySoundAtCollider(10, 449, 0);
-    MakeLerp(18, 80, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(21, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    PlayerMoveTo(230, 10, 15);
-    MakeLerp(80, 18, 10, 0);
-    loop {
-        UpdateLerp();
-        RotateModel(21, EVT_VAR(0), 0, 1, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    PlaySoundAtCollider(10, 450, 0);
-    ModifyColliderFlags(1, 10, 0x7FFFFE00);
-    func_802D2C14(0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80244A68) = {
+    EVT_SET_GROUP(0)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(func_802D2C14, 1)
+    EVT_CALL(PlayerMoveTo, 230, -70, 20)
+    EVT_CALL(ModifyColliderFlags, 0, 10, 0x7FFFFE00)
+    EVT_CALL(PlaySoundAtCollider, 10, 449, 0)
+    EVT_CALL(MakeLerp, 18, 80, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(PlayerMoveTo, 230, 10, 15)
+    EVT_CALL(MakeLerp, 80, 18, 10, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 1, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(PlaySoundAtCollider, 10, 450, 0)
+    EVT_CALL(ModifyColliderFlags, 1, 10, 0x7FFFFE00)
+    EVT_CALL(func_802D2C14, 0)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(npcList_80244C64)[] = {
     0x00000002, 0x00000005, 0xFFFFFFFF,
@@ -419,24 +456,26 @@ s32 N(npcList_80244C70)[] = {
     0x00000003, 0xFFFFFFFF,
 };
 
-EvtSource N(80244C78) = SCRIPT({
-    spawn N(802441C0);
-    ParentColliderToModel(8, 21);
-    if (EVT_STORY_PROGRESS >= STORY_CH2_BOUGHT_SECRET_ITEMS) {
-        RotateModel(21, 18, 0, 1, 0);
-        UpdateColliderTransform(8);
-    }
-    MakeDoorAdvanced(4, N(openDoor_80244340), N(moveWalls_80244390), N(dropDoor_80244474), N(toggleVis_8024468C), 15, 16, 133, N(npcList_80244C64));
-    if (EVT_STORY_PROGRESS >= STORY_CH2_BOUGHT_SECRET_ITEMS) {
-        bind N(8024486C) TRIGGER_WALL_PRESS_A 8;
-        bind N(80244A68) TRIGGER_WALL_PRESS_A 10;
-    }
-    MakeDoorAdvanced(4101, N(openDoor_8024451C), N(moveWalls_8024454C), 0, N(toggleVis_80244600), 12, 13, 94, N(npcList_80244C70));
-    EVT_VAR(0) = 3;
-    spawn N(toggleVis_8024468C);
-    spawn N(8024459C);
-    spawn N(toggleVis_80244600);
-});
+EvtSource N(80244C78) = {
+    EVT_EXEC(N(802441C0))
+    EVT_CALL(ParentColliderToModel, 8, 21)
+    EVT_IF_GE(EVT_SAVE_VAR(0), -64)
+        EVT_CALL(RotateModel, 21, 18, 0, 1, 0)
+        EVT_CALL(UpdateColliderTransform, 8)
+    EVT_END_IF
+    EVT_CALL(MakeDoorAdvanced, 4, EVT_PTR(N(openDoor_80244340)), EVT_PTR(N(moveWalls_80244390)), EVT_PTR(N(dropDoor_80244474)), EVT_PTR(N(toggleVis_8024468C)), 15, 16, 133, EVT_PTR(N(npcList_80244C64)))
+    EVT_IF_GE(EVT_SAVE_VAR(0), -64)
+        EVT_BIND_TRIGGER(N(8024486C), TRIGGER_WALL_PRESS_A, 8, 1, 0)
+        EVT_BIND_TRIGGER(N(80244A68), TRIGGER_WALL_PRESS_A, 10, 1, 0)
+    EVT_END_IF
+    EVT_CALL(MakeDoorAdvanced, 4101, EVT_PTR(N(openDoor_8024451C)), EVT_PTR(N(moveWalls_8024454C)), 0, EVT_PTR(N(toggleVis_80244600)), 12, 13, 94, EVT_PTR(N(npcList_80244C70)))
+    EVT_SET(EVT_VAR(0), 3)
+    EVT_EXEC(N(toggleVis_8024468C))
+    EVT_EXEC(N(8024459C))
+    EVT_EXEC(N(toggleVis_80244600))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_4DD4)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -444,15 +483,19 @@ static s32 N(pad_4DD4)[] = {
 
 s32** N(D_80244DE0_96DFA0) = NULL;
 
-EvtSource N(80244DE4) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 0);
-    return;
-});
+EvtSource N(80244DE4) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244E14) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 16);
-    return;
-});
+EvtSource N(80244E14) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 16)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
 u8 N(quizAnswers)[] = {
     0x02, 0x01, 0x01, 0x02, 0x02, 0x00, 0x02, 0x00,
@@ -473,597 +516,635 @@ QuizRequirements N(quizRequirements)[] = {
     {  96, 64 }, {   0, 64 },
 };
 
-EvtSource N(80244ED4) = SCRIPT({
-    N(GetGameStatus75)();
-    if (EVT_VAR(0) <= 1) {
-        GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 300;
-        SetNpcJumpscale(NPC_SELF, 1);
-        SetNpcAnimation(NPC_SELF, 0xAF000C);
-        sleep 40;
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(80244ED4) = {
+    EVT_CALL(N(GetGameStatus75))
+    EVT_IF_LE(EVT_VAR(0), 1)
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 300)
+        EVT_CALL(SetNpcJumpscale, NPC_SELF, 1)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_C)
+        EVT_WAIT_FRAMES(40)
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244F84) = SCRIPT({
-    N(GetCamVfov)(0, EVT_ARRAY(0));
-    N(SetCamVfov)(0, 25);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    GetCamType(0, EVT_VAR(1), EVT_VAR(2));
-    SetCamType(0, EVT_VAR(1), 0);
-    GetCamDistance(0, EVT_VAR(0));
-    if (EVT_VAR(0) > 0) {
-        EVT_VAR(0) = (float) 370;
-    } else {
-        EVT_VAR(0) = (float) -370;
-    }
-    SetCamDistance(0, EVT_VAR(0));
-    GetCamPitch(0, EVT_VAR(0), EVT_VAR(1));
-    EVT_VAR(0) = (float) 13.0;
-    EVT_VAR(1) = (float) -10.0;
-    SetCamPitch(0, EVT_VAR(0), EVT_VAR(1));
-    PanToTarget(0, 0, 1);
-    SetCamLeadPlayer(0, 0);
-});
+EvtSource N(80244F84) = {
+    EVT_CALL(N(GetCamVfov), 0, EVT_ARRAY(0))
+    EVT_CALL(N(SetCamVfov), 0, 25)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(GetCamType, 0, EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamType, 0, EVT_VAR(1), 0)
+    EVT_CALL(GetCamDistance, 0, EVT_VAR(0))
+    EVT_IF_GT(EVT_VAR(0), 0)
+        EVT_SETF(EVT_VAR(0), 370)
+    EVT_ELSE
+        EVT_SETF(EVT_VAR(0), -370)
+    EVT_END_IF
+    EVT_CALL(SetCamDistance, 0, EVT_VAR(0))
+    EVT_CALL(GetCamPitch, 0, EVT_VAR(0), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(13.0))
+    EVT_SETF(EVT_VAR(1), EVT_FIXED(-10.0))
+    EVT_CALL(SetCamPitch, 0, EVT_VAR(0), EVT_VAR(1))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245120) = SCRIPT({
-    GetNpcPos(NPC_CHUCK_QUIZMO, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += 30;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    GetCamDistance(0, EVT_VAR(0));
-    if (EVT_VAR(0) > 0) {
-        EVT_VAR(0) = (float) 17;
-    } else {
-        EVT_VAR(0) = (float) -17;
-    }
-    SetCamDistance(0, EVT_VAR(0));
-    SetCamSpeed(0, 90.0);
-    WaitForCam(0, 1.0);
-    SetCamSpeed(0, 1);
-});
+EvtSource N(80245120) = {
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), 30)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(GetCamDistance, 0, EVT_VAR(0))
+    EVT_IF_GT(EVT_VAR(0), 0)
+        EVT_SETF(EVT_VAR(0), 17)
+    EVT_ELSE
+        EVT_SETF(EVT_VAR(0), -17)
+    EVT_END_IF
+    EVT_CALL(SetCamDistance, 0, EVT_VAR(0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SetCamSpeed, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024521C) = SCRIPT({
-    N(SetCamVfov)(0, EVT_ARRAY(0));
-    PanToTarget(0, 0, 0);
-});
+EvtSource N(8024521C) = {
+    EVT_CALL(N(SetCamVfov), 0, EVT_ARRAY(0))
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245258) = SCRIPT({
-    sleep 20;
-    N(UnkCameraFunc)(EVT_ARRAY(1), EVT_ARRAY(3), 83, EVT_VAR(0), EVT_VAR(1));
-    spawn {
-        EVT_VAR(2) = (float) 0;
-        loop 60 {
-            EVT_VAR(3) = (float) EVT_VAR(0);
-            EVT_VAR(4) = (float) EVT_VAR(1);
-            EVT_VAR(3) *= (float) EVT_VAR(2);
-            EVT_VAR(4) *= (float) EVT_VAR(2);
-            EVT_VAR(3) /= (float) 60;
-            EVT_VAR(4) /= (float) 60;
-            EVT_VAR(3) += (float) EVT_ARRAY(1);
-            EVT_VAR(4) += (float) EVT_ARRAY(3);
-            SetPlayerPos(EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4));
-            EVT_VAR(2) += (float) 1;
-            sleep 1;
-        }
-        EVT_VAR(3) = (float) EVT_VAR(0);
-        EVT_VAR(4) = (float) EVT_VAR(1);
-        EVT_VAR(3) += (float) EVT_ARRAY(1);
-        EVT_VAR(4) += (float) EVT_ARRAY(3);
-        SetPlayerPos(EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4));
-    }
-    N(UnkRotatePlayer)();
-    func_802D2884(EVT_ARRAY(1), EVT_ARRAY(3), 0);
-    SetPlayerAnimation(ANIM_10002);
-});
+EvtSource N(80245258) = {
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(N(UnkCameraFunc), EVT_ARRAY(1), EVT_ARRAY(3), 83, EVT_VAR(0), EVT_VAR(1))
+    EVT_THREAD
+        EVT_SETF(EVT_VAR(2), 0)
+        EVT_LOOP(60)
+            EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+            EVT_SETF(EVT_VAR(4), EVT_VAR(1))
+            EVT_MULF(EVT_VAR(3), EVT_VAR(2))
+            EVT_MULF(EVT_VAR(4), EVT_VAR(2))
+            EVT_DIVF(EVT_VAR(3), 60)
+            EVT_DIVF(EVT_VAR(4), 60)
+            EVT_ADDF(EVT_VAR(3), EVT_ARRAY(1))
+            EVT_ADDF(EVT_VAR(4), EVT_ARRAY(3))
+            EVT_CALL(SetPlayerPos, EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4))
+            EVT_ADDF(EVT_VAR(2), 1)
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+        EVT_SETF(EVT_VAR(4), EVT_VAR(1))
+        EVT_ADDF(EVT_VAR(3), EVT_ARRAY(1))
+        EVT_ADDF(EVT_VAR(4), EVT_ARRAY(3))
+        EVT_CALL(SetPlayerPos, EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4))
+    EVT_END_THREAD
+    EVT_CALL(N(UnkRotatePlayer))
+    EVT_CALL(func_802D2884, EVT_ARRAY(1), EVT_ARRAY(3), 0)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245408) = SCRIPT({
-    GetNpcPos(NPC_PARTNER, EVT_VAR(10), EVT_VAR(11), EVT_VAR(12));
-    N(UnkCameraFunc)(EVT_VAR(10), EVT_VAR(12), 108, EVT_VAR(0), EVT_VAR(1));
-    EVT_VAR(5) = (float) EVT_ARRAY(2);
-    EVT_VAR(5) -= (float) EVT_VAR(11);
-    spawn {
-        N(UnkMovePartner)();
-        EVT_VAR(3) = (float) EVT_VAR(0);
-        EVT_VAR(4) = (float) EVT_VAR(1);
-        EVT_VAR(6) = (float) EVT_VAR(5);
-        EVT_VAR(3) += (float) EVT_VAR(10);
-        EVT_VAR(4) += (float) EVT_VAR(12);
-        EVT_VAR(6) += (float) EVT_VAR(11);
-        SetNpcPos(NPC_PARTNER, EVT_VAR(3), EVT_VAR(6), EVT_VAR(4));
-    }
-    N(UnkRotatePartner)();
-    NpcFacePlayer(NPC_PARTNER, 0);
-    SetNpcAnimation(NPC_PARTNER, 0x106);
-});
+EvtSource N(80245408) = {
+    EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(10), EVT_VAR(11), EVT_VAR(12))
+    EVT_CALL(N(UnkCameraFunc), EVT_VAR(10), EVT_VAR(12), 108, EVT_VAR(0), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(5), EVT_ARRAY(2))
+    EVT_SUBF(EVT_VAR(5), EVT_VAR(11))
+    EVT_THREAD
+        EVT_CALL(N(UnkMovePartner))
+        EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+        EVT_SETF(EVT_VAR(4), EVT_VAR(1))
+        EVT_SETF(EVT_VAR(6), EVT_VAR(5))
+        EVT_ADDF(EVT_VAR(3), EVT_VAR(10))
+        EVT_ADDF(EVT_VAR(4), EVT_VAR(12))
+        EVT_ADDF(EVT_VAR(6), EVT_VAR(11))
+        EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(3), EVT_VAR(6), EVT_VAR(4))
+    EVT_END_THREAD
+    EVT_CALL(N(UnkRotatePartner))
+    EVT_CALL(NpcFacePlayer, NPC_PARTNER, 0)
+    EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245540) = SCRIPT({
-    GetNpcPos(NPC_CHUCK_QUIZMO, EVT_VAR(10), EVT_VAR(11), EVT_VAR(12));
-    N(UnkCameraFunc)(EVT_VAR(10), EVT_VAR(12), -70, EVT_VAR(0), EVT_VAR(1));
-    spawn {
-        EVT_VAR(2) = (float) 0;
-        loop 60 {
-            EVT_VAR(3) = (float) EVT_VAR(0);
-            EVT_VAR(4) = (float) EVT_VAR(1);
-            EVT_VAR(3) *= (float) EVT_VAR(2);
-            EVT_VAR(4) *= (float) EVT_VAR(2);
-            EVT_VAR(3) /= (float) 60;
-            EVT_VAR(4) /= (float) 60;
-            EVT_VAR(3) += (float) EVT_VAR(10);
-            EVT_VAR(4) += (float) EVT_VAR(12);
-            SetNpcPos(NPC_CHUCK_QUIZMO, EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4));
-            EVT_VAR(2) += (float) 1;
-            sleep 1;
-        }
-    }
-    sleep 60;
-    NpcFacePlayer(NPC_CHUCK_QUIZMO, 0);
-    SetNpcAnimation(NPC_CHUCK_QUIZMO, 0xAF0001);
-});
+EvtSource N(80245540) = {
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(10), EVT_VAR(11), EVT_VAR(12))
+    EVT_CALL(N(UnkCameraFunc), EVT_VAR(10), EVT_VAR(12), -70, EVT_VAR(0), EVT_VAR(1))
+    EVT_THREAD
+        EVT_SETF(EVT_VAR(2), 0)
+        EVT_LOOP(60)
+            EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+            EVT_SETF(EVT_VAR(4), EVT_VAR(1))
+            EVT_MULF(EVT_VAR(3), EVT_VAR(2))
+            EVT_MULF(EVT_VAR(4), EVT_VAR(2))
+            EVT_DIVF(EVT_VAR(3), 60)
+            EVT_DIVF(EVT_VAR(4), 60)
+            EVT_ADDF(EVT_VAR(3), EVT_VAR(10))
+            EVT_ADDF(EVT_VAR(4), EVT_VAR(12))
+            EVT_CALL(SetNpcPos, 10, EVT_VAR(3), EVT_ARRAY(2), EVT_VAR(4))
+            EVT_ADDF(EVT_VAR(2), 1)
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(60)
+    EVT_CALL(NpcFacePlayer, 10, 0)
+    EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802456AC) = SCRIPT({
-    spawn N(80245258);
-    spawn N(80245408);
-    await N(80245540);
-});
+EvtSource N(802456AC) = {
+    EVT_EXEC(N(80245258))
+    EVT_EXEC(N(80245408))
+    EVT_EXEC_WAIT(N(80245540))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802456E0) = SCRIPT({
-    loop {
-        SetPlayerAnimation(ANIM_QUESTION);
-        sleep 20;
-    }
-});
+EvtSource N(802456E0) = {
+    EVT_LOOP(0)
+        EVT_CALL(SetPlayerAnimation, ANIM_QUESTION)
+        EVT_WAIT_FRAMES(20)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245720) = SCRIPT({
-    SetPlayerAnimation(ANIM_THROW);
-    sleep 15;
-    SetPlayerAnimation(ANIM_10002);
-});
+EvtSource N(80245720) = {
+    EVT_CALL(SetPlayerAnimation, ANIM_THROW)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024575C) = SCRIPT({
-    loop {
-        SetPlayerAnimation(ANIM_10002);
-        sleep 1;
-        SetPlayerAnimation(ANIM_BEFORE_JUMP);
-        sleep 2;
-        SetPlayerAnimation(ANIM_MIDAIR_STILL);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_MIDAIR);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_10009);
-        sleep 2;
-        sleep 1;
-        SetPlayerAnimation(ANIM_BEFORE_JUMP);
-        sleep 2;
-        SetPlayerAnimation(ANIM_MIDAIR_STILL);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_MIDAIR);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_10009);
-        sleep 2;
-        sleep 1;
-        SetPlayerAnimation(ANIM_BEFORE_JUMP);
-        sleep 2;
-        SetPlayerAnimation(ANIM_MIDAIR_STILL);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_MIDAIR);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += 0;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -2;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        EVT_VAR(1) += -3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        SetPlayerAnimation(ANIM_10009);
-        sleep 2;
-    }
-    SetPlayerAnimation(ANIM_10002);
-    SetPlayerPos(EVT_VAR(0), EVT_ARRAY(2), EVT_VAR(2));
-    sleep 1;
-});
+EvtSource N(8024575C) = {
+    EVT_LOOP(0)
+        EVT_CALL(SetPlayerAnimation, ANIM_10002)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_BEFORE_JUMP)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR_STILL)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_10009)
+        EVT_WAIT_FRAMES(2)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_BEFORE_JUMP)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR_STILL)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_10009)
+        EVT_WAIT_FRAMES(2)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_BEFORE_JUMP)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR_STILL)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), 0)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -2)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADD(EVT_VAR(1), -3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(SetPlayerAnimation, ANIM_10009)
+        EVT_WAIT_FRAMES(2)
+    EVT_END_LOOP
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_ARRAY(2), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802462A4) = SCRIPT({
-    SetPlayerAnimation(ANIM_SHOCK_STILL);
-    loop {
-        sleep 1;
-    }
-});
+EvtSource N(802462A4) = {
+    EVT_CALL(SetPlayerAnimation, ANIM_SHOCK_STILL)
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802462E4) = SCRIPT({
-    spawn {
-        N(UnkCameraFunc)(EVT_ARRAY(1), EVT_ARRAY(3), 25, EVT_VAR(0), EVT_VAR(1));
-        EVT_VAR(2) = (float) EVT_ARRAY(1);
-        EVT_VAR(2) += (float) EVT_VAR(0);
-        EVT_VAR(3) = (float) EVT_ARRAY(3);
-        EVT_VAR(3) += (float) EVT_VAR(1);
-        SetNpcAnimation(NPC_PARTNER, 0x102);
-        NpcMoveTo(NPC_PARTNER, EVT_VAR(2), EVT_VAR(3), 40);
-        SetNpcAnimation(NPC_PARTNER, 0x106);
-    }
-    PlayerMoveTo(EVT_ARRAY(1), EVT_ARRAY(3), 40);
-});
+EvtSource N(802462E4) = {
+    EVT_THREAD
+        EVT_CALL(N(UnkCameraFunc), EVT_ARRAY(1), EVT_ARRAY(3), 25, EVT_VAR(0), EVT_VAR(1))
+        EVT_SETF(EVT_VAR(2), EVT_ARRAY(1))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(0))
+        EVT_SETF(EVT_VAR(3), EVT_ARRAY(3))
+        EVT_ADDF(EVT_VAR(3), EVT_VAR(1))
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x102)
+        EVT_CALL(NpcMoveTo, NPC_PARTNER, EVT_VAR(2), EVT_VAR(3), 40)
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+    EVT_END_THREAD
+    EVT_CALL(PlayerMoveTo, EVT_ARRAY(1), EVT_ARRAY(3), 40)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802463C0) = SCRIPT({
-    EVT_VAR(1) = spawn N(8024575C);
-    sleep 60;
-    kill EVT_VAR(1);
-    loop 5 {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 2;
-    }
-    sleep 20;
-    await N(802462E4);
-});
+EvtSource N(802463C0) = {
+    EVT_EXEC_GET_TID(N(8024575C), EVT_VAR(1))
+    EVT_WAIT_FRAMES(60)
+    EVT_KILL_THREAD(EVT_VAR(1))
+    EVT_LOOP(5)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(2)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(20)
+    EVT_EXEC_WAIT(N(802462E4))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80246470) = SCRIPT({
-    EVT_VAR(1) = spawn N(802462A4);
-    sleep 60;
-    loop 5 {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += -1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 2;
-    }
-    sleep 20;
-    kill EVT_VAR(1);
-    await N(802462E4);
-});
+EvtSource N(80246470) = {
+    EVT_EXEC_GET_TID(N(802462A4), EVT_VAR(1))
+    EVT_WAIT_FRAMES(60)
+    EVT_LOOP(5)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), -1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(2)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(20)
+    EVT_KILL_THREAD(EVT_VAR(1))
+    EVT_EXEC_WAIT(N(802462E4))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80246520) = SCRIPT({
-    if (EVT_SAVE_VAR(352) > 63) {
-        EVT_VAR(0) = 0;
-        return;
-    }
-    GetPlayerPos(EVT_ARRAY(1), EVT_ARRAY(2), EVT_ARRAY(3));
-    NpcFacePlayer(NPC_SELF, 16);
-    if (EVT_SAVE_VAR(352) == 63) {
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000A));
-    } else {
-        if (EVT_SAVE_FLAG(1767) == 1) {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0009));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0008));
-            EVT_SAVE_FLAG(1767) = 1;
-        }
-    }
-    ShowChoice(MESSAGE_ID(0x1E, 0x000D));
-    if (EVT_VAR(0) == 1) {
-        ContinueSpeech(-1, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000C));
-        await N(80244ED4);
-        EVT_VAR(0) = 0;
-        return;
-    }
-    EVT_SAVE_FLAG(1793) = 1;
-    N(Set80151310_1)();
-    N(UnkAlphaFunc)();
-    spawn N(80244F84);
-    DisablePartnerAI(0);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE);
-    SetNpcFlagBits(NPC_CHUCK_QUIZMO, ((NPC_FLAG_GRAVITY)), FALSE);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_100)), TRUE);
-    SetNpcFlagBits(NPC_CHUCK_QUIZMO, ((NPC_FLAG_100)), TRUE);
-    SetNpcAnimation(NPC_PARTNER, 0x106);
-    EVT_VAR(1) = spawn N(802456AC);
-    ContinueSpeech(-1, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000B));
-    PlaySound(0x89);
-    loop {
-        EVT_VAR(0) = does_script_exist EVT_VAR(1);
-        if (EVT_VAR(0) == 0) {
-            break loop;
-        }
-        sleep 1;
-    }
-    N(func_80240A70_969C30)();
-    loop 5 {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 2;
-    }
-    EVT_VAR(0) = 2883584;
-    EVT_VAR(0) += EVT_SAVE_VAR(352);
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6, 0, EVT_VAR(0));
-    SetPlayerAnimation(ANIM_QUESTION);
-    EVT_VAR(0) = 2949120;
-    EVT_VAR(0) += EVT_SAVE_VAR(352);
-    PlaySound(0x8E);
-    ShowChoice(EVT_VAR(0));
-    kill EVT_VAR(1);
-    StopSound(142);
-    spawn N(80245720);
-    sleep 15;
-    PlaySound(0x8D);
-    N(func_80240D70_969F30)(EVT_VAR(0));
-    EVT_ARRAY(4) = 0;
-    N(func_80241364_96A524)();
-    sleep 40;
-    N(func_802409EC_969BAC)();
-    spawn {
-        sleep 110;
-        CloseChoice();
-        EVT_ARRAY(4) = 0;
-    }
-    if (EVT_VAR(0) == 1) {
-        SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_7);
-        EVT_ARRAY(4) = 1;
-        spawn {
-            N(func_80240D3C_969EFC)(1);
-            sleep 6;
-            sleep 6;
-            sleep 6;
-            N(func_80240D3C_969EFC)(2);
-        }
-        spawn {
-            PlaySound(0x21C);
-            sleep 6;
-            PlaySound(0x21C);
-            sleep 6;
-            PlaySound(0x21C);
-            sleep 6;
-            PlaySound(0x21C);
-        }
-        PlaySound(0x8A);
-        N(func_80240E08_969FC8)();
-        spawn {
-            sleep 15;
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 50;
-            N(UnkCameraFunc)(0, 0, 83, EVT_VAR(0), EVT_VAR(2));
-            PlayEffect(0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            PlayEffect(0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) += -3;
-            N(UnkCameraFunc)(0, 0, 58, EVT_VAR(0), EVT_VAR(2));
-            PlayEffect(0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            PlayEffect(0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) += 30;
-            N(UnkCameraFunc)(0, 0, 93, EVT_VAR(0), EVT_VAR(2));
-            PlayEffect(0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            PlayEffect(0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-        }
-        sleep 20;
-        EVT_VAR(1) = spawn N(802463C0);
-        EVT_SAVE_VAR(352) += 1;
-        if (EVT_SAVE_VAR(352) > 63) {
-            ContinueSpeech(-1, -1, -1, 0, MESSAGE_ID(0x08, 0x0010));
-            SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6);
-            loop {
-                EVT_VAR(0) = does_script_exist EVT_VAR(1);
-                if (EVT_VAR(0) == 0) {
-                    break loop;
-                }
-                sleep 1;
-            }
-            SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5);
-            EVT_VAR(0) = 348;
-            EVT_VAR(1) = 3;
-            await N(80244DE4);
-            AddStarPieces(1);
-            N(func_80240D3C_969EFC)(15);
-            N(func_80240DF0_969FB0)();
-            SetMessageValue(EVT_SAVE_VAR(352), 0);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0011));
-        } else {
-            ContinueSpeech(-1, -1, -1, 0, MESSAGE_ID(0x08, 0x000E));
-            SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6);
-            loop {
-                EVT_VAR(0) = does_script_exist EVT_VAR(1);
-                if (EVT_VAR(0) == 0) {
-                    break loop;
-                }
-                sleep 1;
-            }
-            SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5);
-            EVT_VAR(0) = 348;
-            EVT_VAR(1) = 1;
-            await N(80244DE4);
-            AddStarPieces(1);
-            N(func_80240D3C_969EFC)(15);
-            N(func_80240DF0_969FB0)();
-            SetMessageValue(EVT_SAVE_VAR(352), 0);
-            if (EVT_SAVE_VAR(352) == 1) {
-                SetMessageMsg(2148844180, 1);
-            } else {
-                SetMessageMsg(2148844176, 1);
-            }
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000F));
-        }
-        EVT_VAR(0) = 1;
-    } else {
-        SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_9);
-        EVT_ARRAY(4) = 2;
-        PlaySound(0x21D);
-        PlaySound(0x8B);
-        EVT_VAR(1) = spawn N(80246470);
-        GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        PlayEffect(0x2B, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        ContinueSpeech(-1, -1, -1, 0, MESSAGE_ID(0x08, 0x000D));
-        SetNpcAnimation(NPC_CHUCK_QUIZMO, NPC_ANIM_chuck_quizmo_Palette_00_Anim_A);
-        loop {
-            EVT_VAR(0) = does_script_exist EVT_VAR(1);
-            if (EVT_VAR(0) == 0) {
-                break loop;
-            }
-            sleep 1;
-        }
-        EVT_VAR(0) = 0;
-    }
-    N(func_80240D70_969F30)(-1);
-    EnablePartnerAI();
-    spawn {
-        sleep 30;
-        PlaySound(0x8F);
-    }
-    spawn {
-        sleep 45;
-        StopSound(137);
-    }
-    N(func_80240E24_969FE4)();
-    N(func_80240C88_969E48)();
-    await N(80244ED4);
-    spawn N(8024521C);
-    N(UnkFunc29)();
-    N(Set80151310_0)();
-    EVT_SAVE_FLAG(1793) = 0;
-});
+EvtSource N(80246520) = {
+    EVT_IF_GT(EVT_SAVE_VAR(352), 63)
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(GetPlayerPos, EVT_ARRAY(1), EVT_ARRAY(2), EVT_ARRAY(3))
+    EVT_CALL(NpcFacePlayer, NPC_SELF, 16)
+    EVT_IF_EQ(EVT_SAVE_VAR(352), 63)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000A))
+    EVT_ELSE
+        EVT_IF_EQ(EVT_SAVE_FLAG(1767), 1)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0009))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0008))
+            EVT_SET(EVT_SAVE_FLAG(1767), 1)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x000D))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000C))
+        EVT_EXEC_WAIT(N(80244ED4))
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_SAVE_FLAG(1793), 1)
+    EVT_CALL(N(Set80151310_1))
+    EVT_CALL(N(UnkAlphaFunc))
+    EVT_EXEC(N(80244F84))
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE)
+    EVT_CALL(SetNpcFlagBits, 10, ((NPC_FLAG_GRAVITY)), FALSE)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcFlagBits, 10, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+    EVT_EXEC_GET_TID(N(802456AC), EVT_VAR(1))
+    EVT_CALL(ContinueSpeech, -1, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000B))
+    EVT_CALL(PlaySound, 0x89)
+    EVT_LOOP(0)
+        EVT_IS_THREAD_RUNNING(EVT_VAR(1), EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(N(func_80240A70_969C30))
+    EVT_LOOP(5)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(2)
+    EVT_END_LOOP
+    EVT_SET(EVT_VAR(0), 2883584)
+    EVT_ADD(EVT_VAR(0), EVT_SAVE_VAR(352))
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6, 0, EVT_VAR(0))
+    EVT_CALL(SetPlayerAnimation, ANIM_QUESTION)
+    EVT_SET(EVT_VAR(0), 2949120)
+    EVT_ADD(EVT_VAR(0), EVT_SAVE_VAR(352))
+    EVT_CALL(PlaySound, 0x8E)
+    EVT_CALL(ShowChoice, EVT_VAR(0))
+    EVT_KILL_THREAD(EVT_VAR(1))
+    EVT_CALL(StopSound, 142)
+    EVT_EXEC(N(80245720))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(PlaySound, 0x8D)
+    EVT_CALL(N(func_80240D70_969F30), EVT_VAR(0))
+    EVT_SET(EVT_ARRAY(4), 0)
+    EVT_CALL(N(func_80241364_96A524))
+    EVT_WAIT_FRAMES(40)
+    EVT_CALL(N(func_802409EC_969BAC))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(110)
+        EVT_CALL(CloseChoice)
+        EVT_SET(EVT_ARRAY(4), 0)
+    EVT_END_THREAD
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_7)
+        EVT_SET(EVT_ARRAY(4), 1)
+        EVT_THREAD
+            EVT_CALL(N(func_80240D3C_969EFC), 1)
+            EVT_WAIT_FRAMES(6)
+            EVT_WAIT_FRAMES(6)
+            EVT_WAIT_FRAMES(6)
+            EVT_CALL(N(func_80240D3C_969EFC), 2)
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_CALL(PlaySound, 0x21C)
+            EVT_WAIT_FRAMES(6)
+            EVT_CALL(PlaySound, 0x21C)
+            EVT_WAIT_FRAMES(6)
+            EVT_CALL(PlaySound, 0x21C)
+            EVT_WAIT_FRAMES(6)
+            EVT_CALL(PlaySound, 0x21C)
+        EVT_END_THREAD
+        EVT_CALL(PlaySound, 0x8A)
+        EVT_CALL(N(func_80240E08_969FC8))
+        EVT_THREAD
+            EVT_WAIT_FRAMES(15)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 50)
+            EVT_CALL(N(UnkCameraFunc), 0, 0, 83, EVT_VAR(0), EVT_VAR(2))
+            EVT_CALL(PlayEffect, 0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_ADD(EVT_VAR(1), -3)
+            EVT_CALL(N(UnkCameraFunc), 0, 0, 58, EVT_VAR(0), EVT_VAR(2))
+            EVT_CALL(PlayEffect, 0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_ADD(EVT_VAR(1), 30)
+            EVT_CALL(N(UnkCameraFunc), 0, 0, 93, EVT_VAR(0), EVT_VAR(2))
+            EVT_CALL(PlayEffect, 0x7, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x44, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 60, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+        EVT_END_THREAD
+        EVT_WAIT_FRAMES(20)
+        EVT_EXEC_GET_TID(N(802463C0), EVT_VAR(1))
+        EVT_ADD(EVT_SAVE_VAR(352), 1)
+        EVT_IF_GT(EVT_SAVE_VAR(352), 63)
+            EVT_CALL(ContinueSpeech, -1, -1, -1, 0, MESSAGE_ID(0x08, 0x0010))
+            EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6)
+            EVT_LOOP(0)
+                EVT_IS_THREAD_RUNNING(EVT_VAR(1), EVT_VAR(0))
+                EVT_IF_EQ(EVT_VAR(0), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+                EVT_WAIT_FRAMES(1)
+            EVT_END_LOOP
+            EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5)
+            EVT_SET(EVT_VAR(0), 348)
+            EVT_SET(EVT_VAR(1), 3)
+            EVT_EXEC_WAIT(N(80244DE4))
+            EVT_CALL(AddStarPieces, 1)
+            EVT_CALL(N(func_80240D3C_969EFC), 15)
+            EVT_CALL(N(func_80240DF0_969FB0))
+            EVT_CALL(SetMessageValue, EVT_SAVE_VAR(352), 0)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x0011))
+        EVT_ELSE
+            EVT_CALL(ContinueSpeech, -1, -1, -1, 0, MESSAGE_ID(0x08, 0x000E))
+            EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_6)
+            EVT_LOOP(0)
+                EVT_IS_THREAD_RUNNING(EVT_VAR(1), EVT_VAR(0))
+                EVT_IF_EQ(EVT_VAR(0), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+                EVT_WAIT_FRAMES(1)
+            EVT_END_LOOP
+            EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_5)
+            EVT_SET(EVT_VAR(0), 348)
+            EVT_SET(EVT_VAR(1), 1)
+            EVT_EXEC_WAIT(N(80244DE4))
+            EVT_CALL(AddStarPieces, 1)
+            EVT_CALL(N(func_80240D3C_969EFC), 15)
+            EVT_CALL(N(func_80240DF0_969FB0))
+            EVT_CALL(SetMessageValue, EVT_SAVE_VAR(352), 0)
+            EVT_IF_EQ(EVT_SAVE_VAR(352), 1)
+                EVT_CALL(SetMessageMsg, EVT_PTR(MessageSingular), 1)
+            EVT_ELSE
+                EVT_CALL(SetMessageMsg, EVT_PTR(MessagePlural), 1)
+            EVT_END_IF
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_chuck_quizmo_Palette_00_Anim_4, NPC_ANIM_chuck_quizmo_Palette_00_Anim_1, 0, MESSAGE_ID(0x08, 0x000F))
+        EVT_END_IF
+        EVT_SET(EVT_VAR(0), 1)
+    EVT_ELSE
+        EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_9)
+        EVT_SET(EVT_ARRAY(4), 2)
+        EVT_CALL(PlaySound, SOUND_MENU_BADGE_ERROR)
+        EVT_CALL(PlaySound, 0x8B)
+        EVT_EXEC_GET_TID(N(80246470), EVT_VAR(1))
+        EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_CALL(PlayEffect, 0x2B, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        EVT_CALL(ContinueSpeech, -1, -1, -1, 0, MESSAGE_ID(0x08, 0x000D))
+        EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_chuck_quizmo_Palette_00_Anim_A)
+        EVT_LOOP(0)
+            EVT_IS_THREAD_RUNNING(EVT_VAR(1), EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_SET(EVT_VAR(0), 0)
+    EVT_END_IF
+    EVT_CALL(N(func_80240D70_969F30), -1)
+    EVT_CALL(EnablePartnerAI)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(30)
+        EVT_CALL(PlaySound, 0x8F)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(45)
+        EVT_CALL(StopSound, 137)
+    EVT_END_THREAD
+    EVT_CALL(N(func_80240E24_969FE4))
+    EVT_CALL(N(func_80240C88_969E48))
+    EVT_EXEC_WAIT(N(80244ED4))
+    EVT_EXEC(N(8024521C))
+    EVT_CALL(N(UnkFunc29))
+    EVT_CALL(N(Set80151310_0))
+    EVT_SET(EVT_SAVE_FLAG(1793), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80247250) = SCRIPT({
-    N(UnkQuizFunc)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    SetNpcFlagBits(NPC_SELF, ((0x01000000)), FALSE);
-    SetNpcSprite(-1, 0x00AF0001);
-    N(UnkFunc31)();
-});
+EvtSource N(80247250) = {
+    EVT_CALL(N(UnkQuizFunc))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_1000000)), FALSE)
+    EVT_CALL(SetNpcSprite, -1, 0x00AF0001)
+    EVT_CALL(N(UnkFunc31))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802472C4) = SCRIPT({
-    arr_use gPauseMenuTargetPosX;
-    EVT_SAVE_FLAG(1769) = 1;
-    DisablePlayerPhysics(TRUE);
-    SetPlayerFlagBits(4194304, 1);
-    await N(80246520);
-    DisablePlayerPhysics(FALSE);
-    SetPlayerFlagBits(4194304, 0);
-});
+EvtSource N(802472C4) = {
+    EVT_USE_ARRAY(EVT_PTR(gPauseMenuTargetPosX))
+    EVT_SET(EVT_SAVE_FLAG(1769), 1)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetPlayerFlagBits, 4194304, 1)
+    EVT_EXEC_WAIT(N(80246520))
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(SetPlayerFlagBits, 4194304, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80247344) = SCRIPT({
-    N(GetNpcUnsafeOwner2)();
-});
+EvtSource N(80247344) = {
+    EVT_CALL(N(GetNpcUnsafeOwner2))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_80247360) = {
     .moveSpeed = 0.7f,
@@ -1073,9 +1154,11 @@ NpcAISettings N(npcAISettings_80247360) = {
     .unk_2C = 1,
 };
 
-EvtSource N(80247390) = SCRIPT({
-    DoBasicAI(N(npcAISettings_80247360));
-});
+EvtSource N(80247390) = {
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_80247360)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802473B0) = {
     .unk_00 = { 0x00, 0xAF, 0x00, 0x01 },
@@ -1109,9 +1192,11 @@ NpcAISettings N(npcAISettings_80247408) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80247438) = SCRIPT({
-    DoBasicAI(N(npcAISettings_80247408));
-});
+EvtSource N(npcAI_80247438) = {
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_80247408)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80247458) = {
     .height = 35,
@@ -1136,9 +1221,11 @@ NpcAISettings N(npcAISettings_802474B0) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802474E0) = SCRIPT({
-    DoBasicAI(N(npcAISettings_802474B0));
-});
+EvtSource N(npcAI_802474E0) = {
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_802474B0)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80247500) = {
     .height = 26,
@@ -1279,239 +1366,247 @@ Gfx N(D_80247A38_970BF8)[] = {
     gsSPEndDisplayList(),
 };
 
-EvtSource N(init_80247A80) = SCRIPT({
+EvtSource N(init_80247A80) = {
+    EVT_RETURN
+    EVT_END
+};
 
-});
+EvtSource N(npcAI_80247A90) = {
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_80247A90) = SCRIPT({
+EvtSource N(80247AA0) = {
+    EVT_USE_ARRAY(EVT_PTR(N(D_8024EFD0)))
+    EVT_SET(EVT_ARRAY(9), 0)
+    EVT_CALL(GetNpcPos, 4, EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6))
+    EVT_ADD(EVT_ARRAY(4), 60)
+    EVT_ADD(EVT_ARRAY(6), 0)
+    EVT_CALL(PlaySoundAtNpc, 4, 0x201, 0)
+    EVT_THREAD
+        EVT_CALL(MakeLerp, 720, 0, 60, 0)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(SetNpcRotation, 4, 0, EVT_VAR(0), 0)
+            EVT_IF_GT(EVT_VAR(0), 360)
+                EVT_ADD(EVT_VAR(0), -360)
+            EVT_END_IF
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_RANGE(90, 270)
+                    EVT_SET(EVT_VAR(2), 12189697)
+                EVT_CASE_DEFAULT
+                    EVT_SET(EVT_VAR(2), 12189698)
+            EVT_END_SWITCH
+            EVT_CALL(SetNpcAnimation, 4, EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(SetNpcRotation, 4, 0, 0, 0)
+        EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_world_merlee_Palette_00_Anim_A)
+        EVT_WAIT_FRAMES(200)
+        EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_world_merlee_Palette_00_Anim_9)
+        EVT_WAIT_FRAMES(40)
+        EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_world_merlee_Palette_00_Anim_A)
+        EVT_WAIT_FRAMES(75)
+        EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_world_merlee_Palette_00_Anim_B)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(60)
+    EVT_CALL(PlaySoundAtNpc, 4, 0x202, 0)
+    EVT_SET(EVT_VAR(0), EVT_ARRAY(5))
+    EVT_ADD(EVT_VAR(0), 25)
+    EVT_CALL(PlayEffect, 0x4F, 0, EVT_ARRAY(4), EVT_VAR(0), EVT_ARRAY(6), 1, -1, 0, 0, 0, 0, 0, 0, 0)
+    EVT_SET(EVT_ARRAY(8), EVT_VAR(15))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(30)
+        EVT_CALL(func_802D7B10, EVT_ARRAY(8))
+    EVT_END_THREAD
+    EVT_CALL(N(func_802414C0_96A680))
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(InterpPlayerYaw, 0, 0)
+    EVT_CALL(N(func_802416FC_96A8BC))
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_IF_EQ(EVT_ARRAY(9), 2)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(9)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(4)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(4)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(6)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, -1342177251)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_LOOP(0)
+            EVT_IF_GE(EVT_ARRAY(9), 3)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(9)
+        EVT_CALL(N(func_8024303C_96C1FC))
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(N(func_80243068_96C228))
+        EVT_LOOP(0)
+            EVT_IF_GE(EVT_ARRAY(9), 10)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(PlaySound, 0x204)
+        EVT_LOOP(0)
+            EVT_IF_GE(EVT_ARRAY(9), 11)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlaySound, 0x205)
+    EVT_END_THREAD
+    EVT_LOOP(0)
+        EVT_IF_EQ(EVT_ARRAY(9), 13)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(SetPlayerPos, EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6))
+    EVT_CALL(SetPlayerAnimation, ANIM_GOT_ITEM)
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetPlayerPos, EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6))
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(N(func_80241874_96AA34))
+    EVT_THREAD
+        EVT_CALL(N(func_802415CC_96A78C))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-});
+EvtSource N(802481D8) = {
+    EVT_CALL(GetNpcPos, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 200)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(8.0))
+    EVT_CALL(SetCamPitch, 0, 20, -15)
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80247AA0) = SCRIPT({
-    arr_use N(D_8024EFD0);
-    EVT_ARRAY(9) = 0;
-    GetNpcPos(NPC_WORLD_MERLEE, EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6));
-    EVT_ARRAY(4) += 60;
-    EVT_ARRAY(6) += 0;
-    PlaySoundAtNpc(NPC_WORLD_MERLEE, 513, 0);
-    spawn {
-        MakeLerp(720, 0, 60, 0);
-        loop {
-            UpdateLerp();
-            SetNpcRotation(NPC_WORLD_MERLEE, 0, EVT_VAR(0), 0);
-            if (EVT_VAR(0) > 360) {
-                EVT_VAR(0) += -360;
-            }
-            match EVT_VAR(0) {
-                90 ... 270 {
-                    EVT_VAR(2) = 12189697;
-                }
-                else {
-                    EVT_VAR(2) = 12189698;
-                }
-            }
-            SetNpcAnimation(NPC_WORLD_MERLEE, EVT_VAR(2));
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        SetNpcRotation(NPC_WORLD_MERLEE, 0, 0, 0);
-        SetNpcAnimation(NPC_WORLD_MERLEE, NPC_ANIM_world_merlee_Palette_00_Anim_A);
-        sleep 200;
-        SetNpcAnimation(NPC_WORLD_MERLEE, NPC_ANIM_world_merlee_Palette_00_Anim_9);
-        sleep 40;
-        SetNpcAnimation(NPC_WORLD_MERLEE, NPC_ANIM_world_merlee_Palette_00_Anim_A);
-        sleep 75;
-        SetNpcAnimation(NPC_WORLD_MERLEE, NPC_ANIM_world_merlee_Palette_00_Anim_B);
-    }
-    sleep 60;
-    PlaySoundAtNpc(NPC_WORLD_MERLEE, 514, 0);
-    EVT_VAR(0) = EVT_ARRAY(5);
-    EVT_VAR(0) += 25;
-    PlayEffect(0x4F, 0, EVT_ARRAY(4), EVT_VAR(0), EVT_ARRAY(6), 1, -1, 0, 0, 0, 0, 0, 0, 0);
-    EVT_ARRAY(8) = EVT_VAR(15);
-    spawn {
-        sleep 30;
-        func_802D7B10(EVT_ARRAY(8));
-    }
-    N(func_802414C0_96A680)();
-    DisablePlayerPhysics(TRUE);
-    InterpPlayerYaw(0, 0);
-    N(func_802416FC_96A8BC)();
-    spawn {
-        loop {
-            if (EVT_ARRAY(9) == 2) {
-                break loop;
-            }
-            sleep 1;
-        }
-        PlaySound(-1342177251);
-        sleep 10;
-        PlaySound(-1342177251);
-        sleep 9;
-        PlaySound(-1342177251);
-        sleep 4;
-        PlaySound(-1342177251);
-        sleep 4;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-        sleep 2;
-        PlaySound(-1342177251);
-        sleep 2;
-        PlaySound(-1342177251);
-        sleep 2;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-        sleep 2;
-        PlaySound(-1342177251);
-        sleep 6;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-        sleep 3;
-        PlaySound(-1342177251);
-    }
-    spawn {
-        loop {
-            if (EVT_ARRAY(9) >= 3) {
-                break loop;
-            }
-            sleep 1;
-        }
-        sleep 9;
-        N(func_8024303C_96C1FC)();
-        sleep 2;
-        N(func_80243068_96C228)();
-        loop {
-            if (EVT_ARRAY(9) >= 10) {
-                break loop;
-            }
-            sleep 1;
-        }
-        sleep 3;
-        PlaySound(516);
-        loop {
-            if (EVT_ARRAY(9) >= 11) {
-                break loop;
-            }
-            sleep 1;
-        }
-        sleep 15;
-        PlaySound(517);
-    }
-    loop {
-        if (EVT_ARRAY(9) == 13) {
-            break loop;
-        }
-        sleep 1;
-    }
-    SetPlayerPos(EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6));
-    SetPlayerAnimation(ANIM_GOT_ITEM);
-    sleep 1;
-    SetPlayerPos(EVT_ARRAY(4), EVT_ARRAY(5), EVT_ARRAY(6));
-    sleep 1;
-    DisablePlayerPhysics(FALSE);
-    N(func_80241874_96AA34)();
-    spawn {
-        N(func_802415CC_96A78C)();
-    }
-});
+EvtSource N(802482A8) = {
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802481D8) = SCRIPT({
-    GetNpcPos(NPC_WORLD_MERLEE, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 200);
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 8.0);
-    SetCamPitch(0, 20, -15);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-});
-
-EvtSource N(802482A8) = SCRIPT({
-    PanToTarget(0, 0, 0);
-    SetCamSpeed(0, 3.0);
-    WaitForCam(0, 1.0);
-});
-
-EvtSource N(802482F8) = SCRIPT({
-    func_802D2C14(1);
-    await N(802481D8);
-    EVT_VAR(0) = 0;
-    if (EVT_SAVE_VAR(348) == 8) {
-        EVT_VAR(0) += 1;
-    }
-    if (EVT_SAVE_FLAG(536) == 1) {
-        EVT_VAR(0) += 1;
-    }
-    if (EVT_SAVE_FLAG(759) == 0) {
-        EVT_VAR(0) += 1;
-    }
-    if (EVT_VAR(0) == 3) {
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DC));
-        EVT_VAR(0) = 39;
-        EVT_VAR(1) = 1;
-        await N(80244DE4);
-        AddKeyItem(ITEM_CRYSTAL_BALL);
-        EVT_SAVE_FLAG(759) = 1;
-        sleep 20;
-        func_802D2C14(0);
-        await N(802482A8);
-        return;
-    }
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D6));
-    ShowChoice(MESSAGE_ID(0x1E, 0x0011));
-    if (EVT_VAR(0) != 0) {
-        ContinueSpeech(-1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D7));
-        func_802D2C14(0);
-        await N(802482A8);
-        return;
-    }
-    ContinueSpeech(-1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D8));
-    ShowCoinCounter(1);
-    ShowChoice(MESSAGE_ID(0x1E, 0x0018));
-    ShowCoinCounter(0);
-    if (EVT_VAR(0) == 3) {
-        ContinueSpeech(-1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D7));
-        func_802D2C14(0);
-        await N(802482A8);
-        return;
-    }
-    N(func_80241394_96A554)(EVT_VAR(0), EVT_VAR(1));
-    if (EVT_VAR(1) != 0) {
-        ContinueSpeech(-1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D9));
-        func_802D2C14(0);
-        await N(802482A8);
-        return;
-    }
-    ContinueSpeech(-1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DA));
-    SetMusicTrack(0, SONG_MERLEE_SPELL, 0, 8);
-    DisablePartnerAI(0);
-    SetNpcAnimation(NPC_PARTNER, 0x106);
-    EVT_VAR(9) = spawn N(80247AA0);
-    loop {
-        EVT_VAR(1) = does_script_exist EVT_VAR(9);
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-        sleep 1;
-    }
-    sleep 60;
-    SetNpcAnimation(NPC_WORLD_MERLEE, NPC_ANIM_world_merlee_Palette_00_Anim_4);
-    PlayerMoveTo(-100, -370, 8);
-    SpeakToPlayer(NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DB));
-    spawn N(80243AF0);
-    EnablePartnerAI();
-    func_802D2C14(0);
-    await N(802482A8);
-});
+EvtSource N(802482F8) = {
+    EVT_CALL(func_802D2C14, 1)
+    EVT_EXEC_WAIT(N(802481D8))
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_IF_EQ(EVT_SAVE_VAR(348), 8)
+        EVT_ADD(EVT_VAR(0), 1)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(536), 1)
+        EVT_ADD(EVT_VAR(0), 1)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(759), 0)
+        EVT_ADD(EVT_VAR(0), 1)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 3)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DC))
+        EVT_SET(EVT_VAR(0), 39)
+        EVT_SET(EVT_VAR(1), 1)
+        EVT_EXEC_WAIT(N(80244DE4))
+        EVT_CALL(AddKeyItem, ITEM_CRYSTAL_BALL)
+        EVT_SET(EVT_SAVE_FLAG(759), 1)
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(func_802D2C14, 0)
+        EVT_EXEC_WAIT(N(802482A8))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D6))
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0011))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D7))
+        EVT_CALL(func_802D2C14, 0)
+        EVT_EXEC_WAIT(N(802482A8))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(ContinueSpeech, -1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D8))
+    EVT_CALL(ShowCoinCounter, 1)
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0018))
+    EVT_CALL(ShowCoinCounter, 0)
+    EVT_IF_EQ(EVT_VAR(0), 3)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D7))
+        EVT_CALL(func_802D2C14, 0)
+        EVT_EXEC_WAIT(N(802482A8))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(N(func_80241394_96A554), EVT_VAR(0), EVT_VAR(1))
+    EVT_IF_NE(EVT_VAR(1), 0)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00D9))
+        EVT_CALL(func_802D2C14, 0)
+        EVT_EXEC_WAIT(N(802482A8))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(ContinueSpeech, -1, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DA))
+    EVT_CALL(SetMusicTrack, 0, SONG_MERLEE_SPELL, 0, 8)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+    EVT_EXEC_GET_TID(N(80247AA0), EVT_VAR(9))
+    EVT_LOOP(0)
+        EVT_IS_THREAD_RUNNING(EVT_VAR(9), EVT_VAR(1))
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(60)
+    EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_world_merlee_Palette_00_Anim_4)
+    EVT_CALL(PlayerMoveTo, -100, -370, 8)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_world_merlee_Palette_00_Anim_7, NPC_ANIM_world_merlee_Palette_00_Anim_4, 0, MESSAGE_ID(0x0D, 0x00DB))
+    EVT_EXEC(N(80243AF0))
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(func_802D2C14, 0)
+    EVT_EXEC_WAIT(N(802482A8))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80248754) = {
     .height = 32,
@@ -1530,64 +1625,70 @@ s32 N(D_80248784_971944) = {
     0x00000000,
 };
 
-EvtSource N(80248788) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowKeyChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveKeyItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            EVT_VAR(0) |= (const)  0x50000;
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_80243314_96C4D4)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80248788) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowKeyChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveKeyItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_BITWISE_OR_CONST(EVT_VAR(0), 0x50000)
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80243314_96C4D4), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802488CC) = SCRIPT({
-    N(func_8024334C_96C50C)(EVT_VAR(0));
-    bind_padlock N(80248788) 0x10 0 N(D_8024F080);
-    N(func_802432C0_96C480)(EVT_VAR(0));
-});
+EvtSource N(802488CC) = {
+    EVT_CALL(N(func_8024334C_96C50C), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80248788), 0x10, 0, EVT_PTR(N(D_8024F080)), 0, 1)
+    EVT_CALL(N(func_802432C0_96C480), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024891C) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowConsumableChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_80243314_96C4D4)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(8024891C) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80243314_96C4D4), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80248A50) = SCRIPT({
-    N(func_802433E8_96C5A8)(EVT_VAR(0));
-    bind_padlock N(8024891C) 0x10 0 N(D_8024F248);
-    N(func_802432C0_96C480)(EVT_VAR(0));
-});
+EvtSource N(80248A50) = {
+    EVT_CALL(N(func_802433E8_96C5A8), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(8024891C), 0x10, 0, EVT_PTR(N(D_8024F248)), 0, 1)
+    EVT_CALL(N(func_802432C0_96C480), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
 Gfx N(D_8024A3B8_973578)[];
 s32 N(D_80248DD8_971F98)[];
@@ -1970,749 +2071,790 @@ s32 N(image2)[] = {
     0x00010001, 0x00010001, 0x00010001, 0x00010001, 0x00030000,
 };
 
-EvtSource N(8024AC14) = SCRIPT({
-    EnableModel(EVT_VAR(4), 0);
-    EnableModel(EVT_VAR(5), 1);
-    RotateModel(EVT_VAR(6), 0, 0, 0, 1);
-    RotateModel(EVT_VAR(7), 0, 0, 0, 1);
-});
+EvtSource N(8024AC14) = {
+    EVT_CALL(EnableModel, EVT_VAR(4), 0)
+    EVT_CALL(EnableModel, EVT_VAR(5), 1)
+    EVT_CALL(RotateModel, EVT_VAR(6), 0, 0, 0, 1)
+    EVT_CALL(RotateModel, EVT_VAR(7), 0, 0, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024AC8C) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(7);
-    EVT_VAR(8) = EVT_VAR(6);
-    EVT_VAR(7) = EVT_VAR(5);
-    EVT_VAR(6) = EVT_VAR(4);
-    sleep 70;
-    EnableModel(EVT_VAR(6), 0);
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 0, 0, -1);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 0, 0, -1);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(8024AC8C) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(7))
+    EVT_SET(EVT_VAR(8), EVT_VAR(6))
+    EVT_SET(EVT_VAR(7), EVT_VAR(5))
+    EVT_SET(EVT_VAR(6), EVT_VAR(4))
+    EVT_WAIT_FRAMES(70)
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 0, 0, -1)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 0, 0, -1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024ADE4) = SCRIPT({
-    N(UnkFunc35)(0, 0, 0);
-    await N(8024D434);
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    EVT_VAR(9) = EVT_VAR(1);
-    EVT_VAR(10) = EVT_VAR(2);
-    EVT_VAR(11) = EVT_VAR(3);
-    N(DoesPlayerNeedSleep)();
-    if (EVT_VAR(1) == 0) {
-        EVT_VAR(8) = EVT_VAR(0);
-    }
-    SpeakToPlayer(NPC_SELF, 0x830004, 0x830001, 0, EVT_VAR(8));
-    ShowChoice(MESSAGE_ID(0x1E, 0x0006));
-    sleep 3;
-    if (EVT_VAR(0) == 1) {
-        ContinueSpeech(-1, 0x830004, 0x830001, 0, EVT_VAR(9));
-        return;
-    }
-    ContinueSpeech(-1, 0x830004, 0x830001, 0, EVT_VAR(10));
-    SetPlayerJumpscale(1);
-    DisablePlayerPhysics(TRUE);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), TRUE);
-    N(Call800E9894)();
-    if (EVT_VAR(4) != 0) {
-        spawn N(8024AC8C);
-    }
-    N(GetPartnerCall800EB168)(EVT_VAR(10));
-    sleep 20;
-    await N(8024D494);
-    spawn {
-        MakeLerp(0, 255, 60, 0);
-0:
-        UpdateLerp();
-        N(UnkFunc32)(3, EVT_VAR(0));
-        sleep 1;
-        if (EVT_VAR(1) == 1) {
-            goto 0;
-        }
-        FullyRestoreHPandFP();
-        FullyRestoreSP();
-        if (EVT_VAR(4) != 0) {
-            spawn N(8024AC14);
-        }
-        N(Call800EB168)(EVT_VAR(10));
-        sleep 45;
-        MakeLerp(255, 0, 30, 0);
-1:
-        UpdateLerp();
-        N(UnkFunc32)(0, EVT_VAR(0));
-        sleep 1;
-        if (EVT_VAR(1) == 1) {
-            goto 1;
-        }
-    }
-    sleep 105;
-    await N(8024D700);
-    DisablePlayerPhysics(FALSE);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), FALSE);
-    SpeakToPlayer(NPC_SELF, 0x830004, 0x830001, 0, EVT_VAR(11));
-    N(Call800E98C4SyncStatusMenu)();
-});
+EvtSource N(interact_8024ADE4) = {
+    EVT_CALL(N(UnkFunc35), 0, 0, 0)
+    EVT_EXEC_WAIT(N(8024D434))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_SET(EVT_VAR(10), EVT_VAR(2))
+    EVT_SET(EVT_VAR(11), EVT_VAR(3))
+    EVT_CALL(N(DoesPlayerNeedSleep))
+    EVT_IF_EQ(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(8), EVT_VAR(0))
+    EVT_END_IF
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_toad_Palette_00_Anim_4, NPC_ANIM_toad_Palette_00_Anim_1, 0, EVT_VAR(8))
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0006))
+    EVT_WAIT_FRAMES(3)
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(ContinueSpeech, -1, NPC_ANIM_toad_Palette_00_Anim_4, NPC_ANIM_toad_Palette_00_Anim_1, 0, EVT_VAR(9))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(ContinueSpeech, -1, NPC_ANIM_toad_Palette_00_Anim_4, NPC_ANIM_toad_Palette_00_Anim_1, 0, EVT_VAR(10))
+    EVT_CALL(SetPlayerJumpscale, 1)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(N(Call800E9894))
+    EVT_IF_NE(EVT_VAR(4), 0)
+        EVT_EXEC(N(8024AC8C))
+    EVT_END_IF
+    EVT_CALL(N(GetPartnerCall800EB168), EVT_VAR(10))
+    EVT_WAIT_FRAMES(20)
+    EVT_EXEC_WAIT(N(8024D494))
+    EVT_THREAD
+        EVT_CALL(MakeLerp, 0, 255, 60, 0)
+        EVT_LABEL(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(N(UnkFunc32), 3, EVT_VAR(0))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 1)
+            EVT_GOTO(0)
+        EVT_END_IF
+        EVT_CALL(FullyRestoreHPandFP)
+        EVT_CALL(FullyRestoreSP)
+        EVT_IF_NE(EVT_VAR(4), 0)
+            EVT_EXEC(N(8024AC14))
+        EVT_END_IF
+        EVT_CALL(N(Call800EB168), EVT_VAR(10))
+        EVT_WAIT_FRAMES(45)
+        EVT_CALL(MakeLerp, 255, 0, 30, 0)
+        EVT_LABEL(1)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(N(UnkFunc32), 0, EVT_VAR(0))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 1)
+            EVT_GOTO(1)
+        EVT_END_IF
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(105)
+    EVT_EXEC_WAIT(N(8024D700))
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_toad_Palette_00_Anim_4, NPC_ANIM_toad_Palette_00_Anim_1, 0, EVT_VAR(11))
+    EVT_CALL(N(Call800E98C4SyncStatusMenu))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024B18C) = SCRIPT({
-    loop {
-        GetNpcPos(NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-        N(UnkYawFunc)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-        SetItemPos(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-        sleep 1;
-    }
-});
+EvtSource N(8024B18C) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+        EVT_CALL(N(UnkYawFunc), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+        EVT_CALL(SetItemPos, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024B20C) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowKeyChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveKeyItemAt(EVT_VAR(1));
-            DisablePartnerAI(0);
-            GetNpcPos(NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(UnkYawFunc)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            EVT_VAR(0) |= (const)  0x50000;
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            EVT_VAR(10) = spawn N(8024B18C);
-            SetNpcAnimation(NPC_PARTNER, 0x40002);
-            GetAngleBetweenNPCs(EVT_VAR(9), -4, EVT_VAR(11));
-            GetNpcPos(NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            GetNpcPos(EVT_VAR(9), EVT_VAR(6), EVT_VAR(7), EVT_VAR(8));
-            SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-            if (EVT_VAR(11) <= 180) {
-                EVT_VAR(6) += 20;
-            } else {
-                EVT_VAR(6) += -20;
-            }
-            EVT_VAR(7) += 10;
-            SetNpcJumpscale(NPC_PARTNER, 0.0);
-            NpcJump1(NPC_PARTNER, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 20);
-            kill EVT_VAR(10);
-            RemoveItemEntity(EVT_VAR(0));
-            sleep 20;
-            GetNpcYaw(-4, EVT_VAR(10));
-            EVT_VAR(10) += 180;
-            InterpNpcYaw(NPC_PARTNER, EVT_VAR(10), 0);
-            sleep 5;
-            NpcJump1(NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 20);
-            SetNpcAnimation(NPC_PARTNER, 0x40001);
-            NpcFaceNpc(NPC_PARTNER, EVT_VAR(9), 0);
-            sleep 5;
-            SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), FALSE);
-            EnablePartnerAI();
-            sleep 5;
-        }
-    }
-    N(func_80243314_96C4D4)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(8024B20C) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowKeyChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveKeyItemAt, EVT_VAR(1))
+            EVT_CALL(DisablePartnerAI, 0)
+            EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(UnkYawFunc), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_BITWISE_OR_CONST(EVT_VAR(0), 0x50000)
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_EXEC_GET_TID(N(8024B18C), EVT_VAR(10))
+            EVT_CALL(SetNpcAnimation, NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_2)
+            EVT_CALL(GetAngleBetweenNPCs, EVT_VAR(9), -4, EVT_VAR(11))
+            EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(GetNpcPos, EVT_VAR(9), EVT_VAR(6), EVT_VAR(7), EVT_VAR(8))
+            EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+            EVT_IF_LE(EVT_VAR(11), 180)
+                EVT_ADD(EVT_VAR(6), 20)
+            EVT_ELSE
+                EVT_ADD(EVT_VAR(6), -20)
+            EVT_END_IF
+            EVT_ADD(EVT_VAR(7), 10)
+            EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+            EVT_CALL(NpcJump1, NPC_PARTNER, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 20)
+            EVT_KILL_THREAD(EVT_VAR(10))
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(GetNpcYaw, -4, EVT_VAR(10))
+            EVT_ADD(EVT_VAR(10), 180)
+            EVT_CALL(InterpNpcYaw, NPC_PARTNER, EVT_VAR(10), 0)
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(NpcJump1, NPC_PARTNER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 20)
+            EVT_CALL(SetNpcAnimation, NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_1)
+            EVT_CALL(NpcFaceNpc, NPC_PARTNER, EVT_VAR(9), 0)
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), FALSE)
+            EVT_CALL(EnablePartnerAI)
+            EVT_WAIT_FRAMES(5)
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80243314_96C4D4), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024B530) = SCRIPT({
-    EVT_VAR(0) = EVT_VAR(11);
-    EVT_VAR(1) = EVT_VAR(2);
-    N(func_8024334C_96C50C)(EVT_VAR(0));
-    bind_padlock N(8024B20C) 0x10 0 N(D_8024F080);
-    N(func_802432C0_96C480)(EVT_VAR(0));
-});
+EvtSource N(8024B530) = {
+    EVT_SET(EVT_VAR(0), EVT_VAR(11))
+    EVT_SET(EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(func_8024334C_96C50C), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(8024B20C), 0x10, 0, EVT_PTR(N(D_8024F080)), 0, 1)
+    EVT_CALL(N(func_802432C0_96C480), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024B5A0) = SCRIPT({
-    EVT_VAR(12) = 0;
-    if (EVT_STORY_PROGRESS < STORY_CH2_PARAKARRY_JOINED_PARTY) {
-        return;
-    }
-    N(func_802439FC_96CBBC)();
-    GetCurrentPartnerID(EVT_VAR(0));
-    FindKeyItem(EVT_VAR(5), EVT_VAR(1));
-    if (EVT_VAR(0) == 4) {
-        if (EVT_VAR(1) != -1) {
-            DisablePartnerAI(0);
-            PlayerFaceNpc(EVT_VAR(2), 0);
-            sleep 1;
-            GetNpcPos(EVT_VAR(2), EVT_VAR(13), EVT_VAR(0), EVT_VAR(14));
-            GetNpcPos(NPC_PARTNER, EVT_VAR(13), EVT_VAR(14), EVT_VAR(15));
-            SetNpcJumpscale(NPC_PARTNER, 0.0);
-            EVT_VAR(0) += 10;
-            NpcJump1(NPC_PARTNER, EVT_VAR(13), EVT_VAR(0), EVT_VAR(15), 10);
-            SpeakToNpc(-4, 262150, 262145, 0, EVT_VAR(2), EVT_VAR(7));
-            EnablePartnerAI();
-            await N(8024B530);
-            match EVT_VAR(0) {
-                == -1 {
-                    DisablePartnerAI(0);
-                    sleep 1;
-                    SpeakToPlayer(NPC_PARTNER, 0x40006, 0x40001, 5, EVT_VAR(8));
-                    EnablePartnerAI();
-                    EVT_VAR(12) = 1;
-                } else {
-                    DisablePartnerAI(0);
-                    sleep 1;
-                    SpeakToPlayer(NPC_PARTNER, 0x40006, 0x40001, 5, EVT_VAR(9));
-                    if (EVT_VAR(10) != 0) {
-                        SpeakToPlayer(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), 0, EVT_VAR(10));
-                    }
-                    EnablePartnerAI();
-                    if (EVT_VAR(6) != 0) {
-                        EVT_VAR(0) = EVT_VAR(6);
-                        EVT_VAR(1) = 1;
-                        await N(80244DE4);
-                        AddKeyItem(EVT_VAR(6));
-                    }
-                    EVT_VAR(12) = 2;
-                }
-            }
-        }
-    }
-    N(func_80243A40_96CC00)();
-});
+EvtSource N(8024B5A0) = {
+    EVT_SET(EVT_VAR(12), 0)
+    EVT_IF_LT(EVT_SAVE_VAR(0), -70)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(N(func_802439FC_96CBBC))
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_CALL(FindKeyItem, EVT_VAR(5), EVT_VAR(1))
+    EVT_IF_EQ(EVT_VAR(0), 4)
+        EVT_IF_NE(EVT_VAR(1), -1)
+            EVT_CALL(DisablePartnerAI, 0)
+            EVT_CALL(PlayerFaceNpc, EVT_VAR(2), 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_CALL(GetNpcPos, EVT_VAR(2), EVT_VAR(13), EVT_VAR(0), EVT_VAR(14))
+            EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(13), EVT_VAR(14), EVT_VAR(15))
+            EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+            EVT_ADD(EVT_VAR(0), 10)
+            EVT_CALL(NpcJump1, NPC_PARTNER, EVT_VAR(13), EVT_VAR(0), EVT_VAR(15), 10)
+            EVT_CALL(SpeakToNpc, -4, 262150, 262145, 0, EVT_VAR(2), EVT_VAR(7))
+            EVT_CALL(EnablePartnerAI)
+            EVT_EXEC_WAIT(N(8024B530))
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_EQ(-1)
+                    EVT_CALL(DisablePartnerAI, 0)
+                    EVT_WAIT_FRAMES(1)
+                    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_6, NPC_ANIM_world_parakarry_Palette_00_Anim_1, 5, EVT_VAR(8))
+                    EVT_CALL(EnablePartnerAI)
+                    EVT_SET(EVT_VAR(12), 1)
+                EVT_CASE_DEFAULT
+                    EVT_CALL(DisablePartnerAI, 0)
+                    EVT_WAIT_FRAMES(1)
+                    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_parakarry_Palette_00_Anim_6, NPC_ANIM_world_parakarry_Palette_00_Anim_1, 5, EVT_VAR(9))
+                    EVT_IF_NE(EVT_VAR(10), 0)
+                        EVT_CALL(SpeakToPlayer, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4), 0, EVT_VAR(10))
+                    EVT_END_IF
+                    EVT_CALL(EnablePartnerAI)
+                    EVT_IF_NE(EVT_VAR(6), 0)
+                        EVT_SET(EVT_VAR(0), EVT_VAR(6))
+                        EVT_SET(EVT_VAR(1), 1)
+                        EVT_EXEC_WAIT(N(80244DE4))
+                        EVT_CALL(AddKeyItem, EVT_VAR(6))
+                    EVT_END_IF
+                    EVT_SET(EVT_VAR(12), 2)
+            EVT_END_SWITCH
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(func_80243A40_96CC00))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_8024B898_974A58)[] = {
     0x0000004A, 0x00000000,
 };
 
-EvtSource N(8024B8A0) = SCRIPT({
-    N(SetManyVars)(1, 9634308, 9634305, 74, 75, 852117, 852118, 852119, 852120, N(D_8024B898_974A58));
-    await N(8024B5A0);
-});
+EvtSource N(8024B8A0) = {
+    EVT_CALL(N(SetManyVars), 1, 9634308, 9634305, 74, 75, 852117, 852118, 852119, 852120, EVT_PTR(N(D_8024B898_974A58)))
+    EVT_EXEC_WAIT(N(8024B5A0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024B8F0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_STAR_SPRIT_DEPARTED {
-            if (EVT_SAVE_FLAG(787) == 1) {
-                SpeakToPlayer(NPC_SELF, 0xB80004, 0xB80001, 0, MESSAGE_ID(0x0D, 0x00B2));
-            } else {
-                match EVT_AREA_VAR(3) {
-                    == 0 {
-                        SpeakToPlayer(NPC_SELF, 0xB80004, 0xB80001, 0, MESSAGE_ID(0x0D, 0x00AF));
-                        EVT_AREA_VAR(3) = 1;
-                    }
-                    == 1 {
-                        SpeakToPlayer(NPC_SELF, 0xB80004, 0xB80001, 0, MESSAGE_ID(0x0D, 0x00B0));
-                        EVT_AREA_VAR(3) = 2;
-                    }
-                    == 2 {
-                        SpeakToPlayer(NPC_SELF, 0xB80004, 0xB80001, 0, MESSAGE_ID(0x0D, 0x00B1));
-                        EVT_AREA_VAR(3) = 1;
-                    }
-                }
-            }
-        } else {
-            SpeakToPlayer(NPC_SELF, 0xB80004, 0xB80001, 0, MESSAGE_ID(0x0D, 0x00B3));
-        }
-    }
-});
+EvtSource N(interact_8024B8F0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-53)
+            EVT_IF_EQ(EVT_SAVE_FLAG(787), 1)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_archeologist_Palette_00_Anim_4, NPC_ANIM_archeologist_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B2))
+            EVT_ELSE
+                EVT_SWITCH(EVT_AREA_VAR(3))
+                    EVT_CASE_EQ(0)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_archeologist_Palette_00_Anim_4, NPC_ANIM_archeologist_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AF))
+                        EVT_SET(EVT_AREA_VAR(3), 1)
+                    EVT_CASE_EQ(1)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_archeologist_Palette_00_Anim_4, NPC_ANIM_archeologist_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B0))
+                        EVT_SET(EVT_AREA_VAR(3), 2)
+                    EVT_CASE_EQ(2)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_archeologist_Palette_00_Anim_4, NPC_ANIM_archeologist_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B1))
+                        EVT_SET(EVT_AREA_VAR(3), 1)
+                EVT_END_SWITCH
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_archeologist_Palette_00_Anim_4, NPC_ANIM_archeologist_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B3))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024BA50) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024B8F0));
-    if (EVT_STORY_PROGRESS >= STORY_UNUSED_FFFFFFCC) {
-        RemoveNpc(NPC_SELF);
-    }
-});
+EvtSource N(init_8024BA50) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024B8F0)))
+    EVT_IF_GE(EVT_SAVE_VAR(0), -52)
+        EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024BA9C) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_STAR_SPRIT_DEPARTED {
-            if (EVT_SAVE_FLAG(747) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x930204, 0x930201, 0, MESSAGE_ID(0x0D, 0x0091));
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x930204, 0x930201, 0, MESSAGE_ID(0x0D, 0x0092));
-            }
-        }
-        < STORY_CH5_STAR_SPRIT_DEPARTED {
-            SpeakToPlayer(NPC_SELF, 0x930204, 0x930201, 0, MESSAGE_ID(0x0D, 0x0093));
-        } else {
-            SpeakToPlayer(NPC_SELF, 0x930204, 0x930201, 0, MESSAGE_ID(0x0D, 0x0094));
-        }
-    }
-    await N(8024B8A0);
-    if (EVT_VAR(12) != 0) {
-        return;
-    }
-});
+EvtSource N(interact_8024BA9C) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-53)
+            EVT_IF_EQ(EVT_SAVE_FLAG(747), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_02_Anim_4, NPC_ANIM_dryite_Palette_02_Anim_1, 0, MESSAGE_ID(0x0D, 0x0091))
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_02_Anim_4, NPC_ANIM_dryite_Palette_02_Anim_1, 0, MESSAGE_ID(0x0D, 0x0092))
+            EVT_END_IF
+        EVT_CASE_LT(39)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_02_Anim_4, NPC_ANIM_dryite_Palette_02_Anim_1, 0, MESSAGE_ID(0x0D, 0x0093))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_02_Anim_4, NPC_ANIM_dryite_Palette_02_Anim_1, 0, MESSAGE_ID(0x0D, 0x0094))
+    EVT_END_SWITCH
+    EVT_EXEC_WAIT(N(8024B8A0))
+    EVT_IF_NE(EVT_VAR(12), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024BBAC) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024BA9C));
-});
+EvtSource N(init_8024BBAC) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024BA9C)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024BBD0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_STAR_SPRIT_DEPARTED {
-            if (EVT_AREA_FLAG(3) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x930004, 0x930001, 0, MESSAGE_ID(0x0D, 0x00A1));
-                EVT_AREA_FLAG(3) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x930004, 0x930001, 0, MESSAGE_ID(0x0D, 0x00A2));
-                EVT_AREA_FLAG(3) = 0;
-            }
-        }
-        < STORY_CH5_STAR_SPRIT_DEPARTED {
-            SpeakToPlayer(NPC_SELF, 0x930004, 0x930001, 0, MESSAGE_ID(0x0D, 0x00A3));
-        } else {
-            SpeakToPlayer(NPC_SELF, 0x930004, 0x930001, 0, MESSAGE_ID(0x0D, 0x00A4));
-        }
-    }
-});
+EvtSource N(interact_8024BBD0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-53)
+            EVT_IF_EQ(EVT_AREA_FLAG(3), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_00_Anim_4, NPC_ANIM_dryite_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A1))
+                EVT_SET(EVT_AREA_FLAG(3), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_00_Anim_4, NPC_ANIM_dryite_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A2))
+                EVT_SET(EVT_AREA_FLAG(3), 0)
+            EVT_END_IF
+        EVT_CASE_LT(39)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_00_Anim_4, NPC_ANIM_dryite_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A3))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_00_Anim_4, NPC_ANIM_dryite_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A4))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024BCD4) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024BBD0));
-});
+EvtSource N(init_8024BCD4) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024BBD0)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024BCF8) = SCRIPT({
-    SpeakToPlayer(NPC_SELF, 0x930004, 0x930001, 0, MESSAGE_ID(0x0D, 0x00A0));
-});
+EvtSource N(interact_8024BCF8) = {
+    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_dryite_Palette_00_Anim_4, NPC_ANIM_dryite_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024BD28) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024BCF8));
-});
+EvtSource N(init_8024BD28) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024BCF8)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024BD4C) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_STAR_SPRIT_DEPARTED {
-            if (EVT_AREA_FLAG(4) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00A5));
-                EVT_AREA_FLAG(4) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00A6));
-                EVT_AREA_FLAG(4) = 0;
-            }
-        }
-        < STORY_CH5_STAR_SPRIT_DEPARTED {
-            if (EVT_AREA_FLAG(4) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00A7));
-                EVT_AREA_FLAG(4) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00A8));
-                EVT_AREA_FLAG(4) = 0;
-            }
-        } else {
-            if (EVT_AREA_FLAG(4) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00A9));
-                EVT_AREA_FLAG(4) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00AA));
-                EVT_AREA_FLAG(4) = 0;
-            }
-        }
-    }
-});
+EvtSource N(interact_8024BD4C) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-53)
+            EVT_IF_EQ(EVT_AREA_FLAG(4), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A5))
+                EVT_SET(EVT_AREA_FLAG(4), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A6))
+                EVT_SET(EVT_AREA_FLAG(4), 0)
+            EVT_END_IF
+        EVT_CASE_LT(39)
+            EVT_IF_EQ(EVT_AREA_FLAG(4), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A7))
+                EVT_SET(EVT_AREA_FLAG(4), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A8))
+                EVT_SET(EVT_AREA_FLAG(4), 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_IF_EQ(EVT_AREA_FLAG(4), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00A9))
+                EVT_SET(EVT_AREA_FLAG(4), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AA))
+                EVT_SET(EVT_AREA_FLAG(4), 0)
+            EVT_END_IF
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024BF10) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024BD4C));
-});
+EvtSource N(init_8024BF10) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024BD4C)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024BF34) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_STAR_SPRIT_DEPARTED {
-            if (EVT_AREA_FLAG(5) == 0) {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00AB));
-                EVT_AREA_FLAG(5) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00AC));
-                EVT_AREA_FLAG(5) = 0;
-            }
-        }
-        < STORY_CH5_STAR_SPRIT_DEPARTED {
-            SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00AD));
-        } else {
-            SpeakToPlayer(NPC_SELF, 0x940005, 0x940001, 0, MESSAGE_ID(0x0D, 0x00AE));
-        }
-    }
-});
+EvtSource N(interact_8024BF34) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-53)
+            EVT_IF_EQ(EVT_AREA_FLAG(5), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AB))
+                EVT_SET(EVT_AREA_FLAG(5), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AC))
+                EVT_SET(EVT_AREA_FLAG(5), 0)
+            EVT_END_IF
+        EVT_CASE_LT(39)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AD))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_mouser_Palette_00_Anim_5, NPC_ANIM_mouser_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00AE))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024C038) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024BF34));
-});
+EvtSource N(init_8024C038) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024BF34)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024C05C) = SCRIPT({
-    loop {
-        PlayerFaceNpc(5, 0);
-        NpcFaceNpc(NPC_PARTNER, NPC_MOUSTAFA, 0);
-        sleep 1;
-    }
-});
+EvtSource N(8024C05C) = {
+    EVT_LOOP(0)
+        EVT_CALL(PlayerFaceNpc, 5, 0)
+        EVT_CALL(NpcFaceNpc, NPC_PARTNER, 5, 0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024C0B8) = SCRIPT({
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 275);
-    GetNpcPos(NPC_DISGUISED_MOUSTAFA, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    EVT_VAR(0) += EVT_VAR(3);
-    EVT_VAR(1) += EVT_VAR(4);
-    EVT_VAR(2) += EVT_VAR(5);
-    EVT_VAR(0) /= 2;
-    EVT_VAR(1) /= 2;
-    EVT_VAR(2) /= 2;
-    EVT_VAR(1) += 15;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 8.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-});
+EvtSource N(8024C0B8) = {
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 275)
+    EVT_CALL(GetNpcPos, 2, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(4))
+    EVT_ADD(EVT_VAR(2), EVT_VAR(5))
+    EVT_DIV(EVT_VAR(0), 2)
+    EVT_DIV(EVT_VAR(1), 2)
+    EVT_DIV(EVT_VAR(2), 2)
+    EVT_ADD(EVT_VAR(1), 15)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(8.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024C1F8) = SCRIPT({
-    PanToTarget(0, 0, 0);
-    SetCamSpeed(0, 3.0);
-    WaitForCam(0, 1.0);
-});
+EvtSource N(8024C1F8) = {
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024C248) = SCRIPT({
-    SetNpcYaw(NPC_MOUSTAFA, 270);
-    SetNpcFlagBits(NPC_DISGUISED_MOUSTAFA, ((NPC_FLAG_100)), TRUE);
-    SetNpcFlagBits(NPC_MOUSTAFA, ((NPC_FLAG_100)), TRUE);
-    SetNpcAnimation(NPC_DISGUISED_MOUSTAFA, 0xBC0005);
-    sleep 30;
-    SetNpcAnimation(NPC_DISGUISED_MOUSTAFA, 0xBC0006);
-    SetNpcAnimation(NPC_MOUSTAFA, 0xBD0007);
-    SetNpcPos(NPC_MOUSTAFA, -335, 163, -260);
-    spawn N(80243B9C);
-    MakeLerp(0, 80, 30, 5);
-10:
-    UpdateLerp();
-    EVT_VAR(2) = -335;
-    EVT_VAR(3) = 163;
-    EVT_VAR(2) -= EVT_VAR(0);
-    EVT_VAR(3) += EVT_VAR(0);
-    SetNpcPos(NPC_DISGUISED_MOUSTAFA, EVT_VAR(2), EVT_VAR(3), -260);
-    sleep 1;
-    if (EVT_VAR(1) == 1) {
-        goto 10;
-    }
-    SetNpcFlagBits(NPC_DISGUISED_MOUSTAFA, ((NPC_FLAG_100)), FALSE);
-    SetNpcPos(NPC_DISGUISED_MOUSTAFA, 0, -1000, -250);
-    SetNpcAnimation(NPC_MOUSTAFA, 0xBD0001);
-    SetNpcFlagBits(NPC_DISGUISED_MOUSTAFA, ((NPC_FLAG_100)), FALSE);
-    SetNpcFlagBits(NPC_MOUSTAFA, ((NPC_FLAG_100)), FALSE);
-    sleep 30;
-});
+EvtSource N(8024C248) = {
+    EVT_CALL(SetNpcYaw, 5, 270)
+    EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcFlagBits, 5, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_5)
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_6)
+    EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_moustafa_Palette_00_Anim_7)
+    EVT_CALL(SetNpcPos, 5, -335, 163, -260)
+    EVT_EXEC(N(80243B9C))
+    EVT_CALL(MakeLerp, 0, 80, 30, 5)
+    EVT_LABEL(10)
+    EVT_CALL(UpdateLerp)
+    EVT_SET(EVT_VAR(2), -335)
+    EVT_SET(EVT_VAR(3), 163)
+    EVT_SUB(EVT_VAR(2), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(SetNpcPos, 2, EVT_VAR(2), EVT_VAR(3), -260)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(SetNpcPos, 2, 0, -1000, -250)
+    EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_moustafa_Palette_00_Anim_1)
+    EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(SetNpcFlagBits, 5, ((NPC_FLAG_100)), FALSE)
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_8024C450) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_BOUGHT_SECRET_ITEMS {}
-        < STORY_CH2_GOT_PULSE_STONE {
-            SetNpcPos(NPC_SELF, -335, 163, -260);
-        }
-        >= STORY_CH2_GOT_PULSE_STONE {
-            SetNpcPos(NPC_SELF, 0, -1000, -250);
-            SetNpcPos(NPC_MOUSTAFA, -335, 163, -260);
-        }
-    }
-});
+EvtSource N(idle_8024C450) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-64)
+        EVT_CASE_LT(-63)
+            EVT_CALL(SetNpcPos, NPC_SELF, -335, 163, -260)
+        EVT_CASE_GE(-63)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, -250)
+            EVT_CALL(SetNpcPos, 5, -335, 163, -260)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_8024C4EC) = SCRIPT({
-    if (EVT_SAVE_FLAG(750) == 1) {
-        SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CF));
-        return;
-    }
-    match EVT_STORY_PROGRESS {
-        < STORY_CH2_BOUGHT_SECRET_ITEMS {
-            EVT_VAR(11) = 0;
-            SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B4));
-0:
-            ShowChoice(MESSAGE_ID(0x1E, 0x0019));
-            if (EVT_VAR(0) == 1) {
-                ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B6));
-                spawn N(8024C1F8);
-                return;
-            } else {
-                EndSpeech(2, 12320772, 12320769, 0);
-            }
-1:
-            EVT_VAR(0) = 0;
-            EVT_VAR(1) = 2;
-            await N(80248A50);
-            match EVT_VAR(0) {
-                == 0 {
-                    SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B8));
-                    spawn N(8024C1F8);
-                    return;
-                }
-                == -1 {
-                    SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B7));
-                    spawn N(8024C1F8);
-                    return;
-                }
-            }
-            EVT_VAR(10) = EVT_VAR(0);
-            if (EVT_SAVE_VAR(135) == 0) {
-                if (EVT_VAR(10) == 156) {
-                    EVT_SAVE_VAR(135) = 1;
-                    EVT_SAVE_VAR(134) = 10;
-                    SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BB));
-                    ShowChoice(MESSAGE_ID(0x1E, 0x001C));
-                } else {
-                    EVT_SAVE_VAR(134) += 1;
-                    if (EVT_SAVE_VAR(134) <= 2) {
-                        SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B5));
-                        goto 0;
-                    }
-                    if (EVT_SAVE_VAR(134) == 3) {
-                        SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B9));
-                        ShowChoice(MESSAGE_ID(0x1E, 0x001B));
-                    } else {
-                        SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BA));
-                        ShowChoice(MESSAGE_ID(0x1E, 0x001B));
-                        EVT_SAVE_VAR(134) = 10;
-                    }
-                }
-            } else {
-                SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BA));
-                ShowChoice(MESSAGE_ID(0x1E, 0x001C));
-            }
-            match EVT_VAR(0) {
-                == 0 {
-                    ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BC));
-                }
-                == 1 {
-                    await N(8024C0B8);
-                    ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BD));
-                    EVT_SAVE_FLAG(747) = 1;
-                }
-                == 2 {
-                    await N(8024C0B8);
-                    ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BE));
-                    EVT_SAVE_FLAG(748) = 1;
-                }
-                == 3 {
-                    await N(8024C0B8);
-                    ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00BF));
-                }
-                == 4 {
-                    await N(8024C0B8);
-                    ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00C1));
-                    EVT_SAVE_FLAG(749) = 1;
-                    EVT_VAR(11) = 1;
-                }
-            }
-            EVT_SAVE_FLAG(746) = 1;
-            ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00C0));
-            ShowChoice(MESSAGE_ID(0x1E, 0x001A));
-            if (EVT_VAR(0) == 0) {
-                EndSpeech(2, 12320772, 12320769, 0);
-                goto 1;
-            } else {
-                ContinueSpeech(2, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00B6));
-            }
-            if (EVT_VAR(11) == 1) {
-                if (EVT_MAP_FLAG(0) == 0) {
-                    EVT_MAP_FLAG(0) = 1;
-                    spawn {
-                        GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                        AwaitPlayerLeave(EVT_VAR(0), EVT_VAR(2), 50);
-                        DisablePlayerInput(TRUE);
-                        SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00C2));
-                        DisablePlayerInput(FALSE);
-                        EVT_MAP_FLAG(0) = 0;
-                    }
-                }
-            }
-            spawn N(8024C1F8);
-        }
-        < -63 {
-            spawn {
-                sleep 10;
-                func_802D2C14(1);
-            }
-            SetNpcFlagBits(NPC_DISGUISED_MOUSTAFA, ((NPC_FLAG_100)), TRUE);
-            SetPlayerSpeed(3.0);
-            PlayerMoveTo(-391, -260, 0);
-            InterpPlayerYaw(90, 3);
-            SetNpcFlagBits(NPC_DISGUISED_MOUSTAFA, ((NPC_FLAG_100)), FALSE);
-            EVT_VAR(10) = spawn N(8024C05C);
-            SetNpcFlagBits(NPC_MOUSTAFA, ((NPC_FLAG_100)), TRUE);
-            FadeOutMusic(0, 500);
-            if (EVT_SAVE_FLAG(749) == 1) {
-                SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00C3));
-                await N(8024C248);
-                func_802D2C14(0);
-                SetNpcJumpscale(NPC_MOUSTAFA, 1.0);
-                NpcJump0(NPC_MOUSTAFA, -425, 140, -206, 20);
-                SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00C4));
-            } else {
-                SpeakToPlayer(NPC_DISGUISED_MOUSTAFA, 0xBC0004, 0xBC0001, 0, MESSAGE_ID(0x0D, 0x00C5));
-                await N(8024C248);
-                func_802D2C14(0);
-                SetNpcJumpscale(NPC_MOUSTAFA, 1.0);
-                NpcJump0(NPC_MOUSTAFA, -425, 140, -206, 20);
-                SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00C6));
-            }
-            SetNpcJumpscale(NPC_MOUSTAFA, 1.0);
-            NpcJump0(NPC_MOUSTAFA, -337, 140, -200, 20);
-            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00C7));
-            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00C8));
-            SetNpcJumpscale(NPC_MOUSTAFA, 1.0);
-            NpcJump0(NPC_MOUSTAFA, -335, 163, -260, 20);
-            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00C9));
-            EVT_VAR(0) = 18;
-            EVT_VAR(1) = 1;
-            await N(80244DE4);
-            AddKeyItem(ITEM_PULSE_STONE);
-            EVT_STORY_PROGRESS = STORY_CH2_GOT_PULSE_STONE;
-            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CA));
-            kill EVT_VAR(10);
-            spawn N(80243AF0);
-        }
-        >= -63 {
-            match EVT_STORY_PROGRESS {
-                < STORY_CH2_UNCOVERED_DRY_DRY_RUINS {
-                    SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CB));
-                }
-                >= STORY_CH2_UNCOVERED_DRY_DRY_RUINS {
-                    if (EVT_STORY_PROGRESS >= STORY_CH2_DEFEATED_TUTANKOOPA) {
-                        if (EVT_SAVE_FLAG(751) == 0) {
-                            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CD));
-                            SetPlayerAnimation(ANIM_10002);
-                            sleep 15;
-                            SetPlayerAnimation(ANIM_80007);
-                            sleep 30;
-                            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CE));
-                            EVT_SAVE_FLAG(751) = 1;
-                        } else {
-                            SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00D0));
-                        }
-                    } else {
-                        SpeakToPlayer(NPC_MOUSTAFA, 0xBD0005, 0xBD0001, 0, MESSAGE_ID(0x0D, 0x00CC));
-                    }
-                }
-            }
-        }
-    }
-});
+EvtSource N(interact_8024C4EC) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(750), 1)
+        EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CF))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(-64)
+            EVT_SET(EVT_VAR(11), 0)
+            EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B4))
+            EVT_LABEL(0)
+            EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0019))
+            EVT_IF_EQ(EVT_VAR(0), 1)
+                EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B6))
+                EVT_EXEC(N(8024C1F8))
+                EVT_RETURN
+            EVT_ELSE
+                EVT_CALL(EndSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0)
+            EVT_END_IF
+            EVT_LABEL(1)
+            EVT_SET(EVT_VAR(0), 0)
+            EVT_SET(EVT_VAR(1), 2)
+            EVT_EXEC_WAIT(N(80248A50))
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_EQ(0)
+                    EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B8))
+                    EVT_EXEC(N(8024C1F8))
+                    EVT_RETURN
+                EVT_CASE_EQ(-1)
+                    EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B7))
+                    EVT_EXEC(N(8024C1F8))
+                    EVT_RETURN
+            EVT_END_SWITCH
+            EVT_SET(EVT_VAR(10), EVT_VAR(0))
+            EVT_IF_EQ(EVT_SAVE_VAR(135), 0)
+                EVT_IF_EQ(EVT_VAR(10), 156)
+                    EVT_SET(EVT_SAVE_VAR(135), 1)
+                    EVT_SET(EVT_SAVE_VAR(134), 10)
+                    EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BB))
+                    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x001C))
+                EVT_ELSE
+                    EVT_ADD(EVT_SAVE_VAR(134), 1)
+                    EVT_IF_LE(EVT_SAVE_VAR(134), 2)
+                        EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B5))
+                        EVT_GOTO(0)
+                    EVT_END_IF
+                    EVT_IF_EQ(EVT_SAVE_VAR(134), 3)
+                        EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B9))
+                        EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x001B))
+                    EVT_ELSE
+                        EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BA))
+                        EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x001B))
+                        EVT_SET(EVT_SAVE_VAR(134), 10)
+                    EVT_END_IF
+                EVT_END_IF
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BA))
+                EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x001C))
+            EVT_END_IF
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_EQ(0)
+                    EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BC))
+                EVT_CASE_EQ(1)
+                    EVT_EXEC_WAIT(N(8024C0B8))
+                    EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BD))
+                    EVT_SET(EVT_SAVE_FLAG(747), 1)
+                EVT_CASE_EQ(2)
+                    EVT_EXEC_WAIT(N(8024C0B8))
+                    EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BE))
+                    EVT_SET(EVT_SAVE_FLAG(748), 1)
+                EVT_CASE_EQ(3)
+                    EVT_EXEC_WAIT(N(8024C0B8))
+                    EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00BF))
+                EVT_CASE_EQ(4)
+                    EVT_EXEC_WAIT(N(8024C0B8))
+                    EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C1))
+                    EVT_SET(EVT_SAVE_FLAG(749), 1)
+                    EVT_SET(EVT_VAR(11), 1)
+            EVT_END_SWITCH
+            EVT_SET(EVT_SAVE_FLAG(746), 1)
+            EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C0))
+            EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x001A))
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_CALL(EndSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0)
+                EVT_GOTO(1)
+            EVT_ELSE
+                EVT_CALL(ContinueSpeech, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00B6))
+            EVT_END_IF
+            EVT_IF_EQ(EVT_VAR(11), 1)
+                EVT_IF_EQ(EVT_MAP_FLAG(0), 0)
+                    EVT_SET(EVT_MAP_FLAG(0), 1)
+                    EVT_THREAD
+                        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                        EVT_CALL(AwaitPlayerLeave, EVT_VAR(0), EVT_VAR(2), 50)
+                        EVT_CALL(DisablePlayerInput, TRUE)
+                        EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C2))
+                        EVT_CALL(DisablePlayerInput, FALSE)
+                        EVT_SET(EVT_MAP_FLAG(0), 0)
+                    EVT_END_THREAD
+                EVT_END_IF
+            EVT_END_IF
+            EVT_EXEC(N(8024C1F8))
+        EVT_CASE_LT(-63)
+            EVT_THREAD
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(func_802D2C14, 1)
+            EVT_END_THREAD
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(SetPlayerSpeed, EVT_FIXED(3.0))
+            EVT_CALL(PlayerMoveTo, -391, -260, 0)
+            EVT_CALL(InterpPlayerYaw, 90, 3)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), FALSE)
+            EVT_EXEC_GET_TID(N(8024C05C), EVT_VAR(10))
+            EVT_CALL(SetNpcFlagBits, 5, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(FadeOutMusic, 0, 500)
+            EVT_IF_EQ(EVT_SAVE_FLAG(749), 1)
+                EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C3))
+                EVT_EXEC_WAIT(N(8024C248))
+                EVT_CALL(func_802D2C14, 0)
+                EVT_CALL(SetNpcJumpscale, 5, EVT_FIXED(1.0))
+                EVT_CALL(NpcJump0, 5, -425, 140, -206, 20)
+                EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C4))
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_4, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C5))
+                EVT_EXEC_WAIT(N(8024C248))
+                EVT_CALL(func_802D2C14, 0)
+                EVT_CALL(SetNpcJumpscale, 5, EVT_FIXED(1.0))
+                EVT_CALL(NpcJump0, 5, -425, 140, -206, 20)
+                EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C6))
+            EVT_END_IF
+            EVT_CALL(SetNpcJumpscale, 5, EVT_FIXED(1.0))
+            EVT_CALL(NpcJump0, 5, -337, 140, -200, 20)
+            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C7))
+            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C8))
+            EVT_CALL(SetNpcJumpscale, 5, EVT_FIXED(1.0))
+            EVT_CALL(NpcJump0, 5, -335, 163, -260, 20)
+            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00C9))
+            EVT_SET(EVT_VAR(0), 18)
+            EVT_SET(EVT_VAR(1), 1)
+            EVT_EXEC_WAIT(N(80244DE4))
+            EVT_CALL(AddKeyItem, ITEM_PULSE_STONE)
+            EVT_SET(EVT_SAVE_VAR(0), -63)
+            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CA))
+            EVT_KILL_THREAD(EVT_VAR(10))
+            EVT_EXEC(N(80243AF0))
+        EVT_CASE_GE(-63)
+            EVT_SWITCH(EVT_SAVE_VAR(0))
+                EVT_CASE_LT(-62)
+                    EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CB))
+                EVT_CASE_GE(-62)
+                    EVT_IF_GE(EVT_SAVE_VAR(0), -56)
+                        EVT_IF_EQ(EVT_SAVE_FLAG(751), 0)
+                            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CD))
+                            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+                            EVT_WAIT_FRAMES(15)
+                            EVT_CALL(SetPlayerAnimation, ANIM_80007)
+                            EVT_WAIT_FRAMES(30)
+                            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CE))
+                            EVT_SET(EVT_SAVE_FLAG(751), 1)
+                        EVT_ELSE
+                            EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00D0))
+                        EVT_END_IF
+                    EVT_ELSE
+                        EVT_CALL(SpeakToPlayer, 5, NPC_ANIM_moustafa_Palette_00_Anim_5, NPC_ANIM_moustafa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0D, 0x00CC))
+                    EVT_END_IF
+            EVT_END_SWITCH
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024D04C) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        2, 3 {
-            SetNpcPos(NPC_SELF, 200, 0, -15);
-            InterpNpcYaw(NPC_SELF, 270, 0);
-            SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_200000)), TRUE);
-            SetNpcAnimation(NPC_SELF, 0xBC0005);
-        } else {
-            BindNpcIdle(NPC_SELF, N(idle_8024C450));
-            BindNpcInteract(NPC_SELF, N(interact_8024C4EC));
-        }
-    }
-});
+EvtSource N(init_8024D04C) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(3)
+            EVT_CALL(SetNpcPos, NPC_SELF, 200, 0, -15)
+            EVT_CALL(InterpNpcYaw, NPC_SELF, 270, 0)
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_200000)), TRUE)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_disguised_moustafa_Palette_00_Anim_5)
+        EVT_END_CASE_GROUP
+        EVT_CASE_DEFAULT
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_8024C450)))
+            EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024C4EC)))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024D130) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024C4EC));
-});
+EvtSource N(init_8024D130) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024C4EC)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_8024D154) = SCRIPT({
-    InterpNpcYaw(NPC_DISGUISED_MOUSTAFA, 270, 0);
-10:
-    SetNpcAnimation(NPC_SELF, 0x940107);
-    SetNpcAnimation(NPC_DISGUISED_MOUSTAFA, 0xBC0001);
-    loop 50 {
-        IsPlayerWithin(200, 50, 100, EVT_VAR(0));
-        if (EVT_VAR(0) == 1) {
-            goto 20;
-        }
-        sleep 1;
-    }
-    SetNpcAnimation(NPC_SELF, 0x940101);
-    SetNpcAnimation(NPC_DISGUISED_MOUSTAFA, 0xBC0007);
-    loop 50 {
-        IsPlayerWithin(200, 50, 100, EVT_VAR(0));
-        if (EVT_VAR(0) == 1) {
-            goto 20;
-        }
-        sleep 1;
-    }
-    goto 10;
-20:
-    SetNpcAnimation(NPC_DISGUISED_MOUSTAFA, 0xBC0001);
-    SetNpcAnimation(NPC_SELF, 0x940104);
-    SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), TRUE);
-    SetNpcAnimation(NPC_SELF, 0x940104);
-    NpcMoveTo(NPC_SELF, 150, 18, 20);
-    EnableNpcBlur(-1, 1);
-    PlaySoundAtNpc(NPC_SELF, 0x174, 0);
-    NpcMoveTo(NPC_SELF, -83, 11, 20);
-    NpcMoveTo(NPC_SELF, -239, 5, 20);
-    NpcMoveTo(NPC_SELF, -371, 5, 20);
-    NpcMoveTo(NPC_SELF, -487, 5, 20);
-    SetNpcPos(NPC_SELF, 0, -1000, 0);
-    EVT_STORY_PROGRESS = STORY_CH2_SPOKE_WITH_SHEEK;
-});
+EvtSource N(idle_8024D154) = {
+    EVT_CALL(InterpNpcYaw, 2, 270, 0)
+    EVT_LABEL(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_mouser_Palette_01_Anim_7)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1)
+    EVT_LOOP(50)
+        EVT_CALL(IsPlayerWithin, 200, 50, 100, EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 1)
+            EVT_GOTO(20)
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_mouser_Palette_01_Anim_1)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_7)
+    EVT_LOOP(50)
+        EVT_CALL(IsPlayerWithin, 200, 50, 100, EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 1)
+            EVT_GOTO(20)
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_GOTO(10)
+    EVT_LABEL(20)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_disguised_moustafa_Palette_00_Anim_1)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_mouser_Palette_01_Anim_4)
+    EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_mouser_Palette_01_Anim_4)
+    EVT_CALL(NpcMoveTo, NPC_SELF, 150, 18, 20)
+    EVT_CALL(EnableNpcBlur, -1, 1)
+    EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x174, 0)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -83, 11, 20)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -239, 5, 20)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -371, 5, 20)
+    EVT_CALL(NpcMoveTo, NPC_SELF, -487, 5, 20)
+    EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_SET(EVT_SAVE_VAR(0), -66)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024D3E8) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(idle_8024D154));
-    if (EVT_STORY_PROGRESS >= STORY_CH2_SPOKE_WITH_SHEEK) {
-        RemoveNpc(NPC_SELF);
-    }
-});
+EvtSource N(init_8024D3E8) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_8024D154)))
+    EVT_IF_GE(EVT_SAVE_VAR(0), -66)
+        EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024D434) = SCRIPT({
-    EVT_VAR(0) = 852177;
-    EVT_VAR(8) = 852178;
-    EVT_VAR(1) = 852179;
-    EVT_VAR(2) = 852180;
-    EVT_VAR(3) = 852181;
-});
+EvtSource N(8024D434) = {
+    EVT_SET(EVT_VAR(0), 852177)
+    EVT_SET(EVT_VAR(8), 852178)
+    EVT_SET(EVT_VAR(1), 852179)
+    EVT_SET(EVT_VAR(2), 852180)
+    EVT_SET(EVT_VAR(3), 852181)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024D494) = SCRIPT({
-    spawn N(80243B70);
-    SetPlayerSpeed(3.0);
-    PlayerMoveTo(-179, -198, 0);
-    spawn {
-        sleep 15;
-        N(CamSetFOV)(0, 40);
-        SetCamType(0, 4, 0);
-        SetCamPitch(0, 95, -61);
-        SetCamDistance(0, 108);
-        SetCamPosA(0, 202, 62);
-        SetCamPosB(0, -89, -141);
-        SetCamPosC(0, 0, 0);
-        SetCamSpeed(0, 90.0);
-        PanToTarget(0, 0, 1);
-    }
-    PlayerMoveTo(-187, -267, 0);
-    InterpPlayerYaw(230, 1);
-    HidePlayerShadow(TRUE);
-    SetPlayerAnimation(ANIM_10002);
-    func_802D286C(2048);
-    func_802D2520(ANIM_10002, 5, 7, 1, 1, 0);
-    spawn {
-        sleep 60;
-        SetPlayerAnimation(ANIM_8001D);
-    }
-    sleep 20;
-    spawn {
-        sleep 81;
-        N(CamSetFOV)(0, 25);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-        PanToTarget(0, 0, 0);
-    }
-});
+EvtSource N(8024D494) = {
+    EVT_EXEC(N(80243B70))
+    EVT_CALL(SetPlayerSpeed, EVT_FIXED(3.0))
+    EVT_CALL(PlayerMoveTo, -179, -198, 0)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(N(CamSetFOV), 0, 40)
+        EVT_CALL(SetCamType, 0, 4, 0)
+        EVT_CALL(SetCamPitch, 0, 95, -61)
+        EVT_CALL(SetCamDistance, 0, 108)
+        EVT_CALL(SetCamPosA, 0, 202, 62)
+        EVT_CALL(SetCamPosB, 0, -89, -141)
+        EVT_CALL(SetCamPosC, 0, 0, 0)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_END_THREAD
+    EVT_CALL(PlayerMoveTo, -187, -267, 0)
+    EVT_CALL(InterpPlayerYaw, 230, 1)
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_CALL(func_802D286C, 2048)
+    EVT_CALL(func_802D2520, ANIM_10002, 5, 7, 1, 1, 0)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(60)
+        EVT_CALL(SetPlayerAnimation, ANIM_8001D)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(20)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(81)
+        EVT_CALL(N(CamSetFOV), 0, 25)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024D700) = SCRIPT({
-    HidePlayerShadow(FALSE);
-    func_802D2520(ANIM_10002, 0, 0, 0, 0, 0);
-    SetPlayerPos(-187, 0, -240);
-    SetPlayerSpeed(3.0);
-    PlayerMoveTo(-168, -195, 0);
-    spawn N(80243AF0);
-});
+EvtSource N(8024D700) = {
+    EVT_CALL(HidePlayerShadow, FALSE)
+    EVT_CALL(func_802D2520, ANIM_10002, 0, 0, 0, 0, 0)
+    EVT_CALL(SetPlayerPos, -187, 0, -240)
+    EVT_CALL(SetPlayerSpeed, EVT_FIXED(3.0))
+    EVT_CALL(PlayerMoveTo, -168, -195, 0)
+    EVT_EXEC(N(80243AF0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024D790) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_8024ADE4));
-});
+EvtSource N(init_8024D790) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_8024ADE4)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_8024D7B4)[] = {
     {

--- a/src/world/area_flo/flo_03/CA72E0.c
+++ b/src/world/area_flo/flo_03/CA72E0.c
@@ -27,135 +27,145 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_03_tattle },
 };
 
-EvtSource N(802406A0) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 2) {
-        SetMusicTrack(0, SONG_SUNSHINE_RETURNS, 0, 8);
-    } else {
-        match EVT_STORY_PROGRESS {
-            <= STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-                if (EVT_SAVE_FLAG(1411) == 0) {
-                    SetMusicTrack(0, SONG_MONTY_MOLE_ASSAULT, 0, 8);
-                } else {
-                    SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-                }
-            }
-            < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-            } else {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-            }
-        }
-    }
-});
+EvtSource N(802406A0) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 2)
+        EVT_CALL(SetMusicTrack, 0, SONG_SUNSHINE_RETURNS, 0, 8)
+    EVT_ELSE
+        EVT_SWITCH(EVT_SAVE_VAR(0))
+            EVT_CASE_LE(44)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1411), 0)
+                    EVT_CALL(SetMusicTrack, 0, SONG_MONTY_MOLE_ASSAULT, 0, 8)
+                EVT_ELSE
+                    EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+                EVT_END_IF
+            EVT_CASE_LT(53)
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+            EVT_CASE_DEFAULT
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802407C0) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-        if (EVT_SAVE_FLAG(1411) == 1) {
-            PushSong(137, 0);
-        }
-    }
-});
+EvtSource N(802407C0) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 44)
+        EVT_IF_EQ(EVT_SAVE_FLAG(1411), 1)
+            EVT_CALL(PushSong, 137, 0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240814) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-        if (EVT_SAVE_FLAG(1411) == 1) {
-            FadeOutMusic(0, 250);
-            sleep 10;
-            PopSong();
-        }
-    }
-});
+EvtSource N(80240814) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 44)
+        EVT_IF_EQ(EVT_SAVE_FLAG(1411), 1)
+            EVT_CALL(FadeOutMusic, 0, 250)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(PopSong)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240880) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80240880) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80240B2C) = EXIT_WALK_SCRIPT(60,  0, "flo_09",  1);
 
 EvtSource N(exitWalk_80240B88) = EXIT_WALK_SCRIPT(60,  1, "flo_22",  0);
 
-EvtSource N(80240BE4) = SCRIPT({
-    bind N(exitWalk_80240B2C) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80240B88) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80240BE4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240B2C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80240B88), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    EVT_AREA_FLAG(27) = 0;
-    EVT_AREA_FLAG(28) = 0;
-    EVT_AREA_VAR(1) = 0;
-    MakeNpcs(0, N(npcGroupList_8024442C));
-    await N(makeEntities);
-    await N(80241EF4);
-    spawn N(80244E54);
-    spawn N(80244ED0);
-    ModifyColliderFlags(3, 9, 0x00000006);
-    EVT_VAR(0) = -145;
-    EVT_VAR(1) = -335;
-    EVT_VAR(2) = 182;
-    EVT_VAR(3) = -180;
-    EVT_VAR(4) = 0;
-    spawn N(80240880);
-    EVT_VAR(0) = 200;
-    EVT_VAR(1) = -170;
-    EVT_VAR(2) = 310;
-    EVT_VAR(3) = 150;
-    EVT_VAR(4) = 0;
-    spawn N(80240880);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 2) {
-        spawn N(80240FFC);
-    } else {
-        ModifyColliderFlags(0, 1, 0x7FFFFE00);
-        EVT_VAR(0) = N(80240BE4);
-        spawn EnterWalk;
-    }
-    await N(802406A0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CA72A0)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_SET(EVT_AREA_FLAG(27), 0)
+    EVT_SET(EVT_AREA_FLAG(28), 0)
+    EVT_SET(EVT_AREA_VAR(1), 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_8024442C)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC_WAIT(N(80241EF4))
+    EVT_EXEC(N(80244E54))
+    EVT_EXEC(N(80244ED0))
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000006)
+    EVT_SET(EVT_VAR(0), -145)
+    EVT_SET(EVT_VAR(1), -335)
+    EVT_SET(EVT_VAR(2), 182)
+    EVT_SET(EVT_VAR(3), -180)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240880))
+    EVT_SET(EVT_VAR(0), 200)
+    EVT_SET(EVT_VAR(1), -170)
+    EVT_SET(EVT_VAR(2), 310)
+    EVT_SET(EVT_VAR(3), 150)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240880))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 2)
+        EVT_EXEC(N(80240FFC))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(80240BE4)))
+        EVT_EXEC(EnterWalk)
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(802406A0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CA72A0))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_EA4)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -175,15 +185,19 @@ NpcSettings N(npcSettings_80240EDC) = {
 
 s32** N(D_80240F08_CA81A8) = NULL;
 
-EvtSource N(80240F0C) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 0);
-    return;
-});
+EvtSource N(80240F0C) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240F3C) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 16);
-    return;
-});
+EvtSource N(80240F3C) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 16)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(intTable_80240F6C)[] = {
     0xFFFFFF9C, 0x00000000, 0x000000D2, 0xFFFFFF60, 0x00000000, 0x0000011D, 0xFFFFFFDD, 0x00000000,
@@ -205,677 +219,686 @@ s32 N(intTable_80240FD8)[] = {
     0x0000008C,
 };
 
-EvtSource N(80240FFC) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    SetNpcYaw(NPC_PETUNIA, 90);
-    GetNpcPos(NPC_PETUNIA, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 300);
-    SetCamPitch(0, 17.0, -9.5);
-    SetCamPosA(0, -27, 0);
-    SetCamPosB(0, 0, -50);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 20;
-    SpeakToPlayer(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00C8));
-    SetNpcAnimation(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_3);
-    sleep 10;
-    GotoMap("flo_18", 1);
-    sleep 100;
-});
+EvtSource N(80240FFC) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetNpcYaw, 0, 90)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.5))
+    EVT_CALL(SetCamPosA, 0, -27, 0)
+    EVT_CALL(SetCamPosB, 0, 0, -50)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00C8))
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_petunia_Palette_00_Anim_3)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GotoMap, EVT_PTR("flo_18"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_8024119C) = SCRIPT({
-    N(func_80240158_CA73F8)();
-});
+EvtSource N(npcAI_8024119C) = {
+    EVT_CALL(N(func_80240158_CA73F8))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802411B8) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            EVT_SAVE_FLAG(1366) = 1;
-            DoNpcDefeat();
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_802411B8) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_SAVE_FLAG(1366), 1)
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024122C) = SCRIPT({
-    GetPlayerPos(EVT_VAR(3), EVT_VAR(1), EVT_VAR(2));
-    GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += EVT_VAR(3);
-    EVT_VAR(0) /= 2;
-    SetCamProperties(0, EVT_VAR(4), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 300, 20.0, -9.5);
-});
+EvtSource N(8024122C) = {
+    EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(3))
+    EVT_DIV(EVT_VAR(0), 2)
+    EVT_CALL(SetCamProperties, 0, EVT_VAR(4), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 300, EVT_FIXED(20.0), EVT_FIXED(-9.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_802412BC) = SCRIPT({
-    await N(802407C0);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            EVT_MAP_VAR(14) = 1;
-            EVT_VAR(4) = (int) 3.5;
-            await N(8024122C);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0050));
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_6);
-            SetPlayerAnimation(ANIM_NOD_YES);
-            sleep 20;
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0051));
-            SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_12);
-            SetNpcYaw(NPC_MONTY_MOLE0, 270);
-            GetNpcPos(NPC_MONTY_MOLE0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamSpeed(0, 90.0);
-            SetCamPitch(0, 17.0, -8.0);
-            SetCamDistance(0, 200);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            sleep 20;
-            PlaySoundAtNpc(NPC_MONTY_MOLE0, SOUND_MOLE_SURFACE, 0);
-            SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_16);
-            sleep 10;
-            PlaySoundAtNpc(NPC_MONTY_MOLE0, 0x263, 0);
-            ShowEmote(2, EMOTE_QUESTION, -45, 30, 1, 0, 0, 0, 0);
-            GetNpcPos(NPC_MONTY_MOLE1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0052));
-            SetNpcYaw(NPC_MONTY_MOLE1, 90);
-            SetNpcPos(NPC_MONTY_MOLE1, 0, -1000, 0);
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 200);
-            SetCamPitch(0, 17.0, -8.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_0);
-            sleep 20;
-            PlaySoundAtNpc(NPC_MONTY_MOLE1, SOUND_MOLE_SURFACE, 0);
-            SetNpcPos(NPC_MONTY_MOLE1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-            sleep 20;
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0053));
-            SetNpcYaw(NPC_MONTY_MOLE2, 270);
-            GetNpcPos(NPC_MONTY_MOLE2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 200);
-            SetCamPitch(0, 17.0, -8.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            sleep 20;
-            SetNpcAnimation(NPC_MONTY_MOLE2, NPC_ANIM_monty_mole_Palette_01_Anim_14);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0054));
-            SetNpcYaw(NPC_MONTY_MOLE3, 270);
-            GetNpcPos(NPC_MONTY_MOLE3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 200);
-            SetCamPitch(0, 17.0, -9.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_6);
-            sleep 20;
-            SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_7);
-            sleep 20;
-            SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_8);
-            sleep 20;
-            SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_16);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0055));
-            SetNpcPos(NPC_DAYZEE, -233, 0, -217);
-            GetNpcPos(NPC_DAYZEE, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 300);
-            SetCamPitch(0, 17.0, -9.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            SetNpcAnimation(NPC_DAYZEE, NPC_ANIM_dayzee_Palette_00_Anim_D);
-            PlaySoundAtNpc(NPC_DAYZEE, SOUND_262, 0);
-            ShowEmote(1, EMOTE_EXCLAMATION, 45, 30, 1, 0, 0, 0, 0);
-            sleep 15;
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0056));
-            EVT_VAR(4) = (int) 90.0;
-            await N(8024122C);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0057));
-            SetEnemyFlagBits(1, 1, 0);
-            SetEnemyFlagBits(2, 1, 0);
-            SetEnemyFlagBits(3, 1, 0);
-            SetEnemyFlagBits(4, 1, 0);
-            SetEnemyFlagBits(5, 1, 0);
-            BindNpcAI(NPC_DAYZEE, N(npcAI_8024119C));
-            EVT_MAP_VAR(14) = 0;
-            EVT_MAP_VAR(15) = 60;
-            EVT_STORY_PROGRESS = STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES;
-        }
-        == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            if (EVT_SAVE_FLAG(1411) == 0) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0,
-                              MESSAGE_ID(0x11, 0x0058));
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_6);
-            } else {
-                EVT_VAR(4) = (int) 3.5;
-                await N(8024122C);
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_8, NPC_ANIM_petunia_Palette_00_Anim_3, 0,
-                              MESSAGE_ID(0x11, 0x0059));
-                EndSpeech(-1, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0);
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_4);
-                sleep 20;
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_1);
-                EVT_VAR(0) = 88;
-                EVT_VAR(1) = 1;
-                await N(80240F0C);
-                AddKeyItem(ITEM_MAGICAL_BEAN);
-                sleep 20;
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0,
-                              MESSAGE_ID(0x11, 0x005A));
-                EndSpeech(-1, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0);
-                EVT_STORY_PROGRESS = STORY_CH6_GOT_MAGICAL_BEAN;
-            }
-        }
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005B));
-        }
-        < STORY_CH6_RETURNED_TO_TOAD_TOWN {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005C));
-        } else {
-            if (EVT_AREA_VAR(1) == 0) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0,
-                              MESSAGE_ID(0x11, 0x005D));
-                EVT_AREA_VAR(1) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0,
-                              MESSAGE_ID(0x11, 0x005E));
-            }
-        }
-    }
-    ResetCam(0, 8.0);
-    await N(80240814);
-});
+EvtSource N(interact_802412BC) = {
+    EVT_EXEC_WAIT(N(802407C0))
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_SET(EVT_MAP_VAR(14), 1)
+            EVT_SET(EVT_VAR(4), EVT_FIXED(3.5))
+            EVT_EXEC_WAIT(N(8024122C))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0050))
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_6)
+            EVT_CALL(SetPlayerAnimation, ANIM_NOD_YES)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0051))
+            EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_12)
+            EVT_CALL(SetNpcYaw, 2, 270)
+            EVT_CALL(GetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-8.0))
+            EVT_CALL(SetCamDistance, 0, 200)
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(PlaySoundAtNpc, 2, SOUND_MOLE_SURFACE, 0)
+            EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_16)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(PlaySoundAtNpc, 2, 0x263, 0)
+            EVT_CALL(ShowEmote, 2, EMOTE_QUESTION, -45, 30, 1, 0, 0, 0, 0)
+            EVT_CALL(GetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0052))
+            EVT_CALL(SetNpcYaw, 3, 90)
+            EVT_CALL(SetNpcPos, 3, 0, -1000, 0)
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 200)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-8.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_0)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(PlaySoundAtNpc, 3, SOUND_MOLE_SURFACE, 0)
+            EVT_CALL(SetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0053))
+            EVT_CALL(SetNpcYaw, 4, 270)
+            EVT_CALL(GetNpcPos, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 200)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-8.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_monty_mole_Palette_01_Anim_14)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0054))
+            EVT_CALL(SetNpcYaw, 5, 270)
+            EVT_CALL(GetNpcPos, 5, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 200)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_6)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_7)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_8)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_16)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0055))
+            EVT_CALL(SetNpcPos, 1, -233, 0, -217)
+            EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 300)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_dayzee_Palette_00_Anim_D)
+            EVT_CALL(PlaySoundAtNpc, 1, SOUND_262, 0)
+            EVT_CALL(ShowEmote, 1, EMOTE_EXCLAMATION, 45, 30, 1, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0056))
+            EVT_SET(EVT_VAR(4), EVT_FIXED(90.0))
+            EVT_EXEC_WAIT(N(8024122C))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0057))
+            EVT_CALL(SetEnemyFlagBits, 1, 1, 0)
+            EVT_CALL(SetEnemyFlagBits, 2, 1, 0)
+            EVT_CALL(SetEnemyFlagBits, 3, 1, 0)
+            EVT_CALL(SetEnemyFlagBits, 4, 1, 0)
+            EVT_CALL(SetEnemyFlagBits, 5, 1, 0)
+            EVT_CALL(BindNpcAI, 1, EVT_PTR(N(npcAI_8024119C)))
+            EVT_SET(EVT_MAP_VAR(14), 0)
+            EVT_SET(EVT_MAP_VAR(15), 60)
+            EVT_SET(EVT_SAVE_VAR(0), 44)
+        EVT_CASE_EQ(44)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1411), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0058))
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_6)
+            EVT_ELSE
+                EVT_SET(EVT_VAR(4), EVT_FIXED(3.5))
+                EVT_EXEC_WAIT(N(8024122C))
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_8, NPC_ANIM_petunia_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x0059))
+                EVT_CALL(EndSpeech, -1, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_4)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_1)
+                EVT_SET(EVT_VAR(0), 88)
+                EVT_SET(EVT_VAR(1), 1)
+                EVT_EXEC_WAIT(N(80240F0C))
+                EVT_CALL(AddKeyItem, ITEM_MAGICAL_BEAN)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005A))
+                EVT_CALL(EndSpeech, -1, NPC_ANIM_petunia_Palette_00_Anim_7, NPC_ANIM_petunia_Palette_00_Anim_6, 0)
+                EVT_SET(EVT_SAVE_VAR(0), 45)
+            EVT_END_IF
+        EVT_CASE_LT(53)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005B))
+        EVT_CASE_LT(60)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005C))
+        EVT_CASE_DEFAULT
+            EVT_IF_EQ(EVT_AREA_VAR(1), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005D))
+                EVT_SET(EVT_AREA_VAR(1), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_petunia_Palette_00_Anim_2, NPC_ANIM_petunia_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x005E))
+            EVT_END_IF
+    EVT_END_SWITCH
+    EVT_CALL(ResetCam, 0, EVT_FIXED(8.0))
+    EVT_EXEC_WAIT(N(80240814))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80241DA4) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_802412BC));
-    if (EVT_SAVE_FLAG(1411) == 0) {
-        SetNpcAnimation(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_6);
-    } else {
-        SetNpcAnimation(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_1);
-    }
-});
+EvtSource N(init_80241DA4) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802412BC)))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1411), 0)
+        EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_petunia_Palette_00_Anim_6)
+    EVT_ELSE
+        EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_petunia_Palette_00_Anim_1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80241E10) = SCRIPT({
-    BindNpcDefeat(NPC_SELF, N(defeat_802411B8));
-    EnableNpcShadow(NPC_DAYZEE, FALSE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            SetNpcPos(NPC_DAYZEE, 0, -1000, 0);
-        } else {
-            if (EVT_SAVE_FLAG(1366) == 0) {
-                SetEnemyFlagBits(1, 1, 0);
-                BindNpcIdle(NPC_SELF, N(npcAI_8024119C));
-            } else {
-                SetNpcPos(NPC_DAYZEE, 0, -1000, 0);
-            }
-        }
-    }
-});
+EvtSource N(init_80241E10) = {
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802411B8)))
+    EVT_CALL(EnableNpcShadow, 1, FALSE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_CALL(SetNpcPos, 1, 0, -1000, 0)
+        EVT_CASE_DEFAULT
+            EVT_IF_EQ(EVT_SAVE_FLAG(1366), 0)
+                EVT_CALL(SetEnemyFlagBits, 1, 1, 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_8024119C)))
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 1, 0, -1000, 0)
+            EVT_END_IF
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241EF4) = SCRIPT({
-    EVT_MAP_VAR(14) = 0;
-    EVT_MAP_VAR(10) = 0;
-    EVT_MAP_VAR(11) = 0;
-    EVT_MAP_VAR(12) = 0;
-    EVT_MAP_VAR(13) = 0;
-    EVT_MAP_VAR(15) = 100;
-});
+EvtSource N(80241EF4) = {
+    EVT_SET(EVT_MAP_VAR(14), 0)
+    EVT_SET(EVT_MAP_VAR(10), 0)
+    EVT_SET(EVT_MAP_VAR(11), 0)
+    EVT_SET(EVT_MAP_VAR(12), 0)
+    EVT_SET(EVT_MAP_VAR(13), 0)
+    EVT_SET(EVT_MAP_VAR(15), 100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_80241F64) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            GetSelfNpcID(EVT_VAR(0));
-            match EVT_VAR(0) {
-                == 2 {
-                    EVT_SAVE_FLAG(1367) = 1;
-                }
-                == 3 {
-                    EVT_SAVE_FLAG(1368) = 1;
-                }
-                == 4 {
-                    EVT_SAVE_FLAG(1369) = 1;
-                }
-                == 5 {
-                    EVT_SAVE_FLAG(1370) = 1;
-                }
-            }
-            EVT_VAR(0) = 0;
-            EVT_VAR(0) += EVT_SAVE_FLAG(1367);
-            EVT_VAR(0) += EVT_SAVE_FLAG(1368);
-            EVT_VAR(0) += EVT_SAVE_FLAG(1369);
-            EVT_VAR(0) += EVT_SAVE_FLAG(1370);
-            if (EVT_VAR(0) != 4) {
-                SetNpcAnimation(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_6);
-            } else {
-                SetNpcAnimation(NPC_PETUNIA, NPC_ANIM_petunia_Palette_00_Anim_1);
-                EVT_SAVE_FLAG(1411) = 1;
-                await N(802406A0);
-            }
-            DoNpcDefeat();
-        }
-        == 1 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_1);
-        }
-        == 2 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_1);
-        }
-    }
-});
+EvtSource N(defeat_80241F64) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(GetSelfNpcID, EVT_VAR(0))
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_EQ(2)
+                    EVT_SET(EVT_SAVE_FLAG(1367), 1)
+                EVT_CASE_EQ(3)
+                    EVT_SET(EVT_SAVE_FLAG(1368), 1)
+                EVT_CASE_EQ(4)
+                    EVT_SET(EVT_SAVE_FLAG(1369), 1)
+                EVT_CASE_EQ(5)
+                    EVT_SET(EVT_SAVE_FLAG(1370), 1)
+            EVT_END_SWITCH
+            EVT_SET(EVT_VAR(0), 0)
+            EVT_ADD(EVT_VAR(0), EVT_SAVE_FLAG(1367))
+            EVT_ADD(EVT_VAR(0), EVT_SAVE_FLAG(1368))
+            EVT_ADD(EVT_VAR(0), EVT_SAVE_FLAG(1369))
+            EVT_ADD(EVT_VAR(0), EVT_SAVE_FLAG(1370))
+            EVT_IF_NE(EVT_VAR(0), 4)
+                EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_petunia_Palette_00_Anim_6)
+            EVT_ELSE
+                EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_petunia_Palette_00_Anim_1)
+                EVT_SET(EVT_SAVE_FLAG(1411), 1)
+                EVT_EXEC_WAIT(N(802406A0))
+            EVT_END_IF
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_1)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_1)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(hit_80242138) = SCRIPT({
-    if (EVT_STORY_PROGRESS == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-        GetOwnerEncounterTrigger(EVT_VAR(0));
-        if (EVT_VAR(0) != 1) {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_5);
-        }
-    }
-});
+EvtSource N(hit_80242138) = {
+    EVT_IF_EQ(EVT_SAVE_VAR(0), 44)
+        EVT_CALL(GetOwnerEncounterTrigger, EVT_VAR(0))
+        EVT_IF_NE(EVT_VAR(0), 1)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_monty_mole_Palette_01_Anim_5)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_8024219C) = SCRIPT({
-    loop {
-        if (EVT_MAP_VAR(10) == 0) {
-            if (EVT_AREA_FLAG(23) == 1) {
-                goto 0;
-            }
-            EVT_VAR(3) = 1;
-        } else {
-        0:
-            GetNpcPos(NPC_MONTY_MOLE0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            IsPlayerWithin(EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3));
-        }
-        GetCurrentPartner(EVT_VAR(9));
-        if (EVT_VAR(9) == 9) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_MAP_VAR(14) == 1) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_VAR(3) == 1) {
-            if (EVT_AREA_FLAG(23) == 0) {
-                SetNpcFlagBits(NPC_MONTY_MOLE0, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                NpcFacePlayer(NPC_MONTY_MOLE0, 1);
-                sleep 1;
-                EVT_AREA_FLAG(23) = 1;
-                if (EVT_MAP_VAR(10) != 0) {
-                    if (EVT_STORY_PROGRESS < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-                        EVT_VAR(1) = 4;
-                    } else {
-                        EVT_VAR(1) = 10;
-                    }
-                    PlaySoundAtNpc(NPC_MONTY_MOLE0, SOUND_262, 0);
-                    ShowEmote(2, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0);
-                    sleep EVT_VAR(1);
-                    SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), TRUE);
-                }
-                PlaySoundAtNpc(NPC_MONTY_MOLE0, SOUND_MOLE_DIG, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_11);
-                sleep 20;
-                if (EVT_SAVE_FLAG(1367) == 0) {
-                    SetNpcPos(NPC_MONTY_MOLE0, 0, -50, 0);
-                }
-                sleep 45;
-            }
-        } else {
-            if (EVT_AREA_FLAG(23) == 1) {
-                if (EVT_SAVE_FLAG(1367) == 0) {
-                    RandInt(2, EVT_VAR(0));
-                    EVT_VAR(0) += 1;
-                    buf_use N(intTable_80240F6C);
-                    loop EVT_VAR(0) {
-                        buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3);
-                    }
-                    SetNpcPos(NPC_MONTY_MOLE0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                }
-                SetNpcFlagBits(NPC_MONTY_MOLE0, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                EVT_AREA_FLAG(23) = 0;
-                NpcFacePlayer(NPC_MONTY_MOLE0, 1);
-                sleep 1;
-                PlaySoundAtNpc(NPC_MONTY_MOLE0, SOUND_MOLE_SURFACE, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                sleep 10;
-                SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), FALSE);
-                RandInt(30, EVT_VAR(0));
-                EVT_VAR(0) += 60;
-                EVT_MAP_VAR(10) = EVT_VAR(0);
-            } else {
-                if (EVT_MAP_VAR(10) > 0) {
-                    EVT_MAP_VAR(10) -= 1;
-                }
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_8024219C) = {
+    EVT_LOOP(0)
+        EVT_IF_EQ(EVT_MAP_VAR(10), 0)
+            EVT_IF_EQ(EVT_AREA_FLAG(23), 1)
+                EVT_GOTO(0)
+            EVT_END_IF
+            EVT_SET(EVT_VAR(3), 1)
+        EVT_ELSE
+            EVT_LABEL(0)
+            EVT_CALL(GetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(IsPlayerWithin, EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3))
+        EVT_END_IF
+        EVT_CALL(GetCurrentPartner, EVT_VAR(9))
+        EVT_IF_EQ(EVT_VAR(9), 9)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_MAP_VAR(14), 1)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_VAR(3), 1)
+            EVT_IF_EQ(EVT_AREA_FLAG(23), 0)
+                EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_CALL(NpcFacePlayer, 2, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_SET(EVT_AREA_FLAG(23), 1)
+                EVT_IF_NE(EVT_MAP_VAR(10), 0)
+                    EVT_IF_LT(EVT_SAVE_VAR(0), 44)
+                        EVT_SET(EVT_VAR(1), 4)
+                    EVT_ELSE
+                        EVT_SET(EVT_VAR(1), 10)
+                    EVT_END_IF
+                    EVT_CALL(PlaySoundAtNpc, 2, SOUND_262, 0)
+                    EVT_CALL(ShowEmote, 2, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(EVT_VAR(1))
+                    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), TRUE)
+                EVT_END_IF
+                EVT_CALL(PlaySoundAtNpc, 2, SOUND_MOLE_DIG, 0)
+                EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_11)
+                EVT_WAIT_FRAMES(20)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1367), 0)
+                    EVT_CALL(SetNpcPos, 2, 0, -50, 0)
+                EVT_END_IF
+                EVT_WAIT_FRAMES(45)
+            EVT_END_IF
+        EVT_ELSE
+            EVT_IF_EQ(EVT_AREA_FLAG(23), 1)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1367), 0)
+                    EVT_CALL(RandInt, 2, EVT_VAR(0))
+                    EVT_ADD(EVT_VAR(0), 1)
+                    EVT_USE_BUF(EVT_PTR(N(intTable_80240F6C)))
+                    EVT_LOOP(EVT_VAR(0))
+                        EVT_BUF_READ3(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_END_LOOP
+                    EVT_CALL(SetNpcPos, 2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                EVT_END_IF
+                EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_SET(EVT_AREA_FLAG(23), 0)
+                EVT_CALL(NpcFacePlayer, 2, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(PlaySoundAtNpc, 2, SOUND_MOLE_SURFACE, 0)
+                EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), FALSE)
+                EVT_CALL(RandInt, 30, EVT_VAR(0))
+                EVT_ADD(EVT_VAR(0), 60)
+                EVT_SET(EVT_MAP_VAR(10), EVT_VAR(0))
+            EVT_ELSE
+                EVT_IF_GT(EVT_MAP_VAR(10), 0)
+                    EVT_SUB(EVT_MAP_VAR(10), 1)
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242618) = SCRIPT({
-    loop {
-        if (EVT_MAP_VAR(11) == 0) {
-            if (EVT_AREA_FLAG(24) == 1) {
-                goto 0;
-            }
-            EVT_VAR(3) = 1;
-        } else {
-        0:
-            GetNpcPos(NPC_MONTY_MOLE1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            IsPlayerWithin(EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3));
-        }
-        GetCurrentPartner(EVT_VAR(9));
-        if (EVT_VAR(9) == 9) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_MAP_VAR(14) == 1) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_VAR(3) == 1) {
-            if (EVT_AREA_FLAG(24) == 0) {
-                SetNpcFlagBits(NPC_MONTY_MOLE1, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                NpcFacePlayer(NPC_MONTY_MOLE1, 1);
-                sleep 1;
-                EVT_AREA_FLAG(24) = 1;
-                if (EVT_MAP_VAR(11) != 0) {
-                    if (EVT_STORY_PROGRESS < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-                        EVT_VAR(1) = 4;
-                    } else {
-                        EVT_VAR(1) = 10;
-                    }
-                    PlaySoundAtNpc(NPC_MONTY_MOLE1, SOUND_262, 0);
-                    ShowEmote(3, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0);
-                    sleep EVT_VAR(1);
-                    SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), TRUE);
-                }
-                PlaySoundAtNpc(NPC_MONTY_MOLE1, SOUND_MOLE_DIG, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_11);
-                sleep 20;
-                if (EVT_SAVE_FLAG(1368) == 0) {
-                    SetNpcPos(NPC_MONTY_MOLE1, 0, -50, 0);
-                }
-                sleep 45;
-            }
-        } else {
-            if (EVT_AREA_FLAG(24) == 1) {
-                if (EVT_SAVE_FLAG(1368) == 0) {
-                    RandInt(2, EVT_VAR(0));
-                    EVT_VAR(0) += 1;
-                    buf_use N(intTable_80240F90);
-                    loop EVT_VAR(0) {
-                        buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3);
-                    }
-                    SetNpcPos(NPC_MONTY_MOLE1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                }
-                SetNpcFlagBits(NPC_MONTY_MOLE1, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                EVT_AREA_FLAG(24) = 0;
-                NpcFacePlayer(NPC_MONTY_MOLE1, 1);
-                sleep 1;
-                PlaySoundAtNpc(NPC_MONTY_MOLE1, SOUND_MOLE_SURFACE, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                sleep 10;
-                SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), FALSE);
-                RandInt(35, EVT_VAR(0));
-                EVT_VAR(0) += 55;
-                EVT_MAP_VAR(11) = EVT_VAR(0);
-            } else {
-                if (EVT_MAP_VAR(11) > 0) {
-                    EVT_MAP_VAR(11) -= 1;
-                }
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_80242618) = {
+    EVT_LOOP(0)
+        EVT_IF_EQ(EVT_MAP_VAR(11), 0)
+            EVT_IF_EQ(EVT_AREA_FLAG(24), 1)
+                EVT_GOTO(0)
+            EVT_END_IF
+            EVT_SET(EVT_VAR(3), 1)
+        EVT_ELSE
+            EVT_LABEL(0)
+            EVT_CALL(GetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(IsPlayerWithin, EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3))
+        EVT_END_IF
+        EVT_CALL(GetCurrentPartner, EVT_VAR(9))
+        EVT_IF_EQ(EVT_VAR(9), 9)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_MAP_VAR(14), 1)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_VAR(3), 1)
+            EVT_IF_EQ(EVT_AREA_FLAG(24), 0)
+                EVT_CALL(SetNpcFlagBits, 3, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_CALL(NpcFacePlayer, 3, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_SET(EVT_AREA_FLAG(24), 1)
+                EVT_IF_NE(EVT_MAP_VAR(11), 0)
+                    EVT_IF_LT(EVT_SAVE_VAR(0), 44)
+                        EVT_SET(EVT_VAR(1), 4)
+                    EVT_ELSE
+                        EVT_SET(EVT_VAR(1), 10)
+                    EVT_END_IF
+                    EVT_CALL(PlaySoundAtNpc, 3, SOUND_262, 0)
+                    EVT_CALL(ShowEmote, 3, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(EVT_VAR(1))
+                    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), TRUE)
+                EVT_END_IF
+                EVT_CALL(PlaySoundAtNpc, 3, SOUND_MOLE_DIG, 0)
+                EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_11)
+                EVT_WAIT_FRAMES(20)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1368), 0)
+                    EVT_CALL(SetNpcPos, 3, 0, -50, 0)
+                EVT_END_IF
+                EVT_WAIT_FRAMES(45)
+            EVT_END_IF
+        EVT_ELSE
+            EVT_IF_EQ(EVT_AREA_FLAG(24), 1)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1368), 0)
+                    EVT_CALL(RandInt, 2, EVT_VAR(0))
+                    EVT_ADD(EVT_VAR(0), 1)
+                    EVT_USE_BUF(EVT_PTR(N(intTable_80240F90)))
+                    EVT_LOOP(EVT_VAR(0))
+                        EVT_BUF_READ3(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_END_LOOP
+                    EVT_CALL(SetNpcPos, 3, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                EVT_END_IF
+                EVT_CALL(SetNpcFlagBits, 3, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_SET(EVT_AREA_FLAG(24), 0)
+                EVT_CALL(NpcFacePlayer, 3, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(PlaySoundAtNpc, 3, SOUND_MOLE_SURFACE, 0)
+                EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), FALSE)
+                EVT_CALL(RandInt, 35, EVT_VAR(0))
+                EVT_ADD(EVT_VAR(0), 55)
+                EVT_SET(EVT_MAP_VAR(11), EVT_VAR(0))
+            EVT_ELSE
+                EVT_IF_GT(EVT_MAP_VAR(11), 0)
+                    EVT_SUB(EVT_MAP_VAR(11), 1)
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242A94) = SCRIPT({
-    loop {
-        if (EVT_MAP_VAR(12) == 0) {
-            if (EVT_AREA_FLAG(25) == 1) {
-                goto 0;
-            }
-            EVT_VAR(3) = 1;
-        } else {
-        0:
-            GetNpcPos(NPC_MONTY_MOLE2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            IsPlayerWithin(EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3));
-        }
-        GetCurrentPartner(EVT_VAR(9));
-        if (EVT_VAR(9) == 9) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_MAP_VAR(14) == 1) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_VAR(3) == 1) {
-            if (EVT_AREA_FLAG(25) == 0) {
-                SetNpcFlagBits(NPC_MONTY_MOLE2, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                NpcFacePlayer(NPC_MONTY_MOLE2, 1);
-                sleep 1;
-                EVT_AREA_FLAG(25) = 1;
-                if (EVT_MAP_VAR(12) != 0) {
-                    if (EVT_STORY_PROGRESS < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-                        EVT_VAR(1) = 4;
-                    } else {
-                        EVT_VAR(1) = 10;
-                    }
-                    PlaySoundAtNpc(NPC_MONTY_MOLE2, SOUND_262, 0);
-                    ShowEmote(4, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0);
-                    sleep EVT_VAR(1);
-                    SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), TRUE);
-                }
-                PlaySoundAtNpc(NPC_MONTY_MOLE2, SOUND_MOLE_DIG, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE2, NPC_ANIM_monty_mole_Palette_01_Anim_11);
-                sleep 20;
-                if (EVT_SAVE_FLAG(1369) == 0) {
-                    SetNpcPos(NPC_MONTY_MOLE2, 0, -50, 0);
-                }
-                sleep 45;
-            }
-        } else {
-            if (EVT_AREA_FLAG(25) == 1) {
-                if (EVT_SAVE_FLAG(1369) == 0) {
-                    RandInt(2, EVT_VAR(0));
-                    EVT_VAR(0) += 1;
-                    buf_use N(intTable_80240FB4);
-                    loop EVT_VAR(0) {
-                        buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3);
-                    }
-                    SetNpcPos(NPC_MONTY_MOLE2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                }
-                SetNpcFlagBits(NPC_MONTY_MOLE2, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                EVT_AREA_FLAG(25) = 0;
-                NpcFacePlayer(NPC_MONTY_MOLE2, 1);
-                sleep 1;
-                PlaySoundAtNpc(NPC_MONTY_MOLE2, SOUND_MOLE_SURFACE, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE2, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                sleep 10;
-                SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), FALSE);
-                RandInt(40, EVT_VAR(0));
-                EVT_VAR(0) += 50;
-                EVT_MAP_VAR(12) = EVT_VAR(0);
-            } else {
-                if (EVT_MAP_VAR(12) > 0) {
-                    EVT_MAP_VAR(12) -= 1;
-                }
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_80242A94) = {
+    EVT_LOOP(0)
+        EVT_IF_EQ(EVT_MAP_VAR(12), 0)
+            EVT_IF_EQ(EVT_AREA_FLAG(25), 1)
+                EVT_GOTO(0)
+            EVT_END_IF
+            EVT_SET(EVT_VAR(3), 1)
+        EVT_ELSE
+            EVT_LABEL(0)
+            EVT_CALL(GetNpcPos, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(IsPlayerWithin, EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3))
+        EVT_END_IF
+        EVT_CALL(GetCurrentPartner, EVT_VAR(9))
+        EVT_IF_EQ(EVT_VAR(9), 9)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_MAP_VAR(14), 1)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_VAR(3), 1)
+            EVT_IF_EQ(EVT_AREA_FLAG(25), 0)
+                EVT_CALL(SetNpcFlagBits, 4, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_CALL(NpcFacePlayer, 4, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_SET(EVT_AREA_FLAG(25), 1)
+                EVT_IF_NE(EVT_MAP_VAR(12), 0)
+                    EVT_IF_LT(EVT_SAVE_VAR(0), 44)
+                        EVT_SET(EVT_VAR(1), 4)
+                    EVT_ELSE
+                        EVT_SET(EVT_VAR(1), 10)
+                    EVT_END_IF
+                    EVT_CALL(PlaySoundAtNpc, 4, SOUND_262, 0)
+                    EVT_CALL(ShowEmote, 4, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(EVT_VAR(1))
+                    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), TRUE)
+                EVT_END_IF
+                EVT_CALL(PlaySoundAtNpc, 4, SOUND_MOLE_DIG, 0)
+                EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_monty_mole_Palette_01_Anim_11)
+                EVT_WAIT_FRAMES(20)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1369), 0)
+                    EVT_CALL(SetNpcPos, 4, 0, -50, 0)
+                EVT_END_IF
+                EVT_WAIT_FRAMES(45)
+            EVT_END_IF
+        EVT_ELSE
+            EVT_IF_EQ(EVT_AREA_FLAG(25), 1)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1369), 0)
+                    EVT_CALL(RandInt, 2, EVT_VAR(0))
+                    EVT_ADD(EVT_VAR(0), 1)
+                    EVT_USE_BUF(EVT_PTR(N(intTable_80240FB4)))
+                    EVT_LOOP(EVT_VAR(0))
+                        EVT_BUF_READ3(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_END_LOOP
+                    EVT_CALL(SetNpcPos, 4, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                EVT_END_IF
+                EVT_CALL(SetNpcFlagBits, 4, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_SET(EVT_AREA_FLAG(25), 0)
+                EVT_CALL(NpcFacePlayer, 4, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(PlaySoundAtNpc, 4, SOUND_MOLE_SURFACE, 0)
+                EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), FALSE)
+                EVT_CALL(RandInt, 40, EVT_VAR(0))
+                EVT_ADD(EVT_VAR(0), 50)
+                EVT_SET(EVT_MAP_VAR(12), EVT_VAR(0))
+            EVT_ELSE
+                EVT_IF_GT(EVT_MAP_VAR(12), 0)
+                    EVT_SUB(EVT_MAP_VAR(12), 1)
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242F10) = SCRIPT({
-    loop {
-        if (EVT_MAP_VAR(13) == 0) {
-            if (EVT_AREA_FLAG(26) == 1) {
-                goto 0;
-            }
-            EVT_VAR(3) = 1;
-        } else {
-        0:
-            GetNpcPos(NPC_MONTY_MOLE3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            IsPlayerWithin(EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3));
-        }
-        GetCurrentPartner(EVT_VAR(9));
-        if (EVT_VAR(9) == 9) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_MAP_VAR(14) == 1) {
-            EVT_VAR(3) = 0;
-        }
-        if (EVT_VAR(3) == 1) {
-            if (EVT_AREA_FLAG(26) == 0) {
-                SetNpcFlagBits(NPC_MONTY_MOLE3, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                NpcFacePlayer(NPC_MONTY_MOLE3, 1);
-                sleep 1;
-                EVT_AREA_FLAG(26) = 1;
-                if (EVT_MAP_VAR(13) != 0) {
-                    if (EVT_STORY_PROGRESS < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES) {
-                        EVT_VAR(1) = 4;
-                    } else {
-                        EVT_VAR(1) = 10;
-                    }
-                    PlaySoundAtNpc(NPC_MONTY_MOLE3, SOUND_262, 0);
-                    ShowEmote(5, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0);
-                    sleep EVT_VAR(1);
-                    SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), TRUE);
-                }
-                PlaySoundAtNpc(NPC_MONTY_MOLE3, SOUND_MOLE_DIG, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_11);
-                sleep 20;
-                if (EVT_SAVE_FLAG(1370) == 0) {
-                    SetNpcPos(NPC_MONTY_MOLE3, 0, -50, 0);
-                }
-                sleep 45;
-            }
-        } else {
-            if (EVT_AREA_FLAG(26) == 1) {
-                if (EVT_SAVE_FLAG(1370) == 0) {
-                    RandInt(2, EVT_VAR(0));
-                    EVT_VAR(0) += 1;
-                    buf_use N(intTable_80240FD8);
-                    loop EVT_VAR(0) {
-                        buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3);
-                    }
-                    SetNpcPos(NPC_MONTY_MOLE3, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                }
-                SetNpcFlagBits(NPC_MONTY_MOLE3, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE);
-                EVT_AREA_FLAG(26) = 0;
-                NpcFacePlayer(NPC_MONTY_MOLE3, 1);
-                sleep 1;
-                PlaySoundAtNpc(NPC_MONTY_MOLE3, SOUND_MOLE_SURFACE, 0);
-                SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                sleep 10;
-                SetSelfEnemyFlagBits(((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | 0x02000000 | NPC_FLAG_PARTICLE | 0x10000000)), FALSE);
-                RandInt(45, EVT_VAR(0));
-                EVT_VAR(0) += 45;
-                EVT_MAP_VAR(13) = EVT_VAR(0);
-            } else {
-                if (EVT_MAP_VAR(13) > 0) {
-                    EVT_MAP_VAR(13) -= 1;
-                }
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_80242F10) = {
+    EVT_LOOP(0)
+        EVT_IF_EQ(EVT_MAP_VAR(13), 0)
+            EVT_IF_EQ(EVT_AREA_FLAG(26), 1)
+                EVT_GOTO(0)
+            EVT_END_IF
+            EVT_SET(EVT_VAR(3), 1)
+        EVT_ELSE
+            EVT_LABEL(0)
+            EVT_CALL(GetNpcPos, 5, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(IsPlayerWithin, EVT_VAR(0), EVT_VAR(2), EVT_MAP_VAR(15), EVT_VAR(3))
+        EVT_END_IF
+        EVT_CALL(GetCurrentPartner, EVT_VAR(9))
+        EVT_IF_EQ(EVT_VAR(9), 9)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_MAP_VAR(14), 1)
+            EVT_SET(EVT_VAR(3), 0)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_VAR(3), 1)
+            EVT_IF_EQ(EVT_AREA_FLAG(26), 0)
+                EVT_CALL(SetNpcFlagBits, 5, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_CALL(NpcFacePlayer, 5, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_SET(EVT_AREA_FLAG(26), 1)
+                EVT_IF_NE(EVT_MAP_VAR(13), 0)
+                    EVT_IF_LT(EVT_SAVE_VAR(0), 44)
+                        EVT_SET(EVT_VAR(1), 4)
+                    EVT_ELSE
+                        EVT_SET(EVT_VAR(1), 10)
+                    EVT_END_IF
+                    EVT_CALL(PlaySoundAtNpc, 5, SOUND_262, 0)
+                    EVT_CALL(ShowEmote, 5, EMOTE_EXCLAMATION, 0, EVT_VAR(1), 1, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(EVT_VAR(1))
+                    EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), TRUE)
+                EVT_END_IF
+                EVT_CALL(PlaySoundAtNpc, 5, SOUND_MOLE_DIG, 0)
+                EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_11)
+                EVT_WAIT_FRAMES(20)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1370), 0)
+                    EVT_CALL(SetNpcPos, 5, 0, -50, 0)
+                EVT_END_IF
+                EVT_WAIT_FRAMES(45)
+            EVT_END_IF
+        EVT_ELSE
+            EVT_IF_EQ(EVT_AREA_FLAG(26), 1)
+                EVT_IF_EQ(EVT_SAVE_FLAG(1370), 0)
+                    EVT_CALL(RandInt, 2, EVT_VAR(0))
+                    EVT_ADD(EVT_VAR(0), 1)
+                    EVT_USE_BUF(EVT_PTR(N(intTable_80240FD8)))
+                    EVT_LOOP(EVT_VAR(0))
+                        EVT_BUF_READ3(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_END_LOOP
+                    EVT_CALL(SetNpcPos, 5, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                EVT_END_IF
+                EVT_CALL(SetNpcFlagBits, 5, ((NPC_FLAG_ENABLE_HIT_SCRIPT | NPC_FLAG_40 | NPC_FLAG_8000)), TRUE)
+                EVT_SET(EVT_AREA_FLAG(26), 0)
+                EVT_CALL(NpcFacePlayer, 5, 1)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(PlaySoundAtNpc, 5, SOUND_MOLE_SURFACE, 0)
+                EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(SetSelfEnemyFlagBits, ((NPC_FLAG_MOTION_BLUR | NPC_FLAG_1000000 | NPC_FLAG_SIMPLIFIED_PHYSICS | NPC_FLAG_PARTICLE | NPC_FLAG_10000000)), FALSE)
+                EVT_CALL(RandInt, 45, EVT_VAR(0))
+                EVT_ADD(EVT_VAR(0), 45)
+                EVT_SET(EVT_MAP_VAR(13), EVT_VAR(0))
+            EVT_ELSE
+                EVT_IF_GT(EVT_MAP_VAR(13), 0)
+                    EVT_SUB(EVT_MAP_VAR(13), 1)
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024338C) = SCRIPT({
-    BindNpcHit(-1, N(hit_80242138));
-    BindNpcDefeat(NPC_SELF, N(defeat_80241F64));
-    EnableNpcShadow(NPC_MONTY_MOLE0, FALSE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            BindNpcIdle(NPC_SELF, N(idle_8024219C));
-            SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-        }
-        == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            if (EVT_SAVE_FLAG(1367) == 0) {
-                BindNpcIdle(NPC_SELF, N(idle_8024219C));
-                SetNpcAnimation(NPC_MONTY_MOLE0, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                SetEnemyFlagBits(2, 1, 0);
-            } else {
-                SetNpcPos(NPC_MONTY_MOLE0, 0, -1000, 0);
-            }
-        } else {
-            SetNpcPos(NPC_MONTY_MOLE0, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_8024338C) = {
+    EVT_CALL(BindNpcHit, -1, EVT_PTR(N(hit_80242138)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80241F64)))
+    EVT_CALL(EnableNpcShadow, 2, FALSE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_8024219C)))
+            EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+        EVT_CASE_EQ(44)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1367), 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_8024219C)))
+                EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_CALL(SetEnemyFlagBits, 2, 1, 0)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802434CC) = SCRIPT({
-    BindNpcHit(-1, N(hit_80242138));
-    BindNpcDefeat(NPC_SELF, N(defeat_80241F64));
-    EnableNpcShadow(NPC_MONTY_MOLE1, FALSE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            BindNpcIdle(NPC_SELF, N(idle_80242618));
-            SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-        }
-        == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            if (EVT_SAVE_FLAG(1368) == 0) {
-                BindNpcIdle(NPC_SELF, N(idle_80242618));
-                SetNpcAnimation(NPC_MONTY_MOLE1, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                SetEnemyFlagBits(3, 1, 0);
-            } else {
-                SetNpcPos(NPC_MONTY_MOLE1, 0, -1000, 0);
-            }
-        } else {
-            SetNpcPos(NPC_MONTY_MOLE1, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_802434CC) = {
+    EVT_CALL(BindNpcHit, -1, EVT_PTR(N(hit_80242138)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80241F64)))
+    EVT_CALL(EnableNpcShadow, 3, FALSE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242618)))
+            EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+        EVT_CASE_EQ(44)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1368), 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242618)))
+                EVT_CALL(SetNpcAnimation, 3, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_CALL(SetEnemyFlagBits, 3, 1, 0)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 3, 0, -1000, 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetNpcPos, 3, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024360C) = SCRIPT({
-    BindNpcHit(-1, N(hit_80242138));
-    BindNpcDefeat(NPC_SELF, N(defeat_80241F64));
-    EnableNpcShadow(NPC_MONTY_MOLE2, FALSE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            BindNpcIdle(NPC_SELF, N(idle_80242A94));
-            SetNpcAnimation(NPC_MONTY_MOLE2, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-        }
-        == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            if (EVT_SAVE_FLAG(1369) == 0) {
-                BindNpcIdle(NPC_SELF, N(idle_80242A94));
-                SetNpcAnimation(NPC_MONTY_MOLE2, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                SetEnemyFlagBits(4, 1, 0);
-            } else {
-                SetNpcPos(NPC_MONTY_MOLE2, 0, -1000, 0);
-            }
-        } else {
-            SetNpcPos(NPC_MONTY_MOLE2, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_8024360C) = {
+    EVT_CALL(BindNpcHit, -1, EVT_PTR(N(hit_80242138)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80241F64)))
+    EVT_CALL(EnableNpcShadow, 4, FALSE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242A94)))
+            EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+        EVT_CASE_EQ(44)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1369), 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242A94)))
+                EVT_CALL(SetNpcAnimation, 4, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_CALL(SetEnemyFlagBits, 4, 1, 0)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 4, 0, -1000, 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetNpcPos, 4, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024374C) = SCRIPT({
-    BindNpcHit(-1, N(hit_80242138));
-    BindNpcDefeat(NPC_SELF, N(defeat_80241F64));
-    EnableNpcShadow(NPC_MONTY_MOLE3, FALSE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            BindNpcIdle(NPC_SELF, N(idle_80242F10));
-            SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-        }
-        == STORY_CH6_ASKED_TO_DEFEAT_MONTY_MOLES {
-            if (EVT_SAVE_FLAG(1370) == 0) {
-                BindNpcIdle(NPC_SELF, N(idle_80242F10));
-                SetNpcAnimation(NPC_MONTY_MOLE3, NPC_ANIM_monty_mole_Palette_01_Anim_10);
-                SetEnemyFlagBits(5, 1, 0);
-            } else {
-                SetNpcPos(NPC_MONTY_MOLE3, 0, -1000, 0);
-            }
-        } else {
-            SetNpcPos(NPC_MONTY_MOLE3, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_8024374C) = {
+    EVT_CALL(BindNpcHit, -1, EVT_PTR(N(hit_80242138)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80241F64)))
+    EVT_CALL(EnableNpcShadow, 5, FALSE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(44)
+            EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242F10)))
+            EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+        EVT_CASE_EQ(44)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1370), 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242F10)))
+                EVT_CALL(SetNpcAnimation, 5, NPC_ANIM_monty_mole_Palette_01_Anim_10)
+                EVT_CALL(SetEnemyFlagBits, 5, 1, 0)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 5, 0, -1000, 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetNpcPos, 5, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_8024388C) = {
     .id = NPC_PETUNIA,
@@ -1179,23 +1202,28 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_80244E44) = { -208.0f, 0.0f, -182.0f, 0.0f };
 
-EvtSource N(80244E54) = SCRIPT({
-    EVT_AREA_FLAG(27) = 0;
-    EVT_AREA_FLAG(28) = 0;
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 16;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80244E44);
-});
+EvtSource N(80244E54) = {
+    EVT_SET(EVT_AREA_FLAG(27), 0)
+    EVT_SET(EVT_AREA_FLAG(28), 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 16, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80244E44)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_4ECC) = {
     0x00000000,
 };
 
-EvtSource N(80244ED0) = SCRIPT({
+EvtSource N(80244ED0) = {
+    EVT_RETURN
+    EVT_END
+};
 
-});
-
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EAB04, -175, 0, 150, 0, ITEM_MAP, MAKE_ENTITY_END);
-    AssignPanelFlag(EVT_SAVE_FLAG(1404));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EAB04, -175, 0, 150, 0, 8, MAKE_ENTITY_END)
+    EVT_CALL(AssignPanelFlag, EVT_SAVE_FLAG(1404))
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_07/CAC5D0.c
+++ b/src/world/area_flo/flo_07/CAC5D0.c
@@ -19,187 +19,200 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_07_tattle },
 };
 
-EvtSource N(802407A0) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        SetMusicTrack(0, SONG_SUNSHINE_RETURNS, 0, 8);
-    } else {
-        match EVT_STORY_PROGRESS {
-            < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-            } else {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-            }
-        }
-    }
-    PlaySound(0x80000021);
-});
+EvtSource N(802407A0) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(SetMusicTrack, 0, SONG_SUNSHINE_RETURNS, 0, 8)
+    EVT_ELSE
+        EVT_SWITCH(EVT_SAVE_VAR(0))
+            EVT_CASE_LT(53)
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+            EVT_CASE_DEFAULT
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_CALL(PlaySound, 0x80000021)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024086C) = SCRIPT({
-    PushSong(137, 1);
-});
+EvtSource N(8024086C) = {
+    EVT_CALL(PushSong, 137, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240890) = SCRIPT({
-    FadeOutMusic(0, 250);
-    sleep 10;
-    PopSong();
-});
+EvtSource N(80240890) = {
+    EVT_CALL(FadeOutMusic, 0, 250)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PopSong)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_8CC) = {
     0x00000000,
 };
 
-EvtSource N(updateTexturePan_802408D0) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(updateTexturePan_802408D0) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024096C) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(8024096C) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80240C18) = EXIT_WALK_SCRIPT(60,  0, "flo_25",  1);
 
-EvtSource N(80240C74) = SCRIPT({
-    bind N(exitWalk_80240C18) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(80240C74) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240C18), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    EVT_AREA_FLAG(6) = 0;
-    MakeNpcs(0, N(npcGroupList_80242B0C));
-    await N(802428C4);
-    ModifyColliderFlags(3, 6, 0x00000006);
-    EVT_VAR(0) = 297;
-    EVT_VAR(1) = -95;
-    EVT_VAR(2) = 383;
-    EVT_VAR(3) = -65;
-    EVT_VAR(4) = 0;
-    spawn N(8024096C);
-    EVT_VAR(0) = 293;
-    EVT_VAR(1) = 71;
-    EVT_VAR(2) = 378;
-    EVT_VAR(3) = 113;
-    EVT_VAR(4) = 0;
-    spawn N(8024096C);
-    EVT_VAR(0) = 21;
-    EVT_VAR(1) = -346;
-    EVT_VAR(2) = 147;
-    EVT_VAR(3) = -242;
-    EVT_VAR(4) = 20;
-    spawn N(8024096C);
-    EVT_VAR(0) = -350;
-    EVT_VAR(1) = -190;
-    EVT_VAR(2) = -81;
-    EVT_VAR(3) = -106;
-    EVT_VAR(4) = 0;
-    spawn N(8024096C);
-    EVT_VAR(0) = -380;
-    EVT_VAR(1) = 85;
-    EVT_VAR(2) = -95;
-    EVT_VAR(3) = 150;
-    EVT_VAR(4) = 0;
-    spawn N(8024096C);
-    EnableTexPanning(51, 1);
-    EnableTexPanning(49, 1);
-    EnableTexPanning(50, 1);
-    spawn {
-        EVT_VAR(0) = 2;
-        EVT_VAR(1) = -100;
-        EVT_VAR(2) = 100;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802408D0);
-    }
-    spawn {
-        EVT_VAR(0) = 3;
-        EVT_VAR(1) = 0;
-        EVT_VAR(2) = -1200;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802408D0);
-    }
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        spawn N(80241C14);
-    } else {
-        ModifyColliderFlags(0, 1, 0x7FFFFE00);
-        EVT_VAR(0) = N(80240C74);
-        spawn EnterWalk;
-        spawn N(802424F4);
-    }
-    await N(802407A0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(SpawnSunEffect)();
-    }
-    N(func_80240344_CAC534)();
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_SET(EVT_AREA_FLAG(6), 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80242B0C)))
+    EVT_EXEC_WAIT(N(802428C4))
+    EVT_CALL(ModifyColliderFlags, 3, 6, 0x00000006)
+    EVT_SET(EVT_VAR(0), 297)
+    EVT_SET(EVT_VAR(1), -95)
+    EVT_SET(EVT_VAR(2), 383)
+    EVT_SET(EVT_VAR(3), -65)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(8024096C))
+    EVT_SET(EVT_VAR(0), 293)
+    EVT_SET(EVT_VAR(1), 71)
+    EVT_SET(EVT_VAR(2), 378)
+    EVT_SET(EVT_VAR(3), 113)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(8024096C))
+    EVT_SET(EVT_VAR(0), 21)
+    EVT_SET(EVT_VAR(1), -346)
+    EVT_SET(EVT_VAR(2), 147)
+    EVT_SET(EVT_VAR(3), -242)
+    EVT_SET(EVT_VAR(4), 20)
+    EVT_EXEC(N(8024096C))
+    EVT_SET(EVT_VAR(0), -350)
+    EVT_SET(EVT_VAR(1), -190)
+    EVT_SET(EVT_VAR(2), -81)
+    EVT_SET(EVT_VAR(3), -106)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(8024096C))
+    EVT_SET(EVT_VAR(0), -380)
+    EVT_SET(EVT_VAR(1), 85)
+    EVT_SET(EVT_VAR(2), -95)
+    EVT_SET(EVT_VAR(3), 150)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(8024096C))
+    EVT_CALL(EnableTexPanning, 51, 1)
+    EVT_CALL(EnableTexPanning, 49, 1)
+    EVT_CALL(EnableTexPanning, 50, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(1), -100)
+        EVT_SET(EVT_VAR(2), 100)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802408D0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 3)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(2), -1200)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802408D0))
+    EVT_END_THREAD
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_EXEC(N(80241C14))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(80240C74)))
+        EVT_EXEC(EnterWalk)
+        EVT_EXEC(N(802424F4))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(802407A0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(SpawnSunEffect))
+    EVT_END_IF
+    EVT_CALL(N(func_80240344_CAC534))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1214)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -215,230 +228,227 @@ NpcSettings N(npcSettings_80241220) = {
 
 s32** N(D_80241BB0_CADDA0) = NULL;
 
-EvtSource N(80241BB4) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 0);
-    return;
-});
+EvtSource N(80241BB4) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241BE4) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 16);
-    return;
-});
+EvtSource N(80241BE4) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 16)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241C14) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    GetNpcPos(NPC_POSIE, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 30;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 300);
-    SetCamPitch(0, 11.0, -11.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 20;
-    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00C5));
-    sleep 10;
-    GotoMap("flo_10", 1);
-    sleep 100;
-});
+EvtSource N(80241C14) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 30)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(11.0), EVT_FIXED(-11.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00C5))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GotoMap, EVT_PTR("flo_10"), 1)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241D6C) = SCRIPT({
-0:
-    ShakeCam(0, 0, 1, 1.0);
-    sleep 1;
-    goto 0;
-});
+EvtSource N(80241D6C) = {
+    EVT_LABEL(0)
+    EVT_CALL(ShakeCam, 0, 0, 1, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241DBC) = SCRIPT({
-    if (EVT_AREA_FLAG(6) == 1) {
-        return;
-    }
-    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0068));
-    spawn {
-        SetCamDistance(0, 300);
-        SetCamPitch(0, 18.0, -7.5);
-        SetCamSpeed(0, 0.5);
-        PanToTarget(0, 0, 1);
-    }
-    PlaySound(0x8000006B);
-    EVT_MAP_VAR(0) = spawn N(80241D6C);
-    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_6, NPC_ANIM_posie_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0069));
-    kill EVT_MAP_VAR(0);
-    SetCamDistance(0, 350);
-    SetCamPitch(0, 18.0, -7.5);
-    SetCamSpeed(0, 8.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 10;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) -= EVT_VAR(2);
-    if (EVT_VAR(0) < -250) {
-        MakeItemEntity(ITEM_CRYSTAL_BERRY, -225, 100, -25, 13, EVT_SAVE_FLAG(1374));
-    } else {
-        MakeItemEntity(ITEM_CRYSTAL_BERRY, -265, 100, 54, 13, EVT_SAVE_FLAG(1374));
-        EVT_SAVE_FLAG(1396) = 1;
-    }
-    PlaySound(0x7BC);
-    func_802D62E4(956);
-    EVT_AREA_FLAG(6) = 1;
-    sleep 20;
-    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006A));
-    EVT_STORY_PROGRESS = STORY_CH6_GOT_CRYSTAL_BERRY;
-});
+EvtSource N(80241DBC) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(6), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0068))
+    EVT_THREAD
+        EVT_CALL(SetCamDistance, 0, 300)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.0), EVT_FIXED(-7.5))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(0.5))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_END_THREAD
+    EVT_CALL(PlaySound, 0x8000006B)
+    EVT_EXEC_GET_TID(N(80241D6C), EVT_MAP_VAR(0))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_6, NPC_ANIM_posie_Palette_00_Anim_6, 0, MESSAGE_ID(0x11, 0x0069))
+    EVT_KILL_THREAD(EVT_MAP_VAR(0))
+    EVT_CALL(SetCamDistance, 0, 350)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.0), EVT_FIXED(-7.5))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(8.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SUB(EVT_VAR(0), EVT_VAR(2))
+    EVT_IF_LT(EVT_VAR(0), -250)
+        EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -225, 100, -25, 13, EVT_SAVE_FLAG(1374))
+    EVT_ELSE
+        EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -265, 100, 54, 13, EVT_SAVE_FLAG(1374))
+        EVT_SET(EVT_SAVE_FLAG(1396), 1)
+    EVT_END_IF
+    EVT_CALL(PlaySound, 0x7BC)
+    EVT_CALL(func_802D62E4, 956)
+    EVT_SET(EVT_AREA_FLAG(6), 1)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006A))
+    EVT_SET(EVT_SAVE_VAR(0), 47)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80242044) = SCRIPT({
-    await N(8024086C);
-    NpcFacePlayer(NPC_SELF, 1);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_GOT_MAGICAL_BEAN {
-            if (EVT_AREA_FLAG(5) == 0) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                              0x0070));
-                EVT_AREA_FLAG(5) = 1;
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                              0x0071));
-            }
-        }
-        < STORY_CH6_GOT_FERTILE_SOIL {
-            AdjustCam(0, 4.0, 0, 350.0, 18.0, -7.5);
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0065));
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_5);
-            sleep 20;
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_0);
-            EVT_VAR(0) = 89;
-            EVT_VAR(1) = 1;
-            await N(80241BB4);
-            AddKeyItem(ITEM_FERTILE_SOIL);
-            EVT_STORY_PROGRESS = STORY_CH6_GOT_FERTILE_SOIL;
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0066));
-            if (EVT_SAVE_FLAG(1379) == 1) {
-                await N(80241DBC);
-            }
-            ResetCam(0, 4.0);
-        }
-        < STORY_CH6_GOT_CRYSTAL_BERRY {
-            if (EVT_SAVE_FLAG(1379) == 1) {
-                if (EVT_AREA_FLAG(6) == 0) {
-                    AdjustCam(0, 4.0, 0, 350.0, 18.0, -7.5);
-                    await N(80241DBC);
-                    ResetCam(0, 4.0);
-                } else {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                                  0x0072));
-                }
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                              0x0072));
-            }
-        }
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            if (EVT_SAVE_FLAG(1374) == 0) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                              0x0072));
-            } else {
-                if (EVT_STORY_PROGRESS < STORY_CH6_GOT_WATER_STONE) {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                                  0x0073));
-                } else {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                                  0x0074));
-                }
-                ContinueSpeech(-1, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                               0x0075));
-            }
-        }
-        < STORY_CH6_RETURNED_TO_TOAD_TOWN {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0076));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                          0x0077));
-        }
-    }
-    await N(80240890);
-});
+EvtSource N(interact_80242044) = {
+    EVT_EXEC_WAIT(N(8024086C))
+    EVT_CALL(NpcFacePlayer, NPC_SELF, 1)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(45)
+            EVT_IF_EQ(EVT_AREA_FLAG(5), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0070))
+                EVT_SET(EVT_AREA_FLAG(5), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0071))
+            EVT_END_IF
+        EVT_CASE_LT(46)
+            EVT_CALL(AdjustCam, 0, EVT_FIXED(4.0), 0, EVT_FIXED(350.0), EVT_FIXED(18.0), EVT_FIXED(-7.5))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0065))
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_5)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_0)
+            EVT_SET(EVT_VAR(0), 89)
+            EVT_SET(EVT_VAR(1), 1)
+            EVT_EXEC_WAIT(N(80241BB4))
+            EVT_CALL(AddKeyItem, ITEM_FERTILE_SOIL)
+            EVT_SET(EVT_SAVE_VAR(0), 46)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0066))
+            EVT_IF_EQ(EVT_SAVE_FLAG(1379), 1)
+                EVT_EXEC_WAIT(N(80241DBC))
+            EVT_END_IF
+            EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+        EVT_CASE_LT(47)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1379), 1)
+                EVT_IF_EQ(EVT_AREA_FLAG(6), 0)
+                    EVT_CALL(AdjustCam, 0, EVT_FIXED(4.0), 0, EVT_FIXED(350.0), EVT_FIXED(18.0), EVT_FIXED(-7.5))
+                    EVT_EXEC_WAIT(N(80241DBC))
+                    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+                EVT_ELSE
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0072))
+                EVT_END_IF
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0072))
+            EVT_END_IF
+        EVT_CASE_LT(53)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1374), 0)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0072))
+            EVT_ELSE
+                EVT_IF_LT(EVT_SAVE_VAR(0), 48)
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0073))
+                EVT_ELSE
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0074))
+                EVT_END_IF
+                EVT_CALL(ContinueSpeech, -1, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0075))
+            EVT_END_IF
+        EVT_CASE_LT(60)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0076))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0077))
+    EVT_END_SWITCH
+    EVT_EXEC_WAIT(N(80240890))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80242428) = SCRIPT({
-    if (EVT_STORY_PROGRESS == STORY_CH6_GOT_CRYSTAL_BERRY) {
-        if (EVT_SAVE_FLAG(1374) == 0) {
-            if (EVT_SAVE_FLAG(1396) == 0) {
-                MakeItemEntity(ITEM_CRYSTAL_BERRY, -225, 0, -25, 17, EVT_SAVE_FLAG(1374));
-            } else {
-                MakeItemEntity(ITEM_CRYSTAL_BERRY, -265, 0, 54, 17, EVT_SAVE_FLAG(1374));
-            }
-        }
-    }
-    EVT_AREA_FLAG(5) = 0;
-    BindNpcInteract(NPC_SELF, N(interact_80242044));
-});
+EvtSource N(init_80242428) = {
+    EVT_IF_EQ(EVT_SAVE_VAR(0), 47)
+        EVT_IF_EQ(EVT_SAVE_FLAG(1374), 0)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1396), 0)
+                EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -225, 0, -25, 17, EVT_SAVE_FLAG(1374))
+            EVT_ELSE
+                EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -265, 0, 54, 17, EVT_SAVE_FLAG(1374))
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_SET(EVT_AREA_FLAG(5), 0)
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80242044)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802424F4) = SCRIPT({
-    if (EVT_AREA_VAR(3) != 0) {
-        DisablePlayerInput(TRUE);
-        sleep 10;
-        if (EVT_AREA_VAR(3) < 5) {
-            SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                          0x006E));
-            GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            PlayerMoveTo(410, EVT_VAR(3), 10);
-            EVT_AREA_VAR(3) += 1;
-        } else {
-            SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                          0x006F));
-            EVT_AREA_VAR(3) = 0;
-        }
-        DisablePlayerInput(FALSE);
-    }
-});
+EvtSource N(802424F4) = {
+    EVT_IF_NE(EVT_AREA_VAR(3), 0)
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_WAIT_FRAMES(10)
+        EVT_IF_LT(EVT_AREA_VAR(3), 5)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006E))
+            EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_CALL(PlayerMoveTo, 410, EVT_VAR(3), 10)
+            EVT_ADD(EVT_AREA_VAR(3), 1)
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_2, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006F))
+            EVT_SET(EVT_AREA_VAR(3), 0)
+        EVT_END_IF
+        EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(flo_25_name_hack)[];
 
-EvtSource N(tree1_Callback) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    if (EVT_STORY_PROGRESS < STORY_CH6_GOT_CRYSTAL_BERRY) {
-        NpcFacePlayer(NPC_POSIE, 1);
-        sleep 10;
-        SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_4, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                      0x0067));
-        if (EVT_STORY_PROGRESS == STORY_CH6_GOT_FERTILE_SOIL) {
-            if (EVT_SAVE_FLAG(1379) == 1) {
-                UseSettingsFrom(0, -250, 0, 0);
-                SetPanTarget(0, -250, 0, 0);
-                SetCamDistance(0, 350);
-                PanToTarget(0, 0, 1);
-                await N(80241DBC);
-                ResetCam(0, 4.0);
-            }
-        }
-    } else {
-        if (EVT_SAVE_FLAG(1374) == 0) {
-            NpcFacePlayer(NPC_POSIE, 1);
-            sleep 10;
-            SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_4, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                          0x0067));
-        } else {
-            EVT_AREA_VAR(2) += 1;
-            match EVT_AREA_VAR(2) {
-                < 2 {
-                    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006B));
-                }
-                < 5 {
-                    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006C));
-                }
-                >= 5 {
-                    SpeakToPlayer(NPC_POSIE, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006D));
-                    EVT_AREA_VAR(3) = 1;
-                    GotoMap(N(flo_25_name_hack), 1);
-                    sleep 100;
-                }
-            }
-        }
-    }
-    ResetCam(0, 4.0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(tree1_Callback) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_LT(EVT_SAVE_VAR(0), 47)
+        EVT_CALL(NpcFacePlayer, 0, 1)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_4, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0067))
+        EVT_IF_EQ(EVT_SAVE_VAR(0), 46)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1379), 1)
+                EVT_CALL(UseSettingsFrom, 0, -250, 0, 0)
+                EVT_CALL(SetPanTarget, 0, -250, 0, 0)
+                EVT_CALL(SetCamDistance, 0, 350)
+                EVT_CALL(PanToTarget, 0, 0, 1)
+                EVT_EXEC_WAIT(N(80241DBC))
+                EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+            EVT_END_IF
+        EVT_END_IF
+    EVT_ELSE
+        EVT_IF_EQ(EVT_SAVE_FLAG(1374), 0)
+            EVT_CALL(NpcFacePlayer, 0, 1)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_4, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0067))
+        EVT_ELSE
+            EVT_ADD(EVT_AREA_VAR(2), 1)
+            EVT_SWITCH(EVT_AREA_VAR(2))
+                EVT_CASE_LT(2)
+                    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006B))
+                EVT_CASE_LT(5)
+                    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006C))
+                EVT_CASE_GE(5)
+                    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_posie_Palette_00_Anim_3, NPC_ANIM_posie_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x006D))
+                    EVT_SET(EVT_AREA_VAR(3), 1)
+                    EVT_CALL(GotoMap, EVT_PTR(N(flo_25_name_hack)), 1)
+                    EVT_WAIT_FRAMES(100)
+            EVT_END_SWITCH
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
 FoliageModelList N(tree1_Leaves) = {
     .count = 3,
@@ -458,11 +468,13 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_802428B4) = { -309.0f, 0.0f, 31.0f, 0.0f };
 
-EvtSource N(802428C4) = SCRIPT({
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 4;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_802428B4);
-});
+EvtSource N(802428C4) = {
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 4, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802428B4)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_8024291C) = {
     .id = NPC_POSIE,

--- a/src/world/area_flo/flo_08/CAFAC0.c
+++ b/src/world/area_flo/flo_08/CAFAC0.c
@@ -36,15 +36,16 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_08_tattle },
 };
 
-EvtSource N(80241F40) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80241F40) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_80241FB0_CB0CF0)[] = {
     0x001D00F0, 0x001D00F1,
@@ -66,245 +67,257 @@ f32 N(D_80242008_CB0D48)[3] = {
     140.0f, 180.0f, 220.0f
 };
 
-EvtSource N(80242014) = SCRIPT({
-    sleep 10;
-    PlaySound(0x212D);
-    N(UnkFunc21)(EVT_MAP_VAR(0));
-    sleep 85;
-    spawn {
-        PlaySound(0x212E);
-        N(UnkFunc23)(70, 70);
-        sleep 27;
-        PlaySound(SOUND_208E);
-        N(UnkFunc23)(50, 50);
-    }
-    spawn {
-        sleep 3;
-        N(func_8024003C_CAED7C)(EVT_MAP_VAR(0));
-    }
-    spawn {
-        sleep 47;
-        N(UnkFunc22)();
-        N(UnkPartnerPosFunc)();
-        sleep 5;
-        N(UnkPartnerPosFunc2)();
-        sleep 5;
-        N(UnkPartnerPosFunc)();
-    }
-    sleep 3;
-    N(func_80240600_CAF340)(EVT_MAP_VAR(0));
-    sleep 30;
-});
+EvtSource N(80242014) = {
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PlaySound, 0x212D)
+    EVT_CALL(N(UnkFunc21), EVT_MAP_VAR(0))
+    EVT_WAIT_FRAMES(85)
+    EVT_THREAD
+        EVT_CALL(PlaySound, 0x212E)
+        EVT_CALL(N(UnkFunc23), 70, 70)
+        EVT_WAIT_FRAMES(27)
+        EVT_CALL(PlaySound, SOUND_208E)
+        EVT_CALL(N(UnkFunc23), 50, 50)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(N(func_8024003C_CAED7C), EVT_MAP_VAR(0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(47)
+        EVT_CALL(N(UnkFunc22))
+        EVT_CALL(N(UnkPartnerPosFunc))
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(N(UnkPartnerPosFunc2))
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(N(UnkPartnerPosFunc))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(3)
+    EVT_CALL(N(func_80240600_CAF340), EVT_MAP_VAR(0))
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242178) = SCRIPT({
-    if (EVT_SAVE_FLAG(1402) == 1) {
-        return;
-    }
-    IsStartingConversation(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        return;
-    }
-    N(UnkFunc40)();
-    if (EVT_VAR(0) == 1) {
-        return;
-    }
-    ModifyGlobalOverrideFlags(1, 2097152);
-    N(SetOverrideFlags_40)();
-    DisablePlayerInput(TRUE);
-    DisablePartnerAI(0);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-    N(UnkFunc20)(EVT_MAP_VAR(0), EVT_VAR(9));
-    FindKeyItem(ITEM_ULTRA_STONE, EVT_VAR(12));
-    N(UnkFunc38)();
-    if (EVT_VAR(0) == -1) {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DC), 160, 40);
-        sleep 10;
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    if (EVT_SAVE_FLAG(438) == 0) {
-        EVT_SAVE_FLAG(438) = 1;
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DA), 160, 40);
-    } else {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DB), 160, 40);
-    }
-    N(func_802401CC_CAEF0C)();
-    if (EVT_VAR(0) == -1) {
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EnablePartnerAI();
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != EVT_VAR(11)) {
-        N(SwitchToPartner)(EVT_VAR(11));
-    } else {
-        func_802CF56C(2);
-    }
-    sleep 10;
-    ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DF), 160, 40);
-    ShowChoice(MESSAGE_ID(0x1E, 0x000D));
-    CloseMessage();
-    if (EVT_VAR(0) != 0) {
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    await N(80242014);
-    N(UnkFunc18)(EVT_VAR(11), EVT_VAR(13));
-    EVT_SAVE_FLAG(1402) = 1;
-    N(UnkFunc39)(EVT_VAR(9));
-    N(UnkFunc19)();
-    if (EVT_VAR(13) == 1) {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DD), 160, 40);
-    } else {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DE), 160, 40);
-    }
-    DisablePlayerInput(FALSE);
-    EnablePartnerAI();
-    ModifyGlobalOverrideFlags(0, 2097152);
-    N(UnkFunc17)();
-});
+EvtSource N(80242178) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1402), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(IsStartingConversation, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(N(UnkFunc40))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(ModifyGlobalOverrideFlags, 1, 2097152)
+    EVT_CALL(N(SetOverrideFlags_40))
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(N(UnkFunc20), EVT_MAP_VAR(0), EVT_VAR(9))
+    EVT_CALL(FindKeyItem, ITEM_ULTRA_STONE, EVT_VAR(12))
+    EVT_CALL(N(UnkFunc38))
+    EVT_IF_EQ(EVT_VAR(0), -1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DC), 160, 40)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(438), 0)
+        EVT_SET(EVT_SAVE_FLAG(438), 1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DA), 160, 40)
+    EVT_ELSE
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DB), 160, 40)
+    EVT_END_IF
+    EVT_CALL(N(func_802401CC_CAEF0C))
+    EVT_IF_EQ(EVT_VAR(0), -1)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), EVT_VAR(11))
+        EVT_CALL(N(SwitchToPartner), EVT_VAR(11))
+    EVT_ELSE
+        EVT_CALL(func_802CF56C, 2)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DF), 160, 40)
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x000D))
+    EVT_CALL(CloseMessage)
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80242014))
+    EVT_CALL(N(UnkFunc18), EVT_VAR(11), EVT_VAR(13))
+    EVT_SET(EVT_SAVE_FLAG(1402), 1)
+    EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+    EVT_CALL(N(UnkFunc19))
+    EVT_IF_EQ(EVT_VAR(13), 1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DD), 160, 40)
+    EVT_ELSE
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DE), 160, 40)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+    EVT_CALL(N(UnkFunc17))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA910, -780, 120, -110, 0, MAKE_ENTITY_END);
-    EVT_MAP_VAR(0) = EVT_VAR(0);
-    AssignBlockFlag(EVT_SAVE_FLAG(1402));
-    AssignScript(N(80242178));
-    MakeItemEntity(ITEM_STAR_PIECE, 510, 0, -90, 17, EVT_SAVE_FLAG(1381));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA910, -780, 120, -110, 0, MAKE_ENTITY_END)
+    EVT_SET(EVT_MAP_VAR(0), EVT_VAR(0))
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1402))
+    EVT_CALL(AssignScript, EVT_PTR(N(80242178)))
+    EVT_CALL(MakeItemEntity, ITEM_STAR_PIECE, 510, 0, -90, 17, EVT_SAVE_FLAG(1381))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242680) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80242680) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024292C) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  6);
 
 EvtSource N(exitWalk_80242988) = EXIT_WALK_SCRIPT(60,  1, "flo_24",  0);
 
-EvtSource N(802429E4) = SCRIPT({
-    bind N(exitWalk_8024292C) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80242988) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(802429E4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_8024292C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80242988), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_80242A2C)[] = {
     0x00000009, 0xC4070000, 0x00000000, 0x42480000, 0x0000000A, 0x42700000, 0x00000000, 0x42480000,
     0x0000000F, 0x42700000, 0x00000000, 0x42480000, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80244EC4));
-    await N(makeEntities);
-    spawn N(80245F5C);
-    ModifyColliderFlags(3, 19, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_80242A2C));
-    }
-    EnableTexPanning(22, 1);
-    EnableTexPanning(23, 1);
-    EnableTexPanning(25, 1);
-    EnableTexPanning(27, 1);
-    EnableTexPanning(29, 1);
-    EnableTexPanning(31, 1);
-    EnableTexPanning(41, 1);
-    EnableTexPanning(24, 1);
-    EnableTexPanning(26, 1);
-    EnableTexPanning(28, 1);
-    EnableTexPanning(30, 1);
-    EnableTexPanning(32, 1);
-    spawn {
-        EVT_VAR(0) = 0;
-        EVT_VAR(1) = 0;
-0:
-        EVT_VAR(0) += 140;
-        if (EVT_VAR(0) > 65536) {
-            EVT_VAR(0) += -65536;
-        }
-        SetTexPanOffset(1, 0, EVT_VAR(0), 0);
-        EVT_VAR(1) += -200;
-        if (EVT_VAR(1) < 0) {
-            EVT_VAR(1) += 65536;
-        }
-        SetTexPanOffset(2, 0, EVT_VAR(1), 0);
-        sleep 1;
-        goto 0;
-    }
-    ModifyColliderFlags(3, 21, 0x00000006);
-    EVT_VAR(0) = 140;
-    EVT_VAR(1) = -137;
-    EVT_VAR(2) = 340;
-    EVT_VAR(3) = -60;
-    EVT_VAR(4) = 0;
-    spawn N(80242680);
-    EVT_VAR(0) = 450;
-    EVT_VAR(1) = -137;
-    EVT_VAR(2) = 590;
-    EVT_VAR(3) = -60;
-    EVT_VAR(4) = 0;
-    spawn N(80242680);
-    spawn N(80245914);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(802429E4);
-    spawn EnterWalk;
-    await N(80241F40);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240D40_CAFA80)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80244EC4)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80245F5C))
+    EVT_CALL(ModifyColliderFlags, 3, 19, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_80242A2C)))
+    EVT_END_THREAD
+    EVT_CALL(EnableTexPanning, 22, 1)
+    EVT_CALL(EnableTexPanning, 23, 1)
+    EVT_CALL(EnableTexPanning, 25, 1)
+    EVT_CALL(EnableTexPanning, 27, 1)
+    EVT_CALL(EnableTexPanning, 29, 1)
+    EVT_CALL(EnableTexPanning, 31, 1)
+    EVT_CALL(EnableTexPanning, 41, 1)
+    EVT_CALL(EnableTexPanning, 24, 1)
+    EVT_CALL(EnableTexPanning, 26, 1)
+    EVT_CALL(EnableTexPanning, 28, 1)
+    EVT_CALL(EnableTexPanning, 30, 1)
+    EVT_CALL(EnableTexPanning, 32, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_LABEL(0)
+        EVT_ADD(EVT_VAR(0), 140)
+        EVT_IF_GT(EVT_VAR(0), 65536)
+            EVT_ADD(EVT_VAR(0), -65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 1, 0, EVT_VAR(0), 0)
+        EVT_ADD(EVT_VAR(1), -200)
+        EVT_IF_LT(EVT_VAR(1), 0)
+            EVT_ADD(EVT_VAR(1), 65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 2, 0, EVT_VAR(1), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_CALL(ModifyColliderFlags, 3, 21, 0x00000006)
+    EVT_SET(EVT_VAR(0), 140)
+    EVT_SET(EVT_VAR(1), -137)
+    EVT_SET(EVT_VAR(2), 340)
+    EVT_SET(EVT_VAR(3), -60)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242680))
+    EVT_SET(EVT_VAR(0), 450)
+    EVT_SET(EVT_VAR(1), -137)
+    EVT_SET(EVT_VAR(2), 590)
+    EVT_SET(EVT_VAR(3), -60)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242680))
+    EVT_EXEC(N(80245914))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(802429E4)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80241F40))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240D40_CAFA80))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2EA8)[] = {
     0x00000000, 0x00000000,
@@ -325,19 +338,23 @@ NpcAISettings N(npcAISettings_80242EB0) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80242EE0) = SCRIPT({
-    N(func_8024150C_CB024C)(N(npcAISettings_80242EB0));
-});
+EvtSource N(npcAI_80242EE0) = {
+    EVT_CALL(N(func_8024150C_CB024C), EVT_PTR(N(npcAISettings_80242EB0)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242F00) = SCRIPT({
-0:
-    GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += 30;
-    EVT_VAR(2) -= 2;
-    PlayEffect(0x11, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 30, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep 15;
-    goto 0;
-});
+EvtSource N(80242F00) = {
+    EVT_LABEL(0)
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), 30)
+    EVT_SUB(EVT_VAR(2), 2)
+    EVT_CALL(PlayEffect, 0x11, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 30, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(15)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80242FB4) = {
     .height = 30,
@@ -370,9 +387,11 @@ NpcAISettings N(npcAISettings_8024300C) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_8024303C) = SCRIPT({
-    DoBasicAI(N(npcAISettings_8024300C));
-});
+EvtSource N(npcAI_8024303C) = {
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_8024300C)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024305C) = {
     .height = 30,
@@ -389,188 +408,187 @@ s32 N(D_8024308C_CB1DCC) = {
     0x00000000,
 };
 
-EvtSource N(80243090) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowConsumableChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_802419C4_CB0704)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80243090) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_802419C4_CB0704), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802431C4) = SCRIPT({
-    N(func_802419FC_CB073C)(EVT_VAR(0));
-    bind_padlock N(80243090) 0x10 0 N(D_802462C0_B4AA30);
-    N(func_80241970_CB06B0)(EVT_VAR(0));
-});
+EvtSource N(802431C4) = {
+    EVT_CALL(N(func_802419FC_CB073C), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80243090), 0x10, 0, EVT_PTR(D_802462C0_B4AA30), 0, 1)
+    EVT_CALL(N(func_80241970_CB06B0), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80243214) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    if (EVT_SAVE_FLAG(1364) == 0) {
-        GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamDistance(0, 350);
-        SetCamPitch(0, 18.5, -7.5);
-        SetCamSpeed(0, 4.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0,
-                      MESSAGE_ID(0x11, 0x0042));
-        SetPlayerAnimation(ANIM_THINKING);
-        N(func_80241BCC_CB090C)();
-        EVT_VAR(0) = 0x80246430;
-        EVT_VAR(1) = 0;
-        await N(802431C4);
-        match EVT_VAR(0) {
-            <= 0 {
-                SetPlayerAnimation(ANIM_STAND_STILL);
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0043));
-            } else {
-                EVT_VAR(8) = EVT_VAR(0);
-                N(func_80241B5C_CB089C)(EVT_VAR(0));
-                MakeItemEntity(EVT_VAR(8), -695, 20, -29, 1, 0);
-                EVT_VAR(7) = EVT_VAR(0);
-                PlaySoundAtNpc(NPC_SELF, SOUND_2095, 0);
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_3);
-                sleep 20;
-                RemoveItemEntity(EVT_VAR(7));
-                match EVT_VAR(8) {
-                    == 160 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0046));
-                        PlaySoundAtNpc(NPC_SELF, 0x21C, 0);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0);
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_7);
-                        PlaySoundAtCollider(17, 457, 0);
-                        ModifyColliderFlags(0, 17, 0x7FFFFE00);
-                        MakeLerp(0, 100, 30, 1);
-                        loop {
-                            UpdateLerp();
-                            EVT_VAR(8) = (float) EVT_VAR(0);
-                            EVT_VAR(9) = (float) EVT_VAR(0);
-                            EVT_VAR(8) *= 0.5;
-                            EVT_VAR(9) *= 1.2001953125;
-                            RotateModel(103, EVT_VAR(8), 0, 1, 0);
-                            RotateModel(104, EVT_VAR(8), 0, 1, 0);
-                            RotateModel(105, EVT_VAR(8), 0, 1, 0);
-                            RotateModel(99, EVT_VAR(9), 0, -1, 0);
-                            RotateModel(100, EVT_VAR(9), 0, -1, 0);
-                            RotateModel(101, EVT_VAR(9), 0, -1, 0);
-                            sleep 1;
-                            if (EVT_VAR(1) != 1) {
-                                break loop;
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_5);
-                        EVT_SAVE_FLAG(1364) = 1;
-                    }
-                    == 159 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0045));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1);
-                    }
-                    == 158 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0045));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1);
-                    } else {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0,
-                                      MESSAGE_ID(0x11, 0x0044));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_6);
-                        PlaySoundAtNpc(NPC_SELF, 0x2096, 0);
-                        MakeItemEntity(EVT_VAR(8), 125, 20, 0, 1, 0);
-                        EVT_VAR(7) = EVT_VAR(0);
-                        sleep 5;
-                        GetAngleToPlayer(-1, EVT_VAR(0));
-                        if (EVT_VAR(0) < 180) {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = -0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 0.900390625;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += -700.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -25.0;
-                                N(func_80241A98_CB07D8)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) == 0) {
-                                    break loop;
-                                }
-                            }
-                        } else {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = 0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 0.900390625;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += -690.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -25.0;
-                                N(func_80241A98_CB07D8)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) == 0) {
-                                    break loop;
-                                }
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1);
-                        RemoveItemEntity(EVT_VAR(7));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0);
-                    }
-                }
-            }
-        }
-        spawn {
-            ResetCam(0, 6.0);
-        }
-        sleep 10;
-    } else {
-        if (EVT_STORY_PROGRESS < STORY_CH6_STAR_SPIRIT_RESCUED) {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x0047));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x0048));
-        }
-    }
-    DisablePlayerInput(FALSE);
-    unbind;
-});
+EvtSource N(interact_80243214) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1364), 0)
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamDistance, 0, 350)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.5), EVT_FIXED(-7.5))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0042))
+        EVT_CALL(SetPlayerAnimation, ANIM_THINKING)
+        EVT_CALL(N(func_80241BCC_CB090C))
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(D_80246428)))
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_EXEC_WAIT(N(802431C4))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_LE(0)
+                EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0043))
+            EVT_CASE_DEFAULT
+                EVT_SET(EVT_VAR(8), EVT_VAR(0))
+                EVT_CALL(N(func_80241B5C_CB089C), EVT_VAR(0))
+                EVT_CALL(MakeItemEntity, EVT_VAR(8), -695, 20, -29, 1, 0)
+                EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2095, 0)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_3)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                EVT_SWITCH(EVT_VAR(8))
+                    EVT_CASE_EQ(160)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0046))
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x21C, 0)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0)
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_7)
+                        EVT_CALL(PlaySoundAtCollider, 17, 457, 0)
+                        EVT_CALL(ModifyColliderFlags, 0, 17, 0x7FFFFE00)
+                        EVT_CALL(MakeLerp, 0, 100, 30, 1)
+                        EVT_LOOP(0)
+                            EVT_CALL(UpdateLerp)
+                            EVT_SETF(EVT_VAR(8), EVT_VAR(0))
+                            EVT_SETF(EVT_VAR(9), EVT_VAR(0))
+                            EVT_MULF(EVT_VAR(8), EVT_FIXED(0.5))
+                            EVT_MULF(EVT_VAR(9), EVT_FIXED(1.2))
+                            EVT_CALL(RotateModel, 103, EVT_VAR(8), 0, 1, 0)
+                            EVT_CALL(RotateModel, 104, EVT_VAR(8), 0, 1, 0)
+                            EVT_CALL(RotateModel, 105, EVT_VAR(8), 0, 1, 0)
+                            EVT_CALL(RotateModel, 99, EVT_VAR(9), 0, -1, 0)
+                            EVT_CALL(RotateModel, 100, EVT_VAR(9), 0, -1, 0)
+                            EVT_CALL(RotateModel, 101, EVT_VAR(9), 0, -1, 0)
+                            EVT_WAIT_FRAMES(1)
+                            EVT_IF_NE(EVT_VAR(1), 1)
+                                EVT_BREAK_LOOP
+                            EVT_END_IF
+                        EVT_END_LOOP
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_5)
+                        EVT_SET(EVT_SAVE_FLAG(1364), 1)
+                    EVT_CASE_EQ(159)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0045))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1)
+                    EVT_CASE_EQ(158)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0045))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1)
+                    EVT_CASE_DEFAULT
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_4, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x0044))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_6)
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x2096, 0)
+                        EVT_CALL(MakeItemEntity, EVT_VAR(8), 125, 20, 0, 1, 0)
+                        EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(GetAngleToPlayer, -1, EVT_VAR(0))
+                        EVT_IF_LT(EVT_VAR(0), 180)
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(-0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(0.9))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(-700.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-25.0))
+                                EVT_CALL(N(func_80241A98_CB07D8), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_EQ(EVT_VAR(1), 0)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_ELSE
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(0.9))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(-690.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-25.0))
+                                EVT_CALL(N(func_80241A98_CB07D8), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_EQ(EVT_VAR(1), 0)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_END_IF
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1)
+                        EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_1)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_02_Anim_2, NPC_ANIM_gate_flower_Palette_02_Anim_1, 0)
+                EVT_END_SWITCH
+        EVT_END_SWITCH
+        EVT_THREAD
+            EVT_CALL(ResetCam, 0, EVT_FIXED(6.0))
+        EVT_END_THREAD
+        EVT_WAIT_FRAMES(10)
+    EVT_ELSE
+        EVT_IF_LT(EVT_SAVE_VAR(0), 57)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0, MESSAGE_ID(0x11, 0x0047))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_9, NPC_ANIM_gate_flower_Palette_02_Anim_8, 0, MESSAGE_ID(0x11, 0x0048))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80243B20) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_80243214));
-    if (EVT_SAVE_FLAG(1364) == 1) {
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_5);
-        ModifyColliderFlags(0, 17, 0x7FFFFE00);
-        RotateModel(103, 50, 0, 1, 0);
-        RotateModel(104, 50, 0, 1, 0);
-        RotateModel(105, 50, 0, 1, 0);
-        RotateModel(99, 120, 0, -1, 0);
-        RotateModel(100, 120, 0, -1, 0);
-        RotateModel(101, 120, 0, -1, 0);
-    }
-});
+EvtSource N(init_80243B20) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80243214)))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1364), 1)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_02_Anim_5)
+        EVT_CALL(ModifyColliderFlags, 0, 17, 0x7FFFFE00)
+        EVT_CALL(RotateModel, 103, 50, 0, 1, 0)
+        EVT_CALL(RotateModel, 104, 50, 0, 1, 0)
+        EVT_CALL(RotateModel, 105, 50, 0, 1, 0)
+        EVT_CALL(RotateModel, 99, 120, 0, -1, 0)
+        EVT_CALL(RotateModel, 100, 120, 0, -1, 0)
+        EVT_CALL(RotateModel, 101, 120, 0, -1, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80243C48) = {
     .id = NPC_GATE_FLOWER,
@@ -862,24 +880,26 @@ StaticNpc N(npcGroup_802449D8) = {
     .unk_1E0 = { 00, 00, 00, 03, 00, 00, 00, 00},
 };
 
-EvtSource N(init_80244BC8) = SCRIPT({
-    spawn {
-        sleep 2;
-        GetNpcPointer(2, EVT_VAR(0));
-        if (EVT_VAR(0) == 0) {
-            RemoveNpc(NPC_SELF);
-            return;
-        }
-        RandInt(100, EVT_VAR(0));
-        if (EVT_VAR(0) < 30) {
-            SetNpcFlagBits(NPC_DAYZEE1, ((0x00000002 | NPC_FLAG_4)), TRUE);
-            SetNpcPos(NPC_DAYZEE1, 0, -1000, 0);
-        } else {
-            SetNpcFlagBits(NPC_SELF, ((0x00000002 | NPC_FLAG_4)), TRUE);
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_80244BC8) = {
+    EVT_THREAD
+        EVT_WAIT_FRAMES(2)
+        EVT_CALL(GetNpcPointer, 2, EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+            EVT_RETURN
+        EVT_END_IF
+        EVT_CALL(RandInt, 100, EVT_VAR(0))
+        EVT_IF_LT(EVT_VAR(0), 30)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_2 | NPC_FLAG_4)), TRUE)
+            EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+        EVT_ELSE
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_2 | NPC_FLAG_4)), TRUE)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_END_IF
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80244CD4) = {
     .id = NPC_DAYZEE7,
@@ -1281,134 +1301,142 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_80245904) = { 391.0f, 0.0f, -102.0f, 0.0f };
 
-EvtSource N(80245914) = SCRIPT({
-    EVT_AREA_FLAG(29) = 0;
-    EVT_AREA_FLAG(30) = 0;
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 22;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80245904);
-});
+EvtSource N(80245914) = {
+    EVT_SET(EVT_AREA_FLAG(29), 0)
+    EVT_SET(EVT_AREA_FLAG(30), 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 22, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80245904)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_598C) = {
     0x00000000,
 };
 
-EvtSource N(80245990) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80245990) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245C3C) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(6);
-    EVT_VAR(8) = EVT_VAR(5);
-    EVT_VAR(7) = EVT_VAR(4);
-    EVT_VAR(6) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(2);
-    EVT_VAR(4) = EVT_VAR(1);
-    EVT_VAR(3) = EVT_VAR(0);
-    EnableModel(EVT_VAR(6), 0);
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(UnkFunc43)();
-    if (EVT_VAR(0) == 0) {
-        sleep 1;
-        goto 0;
-    }
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    if (EVT_VAR(10) != 0) {
-        spawn {
-            sleep 5;
-            EVT_VAR(0) = EVT_VAR(3);
-            EVT_VAR(1) = EVT_VAR(4);
-            EVT_VAR(2) = EVT_VAR(5);
-            EVT_VAR(1) += 10;
-            EVT_VAR(2) += 8;
-            PlayEffect(0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) -= 10;
-            MakeItemEntity(EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0);
-        }
-    }
-    spawn {
-        sleep 10;
-        PlaySoundAt(0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 1, 0, 0);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 1, 0, 0);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(80245C3C) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(6))
+    EVT_SET(EVT_VAR(8), EVT_VAR(5))
+    EVT_SET(EVT_VAR(7), EVT_VAR(4))
+    EVT_SET(EVT_VAR(6), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(2))
+    EVT_SET(EVT_VAR(4), EVT_VAR(1))
+    EVT_SET(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(UnkFunc43))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(5)
+            EVT_SET(EVT_VAR(0), EVT_VAR(3))
+            EVT_SET(EVT_VAR(1), EVT_VAR(4))
+            EVT_SET(EVT_VAR(2), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_ADD(EVT_VAR(2), 8)
+            EVT_CALL(PlayEffect, 0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_SUB(EVT_VAR(1), 10)
+            EVT_CALL(MakeItemEntity, EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAt, 0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 1, 0, 0)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245F5C) = SCRIPT({
-    GetModelCenter(60);
-    EVT_VAR(3) = 60;
-    EVT_VAR(4) = 61;
-    EVT_VAR(5) = 62;
-    EVT_VAR(6) = 63;
-    EVT_VAR(10) = 0;
-    spawn N(80245C3C);
-    GetModelCenter(54);
-    EVT_VAR(3) = 54;
-    EVT_VAR(4) = 55;
-    EVT_VAR(5) = 56;
-    EVT_VAR(6) = 57;
-    EVT_VAR(10) = 0;
-    spawn N(80245C3C);
-    GetModelCenter(48);
-    EVT_VAR(3) = 48;
-    EVT_VAR(4) = 49;
-    EVT_VAR(5) = 50;
-    EVT_VAR(6) = 51;
-    EVT_VAR(10) = 0;
-    spawn N(80245C3C);
-    GetModelCenter(67);
-    EVT_VAR(3) = 67;
-    EVT_VAR(4) = 66;
-    EVT_VAR(5) = 68;
-    EVT_VAR(6) = 69;
-    EVT_VAR(10) = 174;
-    spawn N(80245C3C);
-});
+EvtSource N(80245F5C) = {
+    EVT_CALL(GetModelCenter, 60)
+    EVT_SET(EVT_VAR(3), 60)
+    EVT_SET(EVT_VAR(4), 61)
+    EVT_SET(EVT_VAR(5), 62)
+    EVT_SET(EVT_VAR(6), 63)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80245C3C))
+    EVT_CALL(GetModelCenter, 54)
+    EVT_SET(EVT_VAR(3), 54)
+    EVT_SET(EVT_VAR(4), 55)
+    EVT_SET(EVT_VAR(5), 56)
+    EVT_SET(EVT_VAR(6), 57)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80245C3C))
+    EVT_CALL(GetModelCenter, 48)
+    EVT_SET(EVT_VAR(3), 48)
+    EVT_SET(EVT_VAR(4), 49)
+    EVT_SET(EVT_VAR(5), 50)
+    EVT_SET(EVT_VAR(6), 51)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80245C3C))
+    EVT_CALL(GetModelCenter, 67)
+    EVT_SET(EVT_VAR(3), 67)
+    EVT_SET(EVT_VAR(4), 66)
+    EVT_SET(EVT_VAR(5), 68)
+    EVT_SET(EVT_VAR(6), 69)
+    EVT_SET(EVT_VAR(10), 174)
+    EVT_EXEC(N(80245C3C))
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_08/flo_08.h
+++ b/src/world/area_flo/flo_08/flo_08.h
@@ -43,3 +43,4 @@ extern s32 N(D_80241FB0_CB0CF0)[];
 extern s16 N(D_80241FB8_CB0CF8)[];
 extern s32 N(D_80241FC8_CB0D08)[8][2];
 extern f32 N(D_80242008_CB0D48)[3];
+extern s32 D_802462C0_B4AA30;

--- a/src/world/area_flo/flo_09/CB50E0.c
+++ b/src/world/area_flo/flo_09/CB50E0.c
@@ -23,257 +23,270 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_09_tattle },
 };
 
-EvtSource N(80241880) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80241880) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802418F0) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(802418F0) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80241B9C) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  5);
 
 EvtSource N(exitWalk_80241BF8) = EXIT_WALK_SCRIPT(60,  1, "flo_03",  0);
 
-EvtSource N(80241C54) = SCRIPT({
-    bind N(exitWalk_80241B9C) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80241BF8) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80241C54) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80241B9C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80241BF8), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_8024414C));
-    spawn N(802425DC);
-    spawn N(802434A8);
-    ModifyColliderFlags(3, 9, 0x00000006);
-    EVT_VAR(0) = -511;
-    EVT_VAR(1) = -4;
-    EVT_VAR(2) = -319;
-    EVT_VAR(3) = 10;
-    EVT_VAR(4) = 0;
-    spawn N(802418F0);
-    EVT_VAR(0) = -302;
-    EVT_VAR(1) = 77;
-    EVT_VAR(2) = -32;
-    EVT_VAR(3) = 116;
-    EVT_VAR(4) = 0;
-    spawn N(802418F0);
-    EVT_VAR(0) = 51;
-    EVT_VAR(1) = 18;
-    EVT_VAR(2) = 141;
-    EVT_VAR(3) = 127;
-    EVT_VAR(4) = 0;
-    spawn N(802418F0);
-    EVT_VAR(0) = 234;
-    EVT_VAR(1) = 38;
-    EVT_VAR(2) = 502;
-    EVT_VAR(3) = 98;
-    EVT_VAR(4) = 0;
-    spawn N(802418F0);
-    EVT_VAR(0) = -525;
-    EVT_VAR(1) = -163;
-    EVT_VAR(2) = -400;
-    EVT_VAR(3) = -80;
-    EVT_VAR(4) = 60;
-    spawn N(802418F0);
-    EVT_VAR(0) = -346;
-    EVT_VAR(1) = -148;
-    EVT_VAR(2) = 517;
-    EVT_VAR(3) = -91;
-    EVT_VAR(4) = 60;
-    spawn N(802418F0);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80241C54);
-    spawn EnterWalk;
-    await N(80241880);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CB5000)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_8024414C)))
+    EVT_EXEC(N(802425DC))
+    EVT_EXEC(N(802434A8))
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000006)
+    EVT_SET(EVT_VAR(0), -511)
+    EVT_SET(EVT_VAR(1), -4)
+    EVT_SET(EVT_VAR(2), -319)
+    EVT_SET(EVT_VAR(3), 10)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802418F0))
+    EVT_SET(EVT_VAR(0), -302)
+    EVT_SET(EVT_VAR(1), 77)
+    EVT_SET(EVT_VAR(2), -32)
+    EVT_SET(EVT_VAR(3), 116)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802418F0))
+    EVT_SET(EVT_VAR(0), 51)
+    EVT_SET(EVT_VAR(1), 18)
+    EVT_SET(EVT_VAR(2), 141)
+    EVT_SET(EVT_VAR(3), 127)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802418F0))
+    EVT_SET(EVT_VAR(0), 234)
+    EVT_SET(EVT_VAR(1), 38)
+    EVT_SET(EVT_VAR(2), 502)
+    EVT_SET(EVT_VAR(3), 98)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802418F0))
+    EVT_SET(EVT_VAR(0), -525)
+    EVT_SET(EVT_VAR(1), -163)
+    EVT_SET(EVT_VAR(2), -400)
+    EVT_SET(EVT_VAR(3), -80)
+    EVT_SET(EVT_VAR(4), 60)
+    EVT_EXEC(N(802418F0))
+    EVT_SET(EVT_VAR(0), -346)
+    EVT_SET(EVT_VAR(1), -148)
+    EVT_SET(EVT_VAR(2), 517)
+    EVT_SET(EVT_VAR(3), -91)
+    EVT_SET(EVT_VAR(4), 60)
+    EVT_EXEC(N(802418F0))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80241C54)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80241880))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CB5000))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2004)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80242010) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80242010) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802422BC) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(6);
-    EVT_VAR(8) = EVT_VAR(5);
-    EVT_VAR(7) = EVT_VAR(4);
-    EVT_VAR(6) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(2);
-    EVT_VAR(4) = EVT_VAR(1);
-    EVT_VAR(3) = EVT_VAR(0);
-    EnableModel(EVT_VAR(6), 0);
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(UnkFunc43)();
-    if (EVT_VAR(0) == 0) {
-        sleep 1;
-        goto 0;
-    }
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    if (EVT_VAR(10) != 0) {
-        spawn {
-            sleep 5;
-            EVT_VAR(0) = EVT_VAR(3);
-            EVT_VAR(1) = EVT_VAR(4);
-            EVT_VAR(2) = EVT_VAR(5);
-            EVT_VAR(1) += 10;
-            EVT_VAR(2) += 8;
-            PlayEffect(0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) -= 10;
-            MakeItemEntity(EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0);
-        }
-    }
-    spawn {
-        sleep 10;
-        PlaySoundAt(0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 1, 0, 0);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 1, 0, 0);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(802422BC) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(6))
+    EVT_SET(EVT_VAR(8), EVT_VAR(5))
+    EVT_SET(EVT_VAR(7), EVT_VAR(4))
+    EVT_SET(EVT_VAR(6), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(2))
+    EVT_SET(EVT_VAR(4), EVT_VAR(1))
+    EVT_SET(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(UnkFunc43))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(5)
+            EVT_SET(EVT_VAR(0), EVT_VAR(3))
+            EVT_SET(EVT_VAR(1), EVT_VAR(4))
+            EVT_SET(EVT_VAR(2), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_ADD(EVT_VAR(2), 8)
+            EVT_CALL(PlayEffect, 0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_SUB(EVT_VAR(1), 10)
+            EVT_CALL(MakeItemEntity, EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAt, 0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 1, 0, 0)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802425DC) = SCRIPT({
-    GetModelCenter(69);
-    EVT_VAR(3) = 69;
-    EVT_VAR(4) = 70;
-    EVT_VAR(5) = 71;
-    EVT_VAR(6) = 72;
-    EVT_VAR(10) = 0;
-    spawn N(802422BC);
-    GetModelCenter(75);
-    EVT_VAR(3) = 75;
-    EVT_VAR(4) = 76;
-    EVT_VAR(5) = 77;
-    EVT_VAR(6) = 78;
-    EVT_VAR(10) = 174;
-    spawn N(802422BC);
-    GetModelCenter(83);
-    EVT_VAR(3) = 83;
-    EVT_VAR(4) = 84;
-    EVT_VAR(5) = 85;
-    EVT_VAR(6) = 86;
-    EVT_VAR(10) = 0;
-    spawn N(802422BC);
-    GetModelCenter(89);
-    EVT_VAR(3) = 89;
-    EVT_VAR(4) = 90;
-    EVT_VAR(5) = 91;
-    EVT_VAR(6) = 92;
-    EVT_VAR(10) = 0;
-    spawn N(802422BC);
-    GetModelCenter(97);
-    EVT_VAR(3) = 97;
-    EVT_VAR(4) = 98;
-    EVT_VAR(5) = 99;
-    EVT_VAR(6) = 100;
-    EVT_VAR(10) = 0;
-    spawn N(802422BC);
-    GetModelCenter(103);
-    EVT_VAR(3) = 103;
-    EVT_VAR(4) = 104;
-    EVT_VAR(5) = 105;
-    EVT_VAR(6) = 106;
-    EVT_VAR(10) = 0;
-    spawn N(802422BC);
-});
+EvtSource N(802425DC) = {
+    EVT_CALL(GetModelCenter, 69)
+    EVT_SET(EVT_VAR(3), 69)
+    EVT_SET(EVT_VAR(4), 70)
+    EVT_SET(EVT_VAR(5), 71)
+    EVT_SET(EVT_VAR(6), 72)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802422BC))
+    EVT_CALL(GetModelCenter, 75)
+    EVT_SET(EVT_VAR(3), 75)
+    EVT_SET(EVT_VAR(4), 76)
+    EVT_SET(EVT_VAR(5), 77)
+    EVT_SET(EVT_VAR(6), 78)
+    EVT_SET(EVT_VAR(10), 174)
+    EVT_EXEC(N(802422BC))
+    EVT_CALL(GetModelCenter, 83)
+    EVT_SET(EVT_VAR(3), 83)
+    EVT_SET(EVT_VAR(4), 84)
+    EVT_SET(EVT_VAR(5), 85)
+    EVT_SET(EVT_VAR(6), 86)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802422BC))
+    EVT_CALL(GetModelCenter, 89)
+    EVT_SET(EVT_VAR(3), 89)
+    EVT_SET(EVT_VAR(4), 90)
+    EVT_SET(EVT_VAR(5), 91)
+    EVT_SET(EVT_VAR(6), 92)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802422BC))
+    EVT_CALL(GetModelCenter, 97)
+    EVT_SET(EVT_VAR(3), 97)
+    EVT_SET(EVT_VAR(4), 98)
+    EVT_SET(EVT_VAR(5), 99)
+    EVT_SET(EVT_VAR(6), 100)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802422BC))
+    EVT_CALL(GetModelCenter, 103)
+    EVT_SET(EVT_VAR(3), 103)
+    EVT_SET(EVT_VAR(4), 104)
+    EVT_SET(EVT_VAR(5), 105)
+    EVT_SET(EVT_VAR(6), 106)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802422BC))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2874)[] = {
     0x00000000, 0x00000000, 0x00000000,
@@ -281,49 +294,57 @@ static s32 N(pad_2874)[] = {
 
 #include "world/common/foliage.inc.c"
 
-EvtSource N(802431E4) = SCRIPT({
-    GetNpcPos(NPC_BZZAP1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(1) < 0) {
-        GetModelCenter(EVT_VAR(9));
-        EVT_VAR(2) += 35;
-        SetNpcPos(NPC_BZZAP1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    }
-});
+EvtSource N(802431E4) = {
+    EVT_CALL(GetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_LT(EVT_VAR(1), 0)
+        EVT_CALL(GetModelCenter, EVT_VAR(9))
+        EVT_ADD(EVT_VAR(2), 35)
+        EVT_CALL(SetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(tree1_Callback) = SCRIPT({
-    if (EVT_SAVE_FLAG(1382) == 0) {
-        if (EVT_AREA_VAR(5) == 1) {
-            MakeItemEntity(ITEM_HAPPY_FLOWER_B, -250, 100, 0, 13, EVT_SAVE_FLAG(1382));
-        } else {
-            EVT_VAR(9) = 14;
-            spawn N(802431E4);
-        }
-        EVT_AREA_VAR(4) = 0;
-        EVT_AREA_VAR(5) = 0;
-    }
-});
+EvtSource N(tree1_Callback) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1382), 0)
+        EVT_IF_EQ(EVT_AREA_VAR(5), 1)
+            EVT_CALL(MakeItemEntity, ITEM_HAPPY_FLOWER_B, -250, 100, 0, 13, EVT_SAVE_FLAG(1382))
+        EVT_ELSE
+            EVT_SET(EVT_VAR(9), 14)
+            EVT_EXEC(N(802431E4))
+        EVT_END_IF
+        EVT_SET(EVT_AREA_VAR(4), 0)
+        EVT_SET(EVT_AREA_VAR(5), 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(tree2_Callback) = SCRIPT({
-    if (EVT_SAVE_FLAG(1382) == 0) {
-        EVT_AREA_VAR(4) = 1;
-        EVT_AREA_VAR(5) = 0;
-    }
-});
+EvtSource N(tree2_Callback) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1382), 0)
+        EVT_SET(EVT_AREA_VAR(4), 1)
+        EVT_SET(EVT_AREA_VAR(5), 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(tree3_Callback) = SCRIPT({
-    if (EVT_SAVE_FLAG(1382) == 0) {
-        if (EVT_AREA_VAR(4) == 1) {
-            if (EVT_AREA_VAR(5) == 0) {
-                EVT_AREA_VAR(5) = 1;
-                return;
-            }
-        }
-        EVT_VAR(9) = 22;
-        spawn N(802431E4);
-        EVT_AREA_VAR(4) = 0;
-        EVT_AREA_VAR(5) = 0;
-    }
-});
+EvtSource N(tree3_Callback) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1382), 0)
+        EVT_IF_EQ(EVT_AREA_VAR(4), 1)
+            EVT_IF_EQ(EVT_AREA_VAR(5), 0)
+                EVT_SET(EVT_AREA_VAR(5), 1)
+                EVT_RETURN
+            EVT_END_IF
+        EVT_END_IF
+        EVT_SET(EVT_VAR(9), 22)
+        EVT_EXEC(N(802431E4))
+        EVT_SET(EVT_AREA_VAR(4), 0)
+        EVT_SET(EVT_AREA_VAR(5), 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 FoliageModelList N(tree1_Leaves) = {
     .count = 2,
@@ -379,19 +400,21 @@ ShakeTreeConfig N(tree3) = {
 
 Vec4f N(triggerCoord_80243498) = { 200.0f, 0.0f, 1.0f, 0.0f };
 
-EvtSource N(802434A8) = SCRIPT({
-    EVT_AREA_VAR(4) = 0;
-    EVT_AREA_VAR(5) = 0;
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 15;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80243428);
-    EVT_VAR(0) = N(tree2);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 16;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80243460);
-    EVT_VAR(0) = N(tree3);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 17;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80243498);
-});
+EvtSource N(802434A8) = {
+    EVT_SET(EVT_AREA_VAR(4), 0)
+    EVT_SET(EVT_AREA_VAR(5), 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 15, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80243428)), 1, 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree2)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 16, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80243460)), 1, 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree3)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 17, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80243498)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_802435B0) = {
     .moveSpeed = 1.0f,
@@ -408,9 +431,11 @@ NpcAISettings N(npcAISettings_802435B0) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802435E0) = SCRIPT({
-    DoBasicAI(N(npcAISettings_802435B0));
-});
+EvtSource N(npcAI_802435E0) = {
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_802435B0)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80243600) = {
     .height = 30,
@@ -441,13 +466,15 @@ NpcAISettings N(npcAISettings_80243644) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80243674) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -630);
-    SetSelfVar(6, 50);
-    SetSelfVar(1, 200);
-    N(func_8024162C_CB662C)(N(npcAISettings_80243644));
-});
+EvtSource N(npcAI_80243674) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -630)
+    EVT_CALL(SetSelfVar, 6, 50)
+    EVT_CALL(SetSelfVar, 1, 200)
+    EVT_CALL(N(func_8024162C_CB662C), EVT_PTR(N(npcAISettings_80243644)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802436E4) = {
     .height = 26,
@@ -464,51 +491,53 @@ NpcSettings N(npcSettings_80243710) = {
     .level = 99,
 };
 
-EvtSource N(npcAI_8024373C) = SCRIPT({
-    loop {
-        GetSelfVar(0, EVT_VAR(0));
-        match EVT_VAR(0) {
-            == 0 {
-                GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                if (EVT_VAR(1) > 0) {
-                    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    SetNpcJumpscale(NPC_SELF, 0);
-                    NpcJump0(NPC_SELF, EVT_VAR(0), 50, EVT_VAR(2), 15);
-                    SetSelfVar(0, 1);
-                    BindNpcAI(NPC_SELF, N(npcAI_80243674));
-                }
-            }
-            == 2 {
-                DisablePlayerInput(TRUE);
-                sleep 25;
-                SetNpcPos(NPC_SELF, 0, -1000, 0);
-                SetNpcFlagBits(NPC_SELF, ((0x00000002)), FALSE);
-                SetSelfVar(0, 0);
-                DisablePlayerInput(FALSE);
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(npcAI_8024373C) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_EQ(0)
+                EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_IF_GT(EVT_VAR(1), 0)
+                    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_CALL(SetNpcJumpscale, NPC_SELF, 0)
+                    EVT_CALL(NpcJump0, NPC_SELF, EVT_VAR(0), 50, EVT_VAR(2), 15)
+                    EVT_CALL(SetSelfVar, 0, 1)
+                    EVT_CALL(BindNpcAI, NPC_SELF, EVT_PTR(N(npcAI_80243674)))
+                EVT_END_IF
+            EVT_CASE_EQ(2)
+                EVT_CALL(DisablePlayerInput, TRUE)
+                EVT_WAIT_FRAMES(25)
+                EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+                EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_2)), FALSE)
+                EVT_CALL(SetSelfVar, 0, 0)
+                EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_END_SWITCH
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802438C8) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetSelfVar(0, 2);
-            BindNpcAI(NPC_SELF, N(npcAI_8024373C));
-            DoNpcDefeat();
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_802438C8) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetSelfVar, 0, 2)
+            EVT_CALL(BindNpcAI, NPC_SELF, EVT_PTR(N(npcAI_8024373C)))
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80243954) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(npcAI_8024373C));
-    BindNpcDefeat(NPC_SELF, N(defeat_802438C8));
-});
+EvtSource N(init_80243954) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_8024373C)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802438C8)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_8024398C) = {
     .id = NPC_DAYZEE0,

--- a/src/world/area_flo/flo_10/CBA430.c
+++ b/src/world/area_flo/flo_10/CBA430.c
@@ -32,8 +32,10 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_80244A40) = { 137.0f, 0.0f, -283.0f, 0.0f };
 
-EvtSource N(80244A50) = SCRIPT({
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 9;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80244A40);
-});
+EvtSource N(80244A50) = {
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 9, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80244A40)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_11/CBDCD0.c
+++ b/src/world/area_flo/flo_11/CBDCD0.c
@@ -26,390 +26,421 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_11_tattle },
 };
 
-EvtSource N(802403E0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(802403E0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240450) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80240450) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802406FC) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    DisablePartnerAI(0);
-    HidePlayerShadow(TRUE);
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        EnableNpcShadow(NPC_PARTNER, FALSE);
-        SetNpcPos(NPC_PARTNER, 0, -1000, 0);
-    }
-    GetEntryID(EVT_VAR(0));
-    N(GetEntryPos)();
-    EVT_VAR(2) -= 40;
-    SetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    InterpPlayerYaw(EVT_VAR(4), 0);
-    PlaySound(0x163);
-    func_802D286C(256);
-    func_802D2520(ANIM_STAND_STILL, 5, 2, 1, 1, 0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    loop 40 {
-        EVT_VAR(1) += 1;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-    }
-    sleep 3;
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        spawn {
-            DisablePartnerAI(0);
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(2) -= 3;
-            SetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetNpcFlagBits(NPC_PARTNER, ((0x00000002)), FALSE);
-            EnablePartnerAI();
-            EnableNpcShadow(NPC_PARTNER, TRUE);
-        }
-    }
-    sleep 2;
-    func_802D2520(ANIM_STAND_STILL, 0, 0, 0, 0, 0);
-    sleep 1;
-    SetPlayerAnimation(ANIM_10002);
-    DisablePlayerPhysics(FALSE);
-    DisablePlayerInput(FALSE);
-    HidePlayerShadow(FALSE);
-0:
-    N(GetCurrentFloor)();
-    sleep 1;
-    if (EVT_VAR(0) != -1) {
-        goto 0;
-    }
-    spawn 0xFE363C8A;
-});
+EvtSource N(802406FC) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(EnableNpcShadow, NPC_PARTNER, FALSE)
+        EVT_CALL(SetNpcPos, NPC_PARTNER, 0, -1000, 0)
+    EVT_END_IF
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_CALL(N(GetEntryPos))
+    EVT_SUB(EVT_VAR(2), 40)
+    EVT_CALL(SetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_CALL(InterpPlayerYaw, EVT_VAR(4), 0)
+    EVT_CALL(PlaySound, 0x163)
+    EVT_CALL(func_802D286C, 256)
+    EVT_CALL(func_802D2520, ANIM_STAND_STILL, 5, 2, 1, 1, 0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_LOOP(40)
+        EVT_ADD(EVT_VAR(1), 1)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(3)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_THREAD
+            EVT_CALL(DisablePartnerAI, 0)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_SUB(EVT_VAR(2), 3)
+            EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_2)), FALSE)
+            EVT_CALL(EnablePartnerAI)
+            EVT_CALL(EnableNpcShadow, NPC_PARTNER, TRUE)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_WAIT_FRAMES(2)
+    EVT_CALL(func_802D2520, ANIM_STAND_STILL, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(HidePlayerShadow, FALSE)
+    EVT_LABEL(0)
+    EVT_CALL(N(GetCurrentFloor))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_NE(EVT_VAR(0), -1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_EXEC(EVT_VAR(10))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240A50) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    HidePlayerShadow(TRUE);
-    ModifyColliderFlags(0, EVT_VAR(11), 0x7FFFFE00);
-    GetEntryID(EVT_VAR(0));
-    N(GetEntryPos)();
-    EVT_VAR(5) = EVT_VAR(1);
-    EVT_VAR(6) = EVT_VAR(2);
-    EVT_VAR(7) = EVT_VAR(3);
-    EVT_VAR(2) += 2;
-    SetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    InterpPlayerYaw(EVT_VAR(4), 0);
-    if (EVT_VAR(4) == 90) {
-        EVT_VAR(5) += 40;
-    } else {
-        EVT_VAR(5) -= 40;
-    }
-    UseSettingsFrom(0, EVT_VAR(5), EVT_VAR(6), EVT_VAR(7));
-    SetPanTarget(0, EVT_VAR(5), EVT_VAR(6), EVT_VAR(7));
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        DisablePartnerAI(0);
-        EnableNpcShadow(NPC_PARTNER, FALSE);
-        SetNpcPos(NPC_PARTNER, 0, -1000, 0);
-        InterpNpcYaw(NPC_PARTNER, EVT_VAR(0), 0);
-    }
-    sleep 1;
-    PlaySound(0x163);
-    spawn {
-        sleep 25;
-        HidePlayerShadow(FALSE);
-    }
-    func_802D286C(2304);
-    func_802D2520(ANIM_10002, 5, 3, 1, 1, 0);
-    loop 40 {
-        N(SomeXYZFunc2)(1.0);
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-    }
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        spawn {
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(2) -= 3;
-            SetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EnableNpcShadow(NPC_PARTNER, TRUE);
-            EnablePartnerAI();
-        }
-    }
-    sleep 5;
-    func_802D2520(ANIM_10002, 0, 0, 0, 0, 0);
-    ModifyColliderFlags(1, EVT_VAR(11), 0x7FFFFE00);
-    DisablePlayerInput(FALSE);
-    DisablePlayerPhysics(FALSE);
-    PanToTarget(0, 0, 0);
-    spawn 0xFE363C8A;
-});
+EvtSource N(80240A50) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_CALL(ModifyColliderFlags, 0, EVT_VAR(11), 0x7FFFFE00)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_CALL(N(GetEntryPos))
+    EVT_SET(EVT_VAR(5), EVT_VAR(1))
+    EVT_SET(EVT_VAR(6), EVT_VAR(2))
+    EVT_SET(EVT_VAR(7), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(2), 2)
+    EVT_CALL(SetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_CALL(InterpPlayerYaw, EVT_VAR(4), 0)
+    EVT_IF_EQ(EVT_VAR(4), 90)
+        EVT_ADD(EVT_VAR(5), 40)
+    EVT_ELSE
+        EVT_SUB(EVT_VAR(5), 40)
+    EVT_END_IF
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(5), EVT_VAR(6), EVT_VAR(7))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(5), EVT_VAR(6), EVT_VAR(7))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(DisablePartnerAI, 0)
+        EVT_CALL(EnableNpcShadow, NPC_PARTNER, FALSE)
+        EVT_CALL(SetNpcPos, NPC_PARTNER, 0, -1000, 0)
+        EVT_CALL(InterpNpcYaw, NPC_PARTNER, EVT_VAR(0), 0)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(PlaySound, 0x163)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(25)
+        EVT_CALL(HidePlayerShadow, FALSE)
+    EVT_END_THREAD
+    EVT_CALL(func_802D286C, 2304)
+    EVT_CALL(func_802D2520, ANIM_10002, 5, 3, 1, 1, 0)
+    EVT_LOOP(40)
+        EVT_CALL(N(SomeXYZFunc2), EVT_FIXED(1.0))
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_THREAD
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_SUB(EVT_VAR(2), 3)
+            EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(EnableNpcShadow, NPC_PARTNER, TRUE)
+            EVT_CALL(EnablePartnerAI)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(func_802D2520, ANIM_10002, 0, 0, 0, 0, 0)
+    EVT_CALL(ModifyColliderFlags, 1, EVT_VAR(11), 0x7FFFFE00)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_EXEC(EVT_VAR(10))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240E40) = SCRIPT({
-    N(UnkFunc25)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    GetCurrentPartner(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        GetCurrentPartnerID(EVT_VAR(1));
-        if (EVT_VAR(1) != 6) {
-            return;
-        } else {
-            func_802D2B6C();
-            DisablePlayerInput(TRUE);
-        }
-    } else {
-        DisablePlayerInput(TRUE);
-    }
-    await N(80240F1C);
-});
+EvtSource N(80240E40) = {
+    EVT_CALL(N(UnkFunc25))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(GetCurrentPartner, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(GetCurrentPartnerID, EVT_VAR(1))
+        EVT_IF_NE(EVT_VAR(1), 6)
+            EVT_RETURN
+        EVT_ELSE
+            EVT_CALL(func_802D2B6C)
+            EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_END_IF
+    EVT_ELSE
+        EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80240F1C))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240F1C) = SCRIPT({
-    N(SetPlayerStatusAnimFlags100000)();
-    group 27;
-    DisablePlayerPhysics(TRUE);
-    HidePlayerShadow(TRUE);
-    EVT_VAR(0) = EVT_VAR(10);
-    N(GetEntryPos)();
-    PlayerMoveTo(EVT_VAR(1), EVT_VAR(3), 3);
-    EVT_VAR(0) = EVT_VAR(10);
-    N(GetEntryPos)();
-    SetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    SetPlayerFlagBits(2097152, 1);
-    N(GetCurrentCameraYawClamped180)();
-    InterpPlayerYaw(EVT_VAR(0), 0);
-    sleep 2;
-    SetPlayerFlagBits(2097152, 0);
-    PlaySound(0x163);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    spawn {
-        sleep 4;
-        loop 40 {
-            EVT_VAR(1) -= 1;
-            SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 1;
-        }
-    }
-    func_802D286C(2048);
-    func_802D2520(ANIM_10002, 5, 2, 1, 1, 0);
-    sleep 25;
-    await 0xFE363C8C;
-});
+EvtSource N(80240F1C) = {
+    EVT_CALL(N(SetPlayerStatusAnimFlags100000))
+    EVT_SET_GROUP(27)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_CALL(N(GetEntryPos))
+    EVT_CALL(PlayerMoveTo, EVT_VAR(1), EVT_VAR(3), 3)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_CALL(N(GetEntryPos))
+    EVT_CALL(SetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_CALL(SetPlayerFlagBits, 2097152, 1)
+    EVT_CALL(N(GetCurrentCameraYawClamped180))
+    EVT_CALL(InterpPlayerYaw, EVT_VAR(0), 0)
+    EVT_WAIT_FRAMES(2)
+    EVT_CALL(SetPlayerFlagBits, 2097152, 0)
+    EVT_CALL(PlaySound, 0x163)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(4)
+        EVT_LOOP(40)
+            EVT_SUB(EVT_VAR(1), 1)
+            EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(func_802D286C, 2048)
+    EVT_CALL(func_802D2520, ANIM_10002, 5, 2, 1, 1, 0)
+    EVT_WAIT_FRAMES(25)
+    EVT_EXEC_WAIT(EVT_VAR(12))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802410F8) = SCRIPT({
-    IsPlayerOnValidFloor(EVT_VAR(0));
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    GetPlayerActionState(EVT_VAR(0));
-    if (EVT_VAR(0) == 26) {
-        return;
-    }
-    GetCurrentPartner(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        GetCurrentPartnerID(EVT_VAR(1));
-        if (EVT_VAR(1) != 6) {
-            return;
-        } else {
-            func_802D2B6C();
-            DisablePlayerInput(TRUE);
-        }
-    } else {
-        DisablePlayerInput(TRUE);
-    }
-    group 27;
-    N(SetPlayerStatusAnimFlags100000)();
-    DisablePlayerPhysics(TRUE);
-    ModifyColliderFlags(0, EVT_VAR(11), 0x7FFFFE00);
-    EVT_VAR(0) = EVT_VAR(10);
-    N(GetEntryPos)();
-    EVT_VAR(5) = EVT_VAR(1);
-    EVT_VAR(6) = EVT_VAR(2);
-    EVT_VAR(6) += 2;
-    EVT_VAR(7) = EVT_VAR(3);
-    EVT_VAR(8) = EVT_VAR(4);
-    EVT_VAR(8) += 180;
-    if (EVT_VAR(4) >= 360) {
-        EVT_VAR(4) -= 360;
-    }
-    InterpPlayerYaw(EVT_VAR(8), 1);
-    sleep 1;
-    PlaySound(0x163);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPlayerPos(EVT_VAR(0), EVT_VAR(6), EVT_VAR(7));
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    func_802D286C(2048);
-    func_802D2520(ANIM_STAND_STILL, 5, 3, 1, 1, 0);
-    spawn {
-        sleep 8;
-        HidePlayerShadow(TRUE);
-    }
-    spawn {
-        sleep 3;
-        loop 40 {
-            N(SomeXYZFunc2)(1.0);
-            SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 1;
-        }
-    }
-    sleep 25;
-    await 0xFE363C8C;
-});
+EvtSource N(802410F8) = {
+    EVT_CALL(IsPlayerOnValidFloor, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 26)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(GetCurrentPartner, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(GetCurrentPartnerID, EVT_VAR(1))
+        EVT_IF_NE(EVT_VAR(1), 6)
+            EVT_RETURN
+        EVT_ELSE
+            EVT_CALL(func_802D2B6C)
+            EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_END_IF
+    EVT_ELSE
+        EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_END_IF
+    EVT_SET_GROUP(27)
+    EVT_CALL(N(SetPlayerStatusAnimFlags100000))
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(ModifyColliderFlags, 0, EVT_VAR(11), 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_CALL(N(GetEntryPos))
+    EVT_SET(EVT_VAR(5), EVT_VAR(1))
+    EVT_SET(EVT_VAR(6), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(6), 2)
+    EVT_SET(EVT_VAR(7), EVT_VAR(3))
+    EVT_SET(EVT_VAR(8), EVT_VAR(4))
+    EVT_ADD(EVT_VAR(8), 180)
+    EVT_IF_GE(EVT_VAR(4), 360)
+        EVT_SUB(EVT_VAR(4), 360)
+    EVT_END_IF
+    EVT_CALL(InterpPlayerYaw, EVT_VAR(8), 1)
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(PlaySound, 0x163)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(6), EVT_VAR(7))
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_CALL(func_802D286C, 2048)
+    EVT_CALL(func_802D2520, ANIM_STAND_STILL, 5, 3, 1, 1, 0)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(8)
+        EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(3)
+        EVT_LOOP(40)
+            EVT_CALL(N(SomeXYZFunc2), EVT_FIXED(1.0))
+            EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(25)
+    EVT_EXEC_WAIT(EVT_VAR(12))
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024142C) = EXIT_WALK_SCRIPT(60,  0, "flo_23",  1);
 
 EvtSource N(exitWalk_80241488) = EXIT_WALK_SCRIPT(60,  1, "flo_12",  0);
 
-EvtSource N(802414E4) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 5);
-    sleep 100;
-});
+EvtSource N(802414E4) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 5)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241520) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 6);
-    sleep 100;
-});
+EvtSource N(80241520) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 6)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024155C) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 7);
-    sleep 100;
-});
+EvtSource N(8024155C) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 7)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241598) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 2);
-    sleep 100;
-});
+EvtSource N(80241598) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802415D4) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 3);
-    sleep 100;
-});
+EvtSource N(802415D4) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 3)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241610) = SCRIPT({
-    group 27;
-    GotoMap("flo_11", 4);
-    sleep 100;
-});
+EvtSource N(80241610) = {
+    EVT_SET_GROUP(27)
+    EVT_CALL(GotoMap, EVT_PTR("flo_11"), 4)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024164C) = SCRIPT({
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    await N(80240E40);
-});
+EvtSource N(8024164C) = {
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_EXEC_WAIT(N(80240E40))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241698) = SCRIPT({
-    bind N(exitWalk_80241488) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_8024142C) TRIGGER_FLOOR_ABOVE 4;
-    EVT_VAR(0) = 2;
-    EVT_VAR(1) = 35;
-    EVT_VAR(2) = N(802414E4);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-    EVT_VAR(0) = 3;
-    EVT_VAR(1) = 34;
-    EVT_VAR(2) = N(80241520);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-    EVT_VAR(0) = 4;
-    EVT_VAR(1) = 33;
-    EVT_VAR(2) = N(8024155C);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-    EVT_VAR(0) = 5;
-    EVT_VAR(1) = 32;
-    EVT_VAR(2) = N(80241598);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-    EVT_VAR(0) = 6;
-    EVT_VAR(1) = 31;
-    EVT_VAR(2) = N(802415D4);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-    EVT_VAR(0) = 7;
-    EVT_VAR(1) = 30;
-    EVT_VAR(2) = N(80241610);
-    bind N(8024164C) TRIGGER_FLOOR_TOUCH EVT_VAR(1);
-});
+EvtSource N(80241698) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80241488), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024142C), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_SET(EVT_VAR(0), 2)
+    EVT_SET(EVT_VAR(1), 35)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(802414E4)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_SET(EVT_VAR(0), 3)
+    EVT_SET(EVT_VAR(1), 34)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(80241520)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_SET(EVT_VAR(0), 4)
+    EVT_SET(EVT_VAR(1), 33)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(8024155C)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_SET(EVT_VAR(0), 5)
+    EVT_SET(EVT_VAR(1), 32)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(80241598)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_SET(EVT_VAR(0), 6)
+    EVT_SET(EVT_VAR(1), 31)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(802415D4)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_SET(EVT_VAR(0), 7)
+    EVT_SET(EVT_VAR(1), 30)
+    EVT_SET(EVT_VAR(2), EVT_PTR(N(80241610)))
+    EVT_BIND_TRIGGER(N(8024164C), TRIGGER_FLOOR_TOUCH, EVT_VAR(1), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    func_80044238(5);
-    MakeNpcs(0, N(npcGroupList_802430D4));
-    await N(makeEntities);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) <= 1) {
-        EVT_VAR(0) = N(80241698);
-        spawn EnterWalk;
-        spawn N(80242240);
-        sleep 1;
-    } else {
-        EVT_VAR(10) = N(80241698);
-        spawn N(802406FC);
-        sleep 1;
-    }
-    await N(802403E0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_802402E0_CBDFB0)();
-    }
-    ModifyColliderFlags(3, 9, 0x00000009);
-    ModifyColliderFlags(3, 10, 0x00000009);
-    ModifyColliderFlags(3, 11, 0x00000009);
-    ModifyColliderFlags(3, 12, 0x00000009);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(func_80044238, 5)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_802430D4)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_LE(EVT_VAR(0), 1)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(80241698)))
+        EVT_EXEC(EnterWalk)
+        EVT_EXEC(N(80242240))
+        EVT_WAIT_FRAMES(1)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(10), EVT_PTR(N(80241698)))
+        EVT_EXEC(N(802406FC))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(802403E0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_802402E0_CBDFB0))
+    EVT_END_IF
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000009)
+    EVT_CALL(ModifyColliderFlags, 3, 10, 0x00000009)
+    EVT_CALL(ModifyColliderFlags, 3, 11, 0x00000009)
+    EVT_CALL(ModifyColliderFlags, 3, 12, 0x00000009)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1AB8)[] = {
     0x00000000, 0x00000000,
@@ -465,283 +496,301 @@ s32 N(vectorList_80241C84)[] = {
     0x42200000, 0x42C80000, 0x43AF0000, 0x42200000,
 };
 
-EvtSource N(80241CB4) = SCRIPT({
-    loop {
-        PlaySound(0x295);
-        sleep EVT_VAR(0);
-    }
-});
+EvtSource N(80241CB4) = {
+    EVT_LOOP(0)
+        EVT_CALL(PlaySound, SOUND_295)
+        EVT_WAIT_FRAMES(EVT_VAR(0))
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241CF4) = SCRIPT({
-    EVT_VAR(0) = 5;
-    EVT_MAP_VAR(11) = spawn N(80241CB4);
-    spawn {
-        LoadPath(160, N(vectorList_80241AEC), 8, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) == 0) {
-                break loop;
-            }
-        }
-    }
-    LoadPath(160, N(vectorList_80241B4C), 8, 0);
-    loop {
-        GetNextPathPos();
-        SetNpcPos(NPC_LAKITU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) == 0) {
-            break loop;
-        }
-    }
-    EVT_MAP_VAR(10) = 1;
-});
+EvtSource N(80241CF4) = {
+    EVT_SET(EVT_VAR(0), 5)
+    EVT_EXEC_GET_TID(N(80241CB4), EVT_MAP_VAR(11))
+    EVT_THREAD
+        EVT_CALL(LoadPath, 160, EVT_PTR(N(vectorList_80241AEC)), 8, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(LoadPath, 160, EVT_PTR(N(vectorList_80241B4C)), 8, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_SET(EVT_MAP_VAR(10), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241E4C) = SCRIPT({
-    spawn {
-        LoadPath(30, N(vectorList_80241BAC), 4, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) == 0) {
-                break loop;
-            }
-        }
-    }
-    LoadPath(45, N(vectorList_80241BDC), 4, 0);
-    loop {
-        GetNextPathPos();
-        SetNpcPos(NPC_LAKITU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) == 0) {
-            break loop;
-        }
-    }
-    kill EVT_MAP_VAR(11);
-});
+EvtSource N(80241E4C) = {
+    EVT_THREAD
+        EVT_CALL(LoadPath, 30, EVT_PTR(N(vectorList_80241BAC)), 4, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(LoadPath, 45, EVT_PTR(N(vectorList_80241BDC)), 4, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_KILL_THREAD(EVT_MAP_VAR(11))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241F80) = SCRIPT({
-    EVT_VAR(0) = 4;
-    EVT_MAP_VAR(11) = spawn N(80241CB4);
-    spawn {
-        LoadPath(35, N(vectorList_80241C0C), 3, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) == 0) {
-                break loop;
-            }
-        }
-    }
-    LoadPath(35, N(vectorList_80241C30), 3, 0);
-    loop {
-        GetNextPathPos();
-        SetNpcPos(NPC_LAKITU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80241F80) = {
+    EVT_SET(EVT_VAR(0), 4)
+    EVT_EXEC_GET_TID(N(80241CB4), EVT_MAP_VAR(11))
+    EVT_THREAD
+        EVT_CALL(LoadPath, 35, EVT_PTR(N(vectorList_80241C0C)), 3, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(LoadPath, 35, EVT_PTR(N(vectorList_80241C30)), 3, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802420C8) = SCRIPT({
-    spawn {
-        LoadPath(40, N(vectorList_80241C54), 4, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) == 0) {
-                break loop;
-            }
-        }
-        SetNpcPos(NPC_LAKITU0, 0, -1000, 0);
-    }
-    LoadPath(40, N(vectorList_80241C84), 4, 0);
-    loop {
-        GetNextPathPos();
-        SetNpcPos(NPC_LAKITU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) == 0) {
-            break loop;
-        }
-    }
-    SetNpcPos(NPC_LAKITU1, 0, -1000, 0);
-    sleep 40;
-    kill EVT_MAP_VAR(11);
-});
+EvtSource N(802420C8) = {
+    EVT_THREAD
+        EVT_CALL(LoadPath, 40, EVT_PTR(N(vectorList_80241C54)), 4, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(SetNpcPos, 0, 0, -1000, 0)
+    EVT_END_THREAD
+    EVT_CALL(LoadPath, 40, EVT_PTR(N(vectorList_80241C84)), 4, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(SetNpcPos, 1, 0, -1000, 0)
+    EVT_WAIT_FRAMES(40)
+    EVT_KILL_THREAD(EVT_MAP_VAR(11))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242240) = SCRIPT({
-    if (EVT_SAVE_FLAG(1377) == 1) {
-        return;
-    }
-    if (EVT_STORY_PROGRESS < STORY_CH6_GOT_MAGICAL_BEAN) {
-        return;
-    }
-    if (EVT_SAVE_FLAG(1375) == 0) {
-        return;
-    }
-    SetNpcPos(NPC_LAKITU0, 460, 200, -240);
-    SetNpcPos(NPC_LAKITU1, -100, 200, -50);
-    loop {
-        sleep 1;
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(0) < 440) {
-            break loop;
-        }
-    }
-    DisablePlayerInput(TRUE);
-    EVT_MAP_VAR(10) = 0;
-    spawn N(80241CF4);
-    SetCamType(0, 1, 0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 90.0);
-    SetCamPitch(0, 25.0, -7.0);
-    SetCamDistance(0, 450);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 20;
-    EVT_VAR(0) = 270;
-    EVT_VAR(1) = 100;
-    EVT_VAR(2) = -87;
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamPitch(0, 14.0, -11.0);
-    SetCamPosA(0, 87, 0);
-    SetCamPosB(0, 0, -50);
-    SetCamPosC(0, 87, 0);
-    SetCamSpeed(0, 1.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 30;
-    SetCamDistance(0, 150);
-    SetCamPitch(0, 17.0, -16.0);
-    PanToTarget(0, 0, 1);
-    loop {
-        sleep 1;
-        if (EVT_MAP_VAR(10) == 1) {
-            break loop;
-        }
-    }
-    NpcFaceNpc(NPC_LAKITU0, NPC_LAKITU1, 1);
-    NpcFaceNpc(NPC_LAKITU1, NPC_LAKITU0, 1);
-    spawn N(80241E4C);
-    sleep 30;
-    SpeakToPlayer(NPC_LAKITU0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0088));
-    NpcFaceNpc(NPC_LAKITU1, NPC_LAKITU0, 1);
-    SpeakToPlayer(NPC_LAKITU1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0089));
-    InterpNpcYaw(NPC_LAKITU0, 0, 1);
-    sleep 20;
-    SpeakToPlayer(NPC_LAKITU0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x008A));
-    SpeakToPlayer(NPC_LAKITU1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x008B));
-    SetCamType(0, 1, 0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 90.0);
-    SetCamPitch(0, 14.0, -11.0);
-    SetCamDistance(0, 450);
-    SetCamPosA(0, 87, 0);
-    SetCamPosB(0, 0, -50);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    spawn N(80241F80);
-    SetNpcVar(0, 0, 1);
-});
+EvtSource N(80242240) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1377), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_LT(EVT_SAVE_VAR(0), 45)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(1375), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(SetNpcPos, 0, 460, 200, -240)
+    EVT_CALL(SetNpcPos, 1, -100, 200, -50)
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_LT(EVT_VAR(0), 440)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_MAP_VAR(10), 0)
+    EVT_EXEC(N(80241CF4))
+    EVT_CALL(SetCamType, 0, 1, 0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(25.0), EVT_FIXED(-7.0))
+    EVT_CALL(SetCamDistance, 0, 450)
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(20)
+    EVT_SET(EVT_VAR(0), 270)
+    EVT_SET(EVT_VAR(1), 100)
+    EVT_SET(EVT_VAR(2), -87)
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(14.0), EVT_FIXED(-11.0))
+    EVT_CALL(SetCamPosA, 0, 87, 0)
+    EVT_CALL(SetCamPosB, 0, 0, -50)
+    EVT_CALL(SetCamPosC, 0, 87, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SetCamDistance, 0, 150)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-16.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_MAP_VAR(10), 1)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(NpcFaceNpc, 0, 1, 1)
+    EVT_CALL(NpcFaceNpc, 1, 0, 1)
+    EVT_EXEC(N(80241E4C))
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0088))
+    EVT_CALL(NpcFaceNpc, 1, 0, 1)
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0089))
+    EVT_CALL(InterpNpcYaw, 0, 0, 1)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x008A))
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x008B))
+    EVT_CALL(SetCamType, 0, 1, 0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(14.0), EVT_FIXED(-11.0))
+    EVT_CALL(SetCamDistance, 0, 450)
+    EVT_CALL(SetCamPosA, 0, 87, 0)
+    EVT_CALL(SetCamPosB, 0, 0, -50)
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_EXEC(N(80241F80))
+    EVT_CALL(SetNpcVar, 0, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80242810) = SCRIPT({
-    loop {
-        GetSelfVar(0, EVT_VAR(0));
-        if (EVT_VAR(0) != 0) {
-            break loop;
-        }
-        sleep 1;
-    }
-    spawn {
-        AdjustCam(0, 4.0, 0, 1000, 14.0, -11.0);
-    }
-    StartBossBattle(3);
-});
+EvtSource N(idle_80242810) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+        EVT_IF_NE(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_THREAD
+        EVT_CALL(AdjustCam, 0, EVT_FIXED(4.0), 0, 1000, EVT_FIXED(14.0), EVT_FIXED(-11.0))
+    EVT_END_THREAD
+    EVT_CALL(StartBossBattle, 3)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802428B8) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetNpcPos(NPC_LAKITU0, 400, 20, -40);
-            SetNpcPos(NPC_LAKITU1, 400, 20, 40);
-            InterpNpcYaw(NPC_LAKITU0, 270, 0);
-            InterpNpcYaw(NPC_LAKITU1, 270, 0);
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(2) += -60;
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 900);
-            SetCamPitch(0, 24.0, -4.0);
-            SetCamPosA(0, -95.0, 0.0);
-            SetCamPosB(0, 0.0, -50.0);
-            SetCamSpeed(0, 90.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            await N(802420C8);
-            ResetCam(0, 4.0);
-            EVT_SAVE_FLAG(1377) = 1;
-            EVT_MAP_VAR(0) = 1;
-            DisablePlayerInput(FALSE);
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_802428B8) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetNpcPos, 0, 400, 20, -40)
+            EVT_CALL(SetNpcPos, 1, 400, 20, 40)
+            EVT_CALL(InterpNpcYaw, 0, 270, 0)
+            EVT_CALL(InterpNpcYaw, 1, 270, 0)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(2), -60)
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 900)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(24.0), EVT_FIXED(-4.0))
+            EVT_CALL(SetCamPosA, 0, EVT_FIXED(-95.0), EVT_FIXED(0.0))
+            EVT_CALL(SetCamPosB, 0, EVT_FIXED(0.0), EVT_FIXED(-50.0))
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_EXEC_WAIT(N(802420C8))
+            EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+            EVT_SET(EVT_SAVE_FLAG(1377), 1)
+            EVT_SET(EVT_MAP_VAR(0), 1)
+            EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_80242AC4) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-0:
-            if (EVT_MAP_VAR(0) == 0) {
-                sleep 1;
-                goto 0;
-            }
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_80242AC4) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_LABEL(0)
+            EVT_IF_EQ(EVT_MAP_VAR(0), 0)
+                EVT_WAIT_FRAMES(1)
+                EVT_GOTO(0)
+            EVT_END_IF
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80242B58) = SCRIPT({
-    SetNpcPos(NPC_LAKITU0, 0, -1000, 0);
-    if (EVT_SAVE_FLAG(1377) == 0) {
-        if (EVT_STORY_PROGRESS >= STORY_CH6_GOT_MAGICAL_BEAN) {
-            if (EVT_SAVE_FLAG(1375) == 1) {
-                EVT_MAP_VAR(0) = 0;
-                BindNpcIdle(NPC_SELF, N(idle_80242810));
-                BindNpcDefeat(NPC_SELF, N(defeat_802428B8));
-                SetNpcPos(NPC_LAKITU0, 350, 120, -220);
-                InterpNpcYaw(NPC_LAKITU0, 270, 1);
-            }
-        }
-    }
-});
+EvtSource N(init_80242B58) = {
+    EVT_CALL(SetNpcPos, 0, 0, -1000, 0)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1377), 0)
+        EVT_IF_GE(EVT_SAVE_VAR(0), 45)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1375), 1)
+                EVT_SET(EVT_MAP_VAR(0), 0)
+                EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80242810)))
+                EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802428B8)))
+                EVT_CALL(SetNpcPos, 0, 350, 120, -220)
+                EVT_CALL(InterpNpcYaw, 0, 270, 1)
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80242C38) = SCRIPT({
-    SetNpcPos(NPC_LAKITU1, 0, -1000, 0);
-    if (EVT_SAVE_FLAG(1377) == 0) {
-        if (EVT_STORY_PROGRESS >= STORY_CH6_GOT_MAGICAL_BEAN) {
-            if (EVT_SAVE_FLAG(1375) == 1) {
-                BindNpcDefeat(NPC_SELF, N(defeat_80242AC4));
-                SetNpcPos(NPC_LAKITU1, 200, 110, 29);
-                InterpNpcYaw(NPC_LAKITU1, 0, 1);
-            }
-        }
-    }
-});
+EvtSource N(init_80242C38) = {
+    EVT_CALL(SetNpcPos, 1, 0, -1000, 0)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1377), 0)
+        EVT_IF_GE(EVT_SAVE_VAR(0), 45)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1375), 1)
+                EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80242AC4)))
+                EVT_CALL(SetNpcPos, 1, 200, 110, 29)
+                EVT_CALL(InterpNpcYaw, 1, 0, 1)
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80242CF4)[] = {
     {
@@ -829,10 +878,12 @@ static s32 N(pad_30EC) = {
     0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA0E8, -220, 60, -75, 0, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1384));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA0E8, -220, 60, -75, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1384))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/SetPlayerStatusAnimFlags100000.inc.c"
 

--- a/src/world/area_flo/flo_12/CC0E70.c
+++ b/src/world/area_flo/flo_12/CC0E70.c
@@ -22,121 +22,132 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_12_tattle },
 };
 
-EvtSource N(80240750) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        SetMusicTrack(0, SONG_SUNSHINE_RETURNS, 0, 8);
-    } else {
-        match EVT_STORY_PROGRESS {
-            < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-            } else {
-                SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-            }
-        }
-    }
-});
+EvtSource N(80240750) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(SetMusicTrack, 0, SONG_SUNSHINE_RETURNS, 0, 8)
+    EVT_ELSE
+        EVT_SWITCH(EVT_SAVE_VAR(0))
+            EVT_CASE_LT(53)
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+            EVT_CASE_DEFAULT
+                EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024080C) = SCRIPT({
-    PushSong(137, 3);
-});
+EvtSource N(8024080C) = {
+    EVT_CALL(PushSong, 137, 3)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240830) = SCRIPT({
-    FadeOutMusic(0, 250);
-    sleep 10;
-    PopSong();
-});
+EvtSource N(80240830) = {
+    EVT_CALL(FadeOutMusic, 0, 250)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PopSong)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_86C) = {
     0x00000000,
 };
 
-EvtSource N(80240870) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80240870) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80240B1C) = EXIT_WALK_SCRIPT(60,  0, "flo_11",  1);
 
-EvtSource N(80240B78) = SCRIPT({
-    bind N(exitWalk_80240B1C) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(80240B78) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240B1C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    EVT_AREA_FLAG(22) = 0;
-    MakeNpcs(0, N(npcGroupList_802429B8));
-    ModifyColliderFlags(3, 11, 0x00000006);
-    EVT_VAR(0) = -65;
-    EVT_VAR(1) = -210;
-    EVT_VAR(2) = 90;
-    EVT_VAR(3) = -110;
-    EVT_VAR(4) = 0;
-    spawn N(80240870);
-    EVT_VAR(0) = -200;
-    EVT_VAR(1) = 130;
-    EVT_VAR(2) = -80;
-    EVT_VAR(3) = 170;
-    EVT_VAR(4) = 0;
-    spawn N(80240870);
-    EVT_VAR(0) = -270;
-    EVT_VAR(1) = -80;
-    EVT_VAR(2) = -225;
-    EVT_VAR(3) = 125;
-    EVT_VAR(4) = 0;
-    spawn N(80240870);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        spawn N(802419F4);
-    } else {
-        ModifyColliderFlags(0, 1, 0x7FFFFE00);
-        EVT_VAR(0) = N(80240B78);
-        spawn EnterWalk;
-    }
-    await N(80240750);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CC0E30)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_SET(EVT_AREA_FLAG(22), 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_802429B8)))
+    EVT_CALL(ModifyColliderFlags, 3, 11, 0x00000006)
+    EVT_SET(EVT_VAR(0), -65)
+    EVT_SET(EVT_VAR(1), -210)
+    EVT_SET(EVT_VAR(2), 90)
+    EVT_SET(EVT_VAR(3), -110)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240870))
+    EVT_SET(EVT_VAR(0), -200)
+    EVT_SET(EVT_VAR(1), 130)
+    EVT_SET(EVT_VAR(2), -80)
+    EVT_SET(EVT_VAR(3), 170)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240870))
+    EVT_SET(EVT_VAR(0), -270)
+    EVT_SET(EVT_VAR(1), -80)
+    EVT_SET(EVT_VAR(2), -225)
+    EVT_SET(EVT_VAR(3), 125)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240870))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_EXEC(N(802419F4))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(80240B78)))
+        EVT_EXEC(EnterWalk)
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80240750))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CC0E30))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_E28)[] = {
     0x00000000, 0x00000000,
@@ -158,15 +169,19 @@ NpcSettings N(npcSettings_80240E5C) = {
 
 s32** N(D_802417EC_CC261C) = NULL;
 
-EvtSource N(802417F0) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 0);
-    return;
-});
+EvtSource N(802417F0) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 0)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241820) = SCRIPT({
-    ShowGotItem(EVT_VAR(0), 1, 16);
-    return;
-});
+EvtSource N(80241820) = {
+    EVT_CALL(ShowGotItem, EVT_VAR(0), 1, 16)
+    EVT_RETURN
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_80241850_CC2680) = {
     0x00000000,
@@ -176,233 +191,222 @@ s32 N(D_80241854_CC2684) = {
     0x00000000,
 };
 
-EvtSource N(80241858) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowKeyChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveKeyItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            EVT_VAR(0) |= (const)  0x50000;
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_80240614_CC1444)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80241858) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowKeyChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveKeyItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_BITWISE_OR_CONST(EVT_VAR(0), 0x50000)
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80240614_CC1444), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024199C) = SCRIPT({
-    N(func_8024064C_CC147C)(EVT_VAR(0));
-    bind_padlock N(80241858) 0x10 0 N(D_802429E0);
-    N(func_802405C0_CC13F0)(EVT_VAR(0));
-});
+EvtSource N(8024199C) = {
+    EVT_CALL(N(func_8024064C_CC147C), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80241858), 0x10, 0, EVT_PTR(N(D_802429E0)), 0, 1)
+    EVT_CALL(N(func_802405C0_CC13F0), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_802419EC_CC281C)[] = {
     0x0000001E, 0x00000000,
 };
 
-EvtSource N(802419F4) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    GetNpcPos(NPC_ROSIE0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 350);
-    SetCamPitch(0, 17.0, -9.5);
-    SetCamPosA(0, 0, 0);
-    SetCamPosB(0, 0, -50);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 20;
-    SpeakToPlayer(NPC_ROSIE0, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x00C7));
-    sleep 10;
-    GotoMap("flo_03", 2);
-    sleep 100;
-});
+EvtSource N(802419F4) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 350)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.5))
+    EVT_CALL(SetCamPosA, 0, 0, 0)
+    EVT_CALL(SetCamPosB, 0, 0, -50)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x00C7))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GotoMap, EVT_PTR("flo_03"), 2)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241B6C) = SCRIPT({
-    sleep 10;
-    SetNpcFlagBits(NPC_ROSIE0, ((NPC_FLAG_100)), TRUE);
-    PlayerMoveTo(-5, 20, 20);
-    SetNpcFlagBits(NPC_ROSIE0, ((NPC_FLAG_100)), FALSE);
-    PlayerFaceNpc(0, 1);
-});
+EvtSource N(80241B6C) = {
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(PlayerMoveTo, -5, 20, 20)
+    EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(PlayerFaceNpc, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241BE4) = SCRIPT({
-    sleep 10;
-    SetNpcFlagBits(NPC_ROSIE0, ((NPC_FLAG_100)), TRUE);
-    SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), TRUE);
-    PlayerMoveTo(-5, 20, 20);
-    SetNpcFlagBits(NPC_ROSIE0, ((NPC_FLAG_100)), FALSE);
-    SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), FALSE);
-    PlayerFaceNpc(0, 1);
-});
+EvtSource N(80241BE4) = {
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(PlayerMoveTo, -5, 20, 20)
+    EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(PlayerFaceNpc, 0, 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80241C8C) = SCRIPT({
-    await N(8024080C);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_GOT_CRYSTAL_BERRY {
-            match EVT_SAVE_FLAG(1378) {
-                == 0 {
-                    spawn N(80241B6C);
-                    GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    EVT_VAR(0) += 30;
-                    SetCamProperties(0, 4.0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 325, 19.0, -9.5);
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008C));
-                    ShowChoice(MESSAGE_ID(0x1E, 0x0011));
-                    sleep 10;
-                    match EVT_VAR(0) {
-                        == 0 {
-                            ContinueSpeech(-1, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008D));
-                        }
-                        == 1 {
-                            ContinueSpeech(-1, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008E));
-                        }
-                    }
-                    SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), FALSE);
-                    SetNpcAnimation(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_5);
-                    sleep 10;
-                    SetNpcAnimation(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2);
-                    MakeItemEntity(ITEM_WATER_STONE, -33, 14, 19, 1, 1380);
-                    sleep 10;
-                    match EVT_SAVE_FLAG(1375) {
-                        == 0 {
-                            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x008F));
-                        }
-                        == 1 {
-                            SetPlayerAnimation(0x60002);
-                            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x008F));
-                            SetPlayerAnimation(0x60005);
-                            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0091));
-                            SetPlayerAnimation(ANIM_PRAY);
-                            sleep 40;
-                            SetPlayerAnimation(ANIM_10002);
-                            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0092));
-                            EVT_SAVE_FLAG(1379) = 1;
-                        }
-                    }
-                    EVT_SAVE_FLAG(1378) = 1;
-                }
-                == 1 {
-                    match EVT_SAVE_FLAG(1379) {
-                        == 0 {
-                            if (EVT_SAVE_FLAG(1375) == 1) {
-                                spawn N(80241BE4);
-                                SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11,
-                                              0x0090));
-                                SetPlayerAnimation(0x60005);
-                                SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11,
-                                              0x0091));
-                                SetPlayerAnimation(ANIM_PRAY);
-                                sleep 40;
-                                SetPlayerAnimation(ANIM_10002);
-                                SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11,
-                                              0x0092));
-                                EVT_SAVE_FLAG(1379) = 1;
-                            } else {
-                                SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11,
-                                              0x0090));
-                            }
-                        }
-                        == 1 {
-                            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0093));
-                        }
-                    }
-                }
-            }
-        }
-        < 48 {
-            FindKeyItem(ITEM_CRYSTAL_BERRY, EVT_VAR(0));
-            if (EVT_VAR(0) != -1) {
-                spawn N(80241BE4);
-                GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                EVT_VAR(0) += 30;
-                SetCamProperties(0, 4.0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 325, 19.0, -9.5);
-            }
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0094));
-            EVT_VAR(0) = N(D_802419EC_CC281C);
-            EVT_VAR(1) = 0;
-            await N(8024199C);
-            match EVT_VAR(0) {
-                <= 0 {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0093));
-                } else {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11,
-                                  0x0095));
-                    RemoveItemEntity(EVT_VAR(7));
-                    MakeItemEntity(ITEM_CRYSTAL_BERRY, -33, 14, 19, 1, 1380);
-                    EVT_VAR(0) = 87;
-                    EVT_VAR(1) = 1;
-                    await N(802417F0);
-                    AddKeyItem(ITEM_WATER_STONE);
-                    sleep 10;
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11,
-                                  0x0096));
-                    EVT_AREA_FLAG(22) = 1;
-                    EVT_STORY_PROGRESS = STORY_CH6_GOT_WATER_STONE;
-                }
-            }
-        }
-        < 53 {
-            match EVT_AREA_FLAG(22) {
-                == 0 {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0097));
-                }
-                == 1 {
-                    SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0096));
-                }
-            }
-        }
-        < 60 {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0098));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11,
-                          0x0099));
-        }
-    }
-    ResetCam(0, 4.0);
-    await N(80240830);
-});
+EvtSource N(interact_80241C8C) = {
+    EVT_EXEC_WAIT(N(8024080C))
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(47)
+            EVT_SWITCH(EVT_SAVE_FLAG(1378))
+                EVT_CASE_EQ(0)
+                    EVT_EXEC(N(80241B6C))
+                    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_ADD(EVT_VAR(0), 30)
+                    EVT_CALL(SetCamProperties, 0, EVT_FIXED(4.0), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 325, EVT_FIXED(19.0), EVT_FIXED(-9.5))
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008C))
+                    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0011))
+                    EVT_WAIT_FRAMES(10)
+                    EVT_SWITCH(EVT_VAR(0))
+                        EVT_CASE_EQ(0)
+                            EVT_CALL(ContinueSpeech, -1, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008D))
+                        EVT_CASE_EQ(1)
+                            EVT_CALL(ContinueSpeech, -1, NPC_ANIM_rosie_Palette_00_Anim_3, NPC_ANIM_rosie_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x008E))
+                    EVT_END_SWITCH
+                    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+                    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_5)
+                    EVT_WAIT_FRAMES(10)
+                    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2)
+                    EVT_CALL(MakeItemEntity, ITEM_WATER_STONE, -33, 14, 19, 1, 1380)
+                    EVT_WAIT_FRAMES(10)
+                    EVT_SWITCH(EVT_SAVE_FLAG(1375))
+                        EVT_CASE_EQ(0)
+                            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x008F))
+                        EVT_CASE_EQ(1)
+                            EVT_CALL(SetPlayerAnimation, 393218)
+                            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x008F))
+                            EVT_CALL(SetPlayerAnimation, 393221)
+                            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0091))
+                            EVT_CALL(SetPlayerAnimation, ANIM_PRAY)
+                            EVT_WAIT_FRAMES(40)
+                            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+                            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0092))
+                            EVT_SET(EVT_SAVE_FLAG(1379), 1)
+                    EVT_END_SWITCH
+                    EVT_SET(EVT_SAVE_FLAG(1378), 1)
+                EVT_CASE_EQ(1)
+                    EVT_SWITCH(EVT_SAVE_FLAG(1379))
+                        EVT_CASE_EQ(0)
+                            EVT_IF_EQ(EVT_SAVE_FLAG(1375), 1)
+                                EVT_EXEC(N(80241BE4))
+                                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x0090))
+                                EVT_CALL(SetPlayerAnimation, 393221)
+                                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0091))
+                                EVT_CALL(SetPlayerAnimation, ANIM_PRAY)
+                                EVT_WAIT_FRAMES(40)
+                                EVT_CALL(SetPlayerAnimation, ANIM_10002)
+                                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0092))
+                                EVT_SET(EVT_SAVE_FLAG(1379), 1)
+                            EVT_ELSE
+                                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_4, 5, MESSAGE_ID(0x11, 0x0090))
+                            EVT_END_IF
+                        EVT_CASE_EQ(1)
+                            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0093))
+                    EVT_END_SWITCH
+            EVT_END_SWITCH
+        EVT_CASE_LT(48)
+            EVT_CALL(FindKeyItem, ITEM_CRYSTAL_BERRY, EVT_VAR(0))
+            EVT_IF_NE(EVT_VAR(0), -1)
+                EVT_EXEC(N(80241BE4))
+                EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_ADD(EVT_VAR(0), 30)
+                EVT_CALL(SetCamProperties, 0, EVT_FIXED(4.0), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 325, EVT_FIXED(19.0), EVT_FIXED(-9.5))
+            EVT_END_IF
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0094))
+            EVT_SET(EVT_VAR(0), EVT_PTR(N(D_802419EC_CC281C)))
+            EVT_SET(EVT_VAR(1), 0)
+            EVT_EXEC_WAIT(N(8024199C))
+            EVT_SWITCH(EVT_VAR(0))
+                EVT_CASE_LE(0)
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0093))
+                EVT_CASE_DEFAULT
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0095))
+                    EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                    EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -33, 14, 19, 1, 1380)
+                    EVT_SET(EVT_VAR(0), 87)
+                    EVT_SET(EVT_VAR(1), 1)
+                    EVT_EXEC_WAIT(N(802417F0))
+                    EVT_CALL(AddKeyItem, ITEM_WATER_STONE)
+                    EVT_WAIT_FRAMES(10)
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0096))
+                    EVT_SET(EVT_AREA_FLAG(22), 1)
+                    EVT_SET(EVT_SAVE_VAR(0), 48)
+            EVT_END_SWITCH
+        EVT_CASE_LT(53)
+            EVT_SWITCH(EVT_AREA_FLAG(22))
+                EVT_CASE_EQ(0)
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0097))
+                EVT_CASE_EQ(1)
+                    EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0096))
+            EVT_END_SWITCH
+        EVT_CASE_LT(60)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0098))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_4, NPC_ANIM_rosie_Palette_00_Anim_2, 5, MESSAGE_ID(0x11, 0x0099))
+    EVT_END_SWITCH
+    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_EXEC_WAIT(N(80240830))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802423D0) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_80241C8C));
-    GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 35;
-    SetNpcPos(NPC_ROSIE1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetNpcFlagBits(NPC_ROSIE1, ((0x00000002)), TRUE);
-    SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_HAS_SHADOW)), TRUE);
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_GOT_CRYSTAL_BERRY {
-            if (EVT_SAVE_FLAG(1378) == 1) {
-                SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), FALSE);
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2);
-                MakeItemEntity(ITEM_WATER_STONE, -33, 14, 19, 1, 1380);
-                EVT_VAR(10) = EVT_VAR(0);
-            }
-        }
-        < STORY_CH6_GOT_WATER_STONE {
-            SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), FALSE);
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2);
-            MakeItemEntity(ITEM_WATER_STONE, -33, 14, 19, 1, 1380);
-            EVT_VAR(10) = EVT_VAR(0);
-        } else {
-            SetNpcFlagBits(NPC_ROSIE1, ((NPC_FLAG_100)), FALSE);
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2);
-            MakeItemEntity(ITEM_CRYSTAL_BERRY, -33, 14, 19, 1, 1380);
-            EVT_VAR(10) = EVT_VAR(0);
-        }
-    }
-});
+EvtSource N(init_802423D0) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80241C8C)))
+    EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 35)
+    EVT_CALL(SetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_2)), TRUE)
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_HAS_SHADOW)), TRUE)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(47)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1378), 1)
+                EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2)
+                EVT_CALL(MakeItemEntity, ITEM_WATER_STONE, -33, 14, 19, 1, 1380)
+                EVT_SET(EVT_VAR(10), EVT_VAR(0))
+            EVT_END_IF
+        EVT_CASE_LT(48)
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2)
+            EVT_CALL(MakeItemEntity, ITEM_WATER_STONE, -33, 14, 19, 1, 1380)
+            EVT_SET(EVT_VAR(10), EVT_VAR(0))
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_rosie_Palette_00_Anim_2)
+            EVT_CALL(MakeItemEntity, ITEM_CRYSTAL_BERRY, -33, 14, 19, 1, 1380)
+            EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_802425D8)[] = {
     {

--- a/src/world/area_flo/flo_13/CC3850.c
+++ b/src/world/area_flo/flo_13/CC3850.c
@@ -32,178 +32,194 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_13_tattle },
 };
 
-EvtSource N(802436D0) = SCRIPT({
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(0) < -500) {
-        goto 10;
-    }
-0:
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(0) < -500) {
-            break loop;
-        }
-        sleep 1;
-    }
-10:
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_SUN_TOWER_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_SUN_TOWER_SUNNY, 0, 8);
-        }
-    }
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(0) > -500) {
-            break loop;
-        }
-        sleep 1;
-    }
-    goto 0;
-});
+EvtSource N(802436D0) = {
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_LT(EVT_VAR(0), -500)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_LABEL(0)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_LT(EVT_VAR(0), -500)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_LABEL(10)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_SUN_TOWER_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_SUN_TOWER_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_GT(EVT_VAR(0), -500)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802438B0) = SCRIPT({
-    spawn N(802436D0);
-});
+EvtSource N(802438B0) = {
+    EVT_EXEC(N(802436D0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802438CC) = SCRIPT({
-    SetMusicTrack(0, SONG_NEW_PARTNER, 0, 8);
-});
+EvtSource N(802438CC) = {
+    EVT_CALL(SetMusicTrack, 0, SONG_NEW_PARTNER, 0, 8)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802438F8) = SCRIPT({
-    FadeOutMusic(0, 500);
-    sleep 15;
-    SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-});
+EvtSource N(802438F8) = {
+    EVT_CALL(FadeOutMusic, 0, 500)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3944)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80243950) = SCRIPT({
-    ModifyColliderFlags(0, 14, 0x7FFFFE00);
-});
+EvtSource N(80243950) = {
+    EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeItemEntity(ITEM_MEGA_SMASH, -61, 60, -85, 17, EVT_SAVE_FLAG(1385));
-    MakeItemEntity(ITEM_SHOOTING_STAR, 128, 0, 157, 17, EVT_SAVE_FLAG(1386));
-    if (EVT_SAVE_FLAG(1385) == 0) {
-        MakeEntity(0x802BCF00, -160, 160, -90, 0, MAKE_ENTITY_END);
-        AssignScript(N(80243950));
-    } else {
-        ModifyColliderFlags(0, 14, 0x7FFFFE00);
-    }
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeItemEntity, ITEM_MEGA_SMASH, -61, 60, -85, 17, EVT_SAVE_FLAG(1385))
+    EVT_CALL(MakeItemEntity, ITEM_SHOOTING_STAR, 128, 0, 157, 17, EVT_SAVE_FLAG(1386))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1385), 0)
+        EVT_CALL(MakeEntity, 0x802BCF00, -160, 160, -90, 0, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80243950)))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3A3C) = {
     0x00000000,
 };
 
-EvtSource N(80243A40) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80243A40) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80243CEC) = EXIT_WALK_SCRIPT(60,  0, "flo_14",  1);
 
 EvtSource N(exitWalk_80243D48) = EXIT_WALK_SCRIPT(60,  1, "flo_15",  0);
 
-EvtSource N(80243DA4) = SCRIPT({
-    bind N(exitWalk_80243D48) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80243CEC) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80243DA4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80243D48), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80243CEC), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80247984));
-    await N(makeEntities);
-    ModifyColliderFlags(3, 13, 0x00000006);
-    EVT_VAR(0) = 274;
-    EVT_VAR(1) = -137;
-    EVT_VAR(2) = 583;
-    EVT_VAR(3) = -64;
-    EVT_VAR(4) = 0;
-    spawn N(80243A40);
-    EVT_VAR(0) = 433;
-    EVT_VAR(1) = 108;
-    EVT_VAR(2) = 580;
-    EVT_VAR(3) = 169;
-    EVT_VAR(4) = 0;
-    spawn N(80243A40);
-    EVT_VAR(0) = -460;
-    EVT_VAR(1) = 90;
-    EVT_VAR(2) = -125;
-    EVT_VAR(3) = 130;
-    EVT_VAR(4) = 0;
-    spawn N(80243A40);
-    EVT_VAR(0) = -420;
-    EVT_VAR(1) = -130;
-    EVT_VAR(2) = -260;
-    EVT_VAR(3) = -90;
-    EVT_VAR(4) = 0;
-    spawn N(80243A40);
-    EVT_VAR(0) = -220;
-    EVT_VAR(1) = -137;
-    EVT_VAR(2) = 0;
-    EVT_VAR(3) = -50;
-    EVT_VAR(4) = 160;
-    spawn N(80243A40);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80243DA4);
-    spawn EnterWalk;
-    await N(802438B0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CC3810)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80247984)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_CALL(ModifyColliderFlags, 3, 13, 0x00000006)
+    EVT_SET(EVT_VAR(0), 274)
+    EVT_SET(EVT_VAR(1), -137)
+    EVT_SET(EVT_VAR(2), 583)
+    EVT_SET(EVT_VAR(3), -64)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80243A40))
+    EVT_SET(EVT_VAR(0), 433)
+    EVT_SET(EVT_VAR(1), 108)
+    EVT_SET(EVT_VAR(2), 580)
+    EVT_SET(EVT_VAR(3), 169)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80243A40))
+    EVT_SET(EVT_VAR(0), -460)
+    EVT_SET(EVT_VAR(1), 90)
+    EVT_SET(EVT_VAR(2), -125)
+    EVT_SET(EVT_VAR(3), 130)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80243A40))
+    EVT_SET(EVT_VAR(0), -420)
+    EVT_SET(EVT_VAR(1), -130)
+    EVT_SET(EVT_VAR(2), -260)
+    EVT_SET(EVT_VAR(3), -90)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80243A40))
+    EVT_SET(EVT_VAR(0), -220)
+    EVT_SET(EVT_VAR(1), -137)
+    EVT_SET(EVT_VAR(2), 0)
+    EVT_SET(EVT_VAR(3), -50)
+    EVT_SET(EVT_VAR(4), 160)
+    EVT_EXEC(N(80243A40))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80243DA4)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(802438B0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CC3810))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244100) = {
     .height = 32,
@@ -233,13 +249,15 @@ NpcAISettings N(npcAISettings_80244144) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80244174) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -650);
-    SetSelfVar(6, 30);
-    SetSelfVar(1, 400);
-    N(func_80241DB8_CC55C8)(N(npcAISettings_80244144));
-});
+EvtSource N(npcAI_80244174) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -650)
+    EVT_CALL(SetSelfVar, 6, 30)
+    EVT_CALL(SetSelfVar, 1, 400)
+    EVT_CALL(N(func_80241DB8_CC55C8), EVT_PTR(N(npcAISettings_80244144)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802441E4) = {
     .height = 28,
@@ -263,31 +281,32 @@ NpcAISettings N(npcAISettings_80244210) = {
     .unk_2C = 3,
 };
 
-EvtSource N(npcAI_80244240) = SCRIPT({
-    SetSelfVar(2, 3);
-    SetSelfVar(3, 18);
-    SetSelfVar(5, 3);
-    SetSelfVar(7, 4);
-    N(func_80242A6C_CC627C)(N(npcAISettings_80244210));
-});
+EvtSource N(npcAI_80244240) = {
+    EVT_CALL(SetSelfVar, 2, 3)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(SetSelfVar, 5, 3)
+    EVT_CALL(SetSelfVar, 7, 4)
+    EVT_CALL(N(func_80242A6C_CC627C), EVT_PTR(N(npcAISettings_80244210)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802442B0) = SCRIPT({
-    SetNpcRotation(NPC_SELF, 0, 0, 0);
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetSelfVar(10, 100);
-            DoNpcDefeat();
-        }
-        == 2 {
-            func_80045900(0);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(802442B0) = {
+    EVT_CALL(SetNpcRotation, NPC_SELF, 0, 0, 0)
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetSelfVar, 10, 100)
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(2)
+            EVT_CALL(func_80045900, 0)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024437C) = {
     .height = 21,
@@ -316,487 +335,505 @@ Vec3f N(vectorList_80244420)[] = {
     { -390.0, 300.0, 45.0 },
 };
 
-EvtSource N(8024445C) = SCRIPT({
-    GetNpcPos(NPC_WORLD_LAKILESTER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-0:
-    GetNpcPos(NPC_WORLD_LAKILESTER, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    N(UnkFunc42)();
-    InterpNpcYaw(NPC_WORLD_LAKILESTER, EVT_VAR(10), 0);
-    EVT_VAR(0) = EVT_VAR(3);
-    EVT_VAR(1) = EVT_VAR(4);
-    EVT_VAR(2) = EVT_VAR(5);
-    GetAngleBetweenNPCs(-4, 0, EVT_VAR(10));
-    InterpNpcYaw(NPC_PARTNER, EVT_VAR(10), 0);
-    PlayerFaceNpc(0, 0);
-    sleep 1;
-    goto 0;
-});
+EvtSource N(8024445C) = {
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_LABEL(0)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(N(UnkFunc42))
+    EVT_CALL(InterpNpcYaw, 0, EVT_VAR(10), 0)
+    EVT_SET(EVT_VAR(0), EVT_VAR(3))
+    EVT_SET(EVT_VAR(1), EVT_VAR(4))
+    EVT_SET(EVT_VAR(2), EVT_VAR(5))
+    EVT_CALL(GetAngleBetweenNPCs, -4, 0, EVT_VAR(10))
+    EVT_CALL(InterpNpcYaw, NPC_PARTNER, EVT_VAR(10), 0)
+    EVT_CALL(PlayerFaceNpc, 0, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244560) = SCRIPT({
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-0:
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    N(UnkFunc42)();
-    InterpNpcYaw(NPC_LAKILULU0, EVT_VAR(10), 0);
-    EVT_VAR(0) = EVT_VAR(3);
-    EVT_VAR(1) = EVT_VAR(4);
-    EVT_VAR(2) = EVT_VAR(5);
-    GetAngleBetweenNPCs(-4, 1, EVT_VAR(10));
-    InterpNpcYaw(NPC_PARTNER, EVT_VAR(10), 0);
-    if (EVT_STORY_PROGRESS < STORY_CH6_LAKILESTER_JOINED_PARTY) {
-        GetAngleBetweenNPCs(0, 1, EVT_VAR(11));
-        InterpNpcYaw(NPC_WORLD_LAKILESTER, EVT_VAR(11), 0);
-    }
-    PlayerFaceNpc(1, 0);
-    sleep 1;
-    goto 0;
-});
+EvtSource N(80244560) = {
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_LABEL(0)
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_CALL(N(UnkFunc42))
+    EVT_CALL(InterpNpcYaw, 1, EVT_VAR(10), 0)
+    EVT_SET(EVT_VAR(0), EVT_VAR(3))
+    EVT_SET(EVT_VAR(1), EVT_VAR(4))
+    EVT_SET(EVT_VAR(2), EVT_VAR(5))
+    EVT_CALL(GetAngleBetweenNPCs, -4, 1, EVT_VAR(10))
+    EVT_CALL(InterpNpcYaw, NPC_PARTNER, EVT_VAR(10), 0)
+    EVT_IF_LT(EVT_SAVE_VAR(0), 51)
+        EVT_CALL(GetAngleBetweenNPCs, 0, 1, EVT_VAR(11))
+        EVT_CALL(InterpNpcYaw, 0, EVT_VAR(11), 0)
+    EVT_END_IF
+    EVT_CALL(PlayerFaceNpc, 1, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802446AC) = SCRIPT({
-    EVT_MAP_VAR(10) = 0;
-    loop {
-        loop 2 {
-            GetNpcPos(NPC_LAKILULU1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetNpcPos(NPC_LAKILULU1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 2;
-        }
-        sleep 1;
-        loop 2 {
-            GetNpcPos(NPC_LAKILULU1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += -1;
-            SetNpcPos(NPC_LAKILULU1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += -1;
-            SetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep 2;
-        }
-        sleep 1;
-        if (EVT_MAP_VAR(10) == 1) {
-            EVT_MAP_VAR(10) = 2;
-            break loop;
-        }
-    }
-});
+EvtSource N(802446AC) = {
+    EVT_SET(EVT_MAP_VAR(10), 0)
+    EVT_LOOP(0)
+        EVT_LOOP(2)
+            EVT_CALL(GetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(2)
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(1)
+        EVT_LOOP(2)
+            EVT_CALL(GetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), -1)
+            EVT_CALL(SetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), -1)
+            EVT_CALL(SetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(2)
+        EVT_END_LOOP
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_MAP_VAR(10), 1)
+            EVT_SET(EVT_MAP_VAR(10), 2)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244888) = SCRIPT({
-    spawn N(802446AC);
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_C);
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    EVT_VAR(1) += -5;
-    EVT_VAR(2) += 30;
-    EVT_VAR(3) += 2;
-    SetNpcYaw(NPC_LAKILULU1, 270);
-    SetNpcPos(NPC_LAKILULU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    spawn {
-        sleep 5;
-        SetPlayerAnimation(ANIM_1002B);
-    }
-    ContinueSpeech(1, -1, -1, 512, MESSAGE_ID(0x11, 0x00A8));
-    spawn {
-        sleep 15;
-        EndSpeech(1, -1, -1, 512);
-    }
-    EVT_MAP_VAR(10) = 1;
-    loop {
-        sleep 1;
-        if (EVT_MAP_VAR(10) == 2) {
-            break loop;
-        }
-    }
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_D);
-    GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    EVT_VAR(1) += 5;
-    EVT_VAR(2) += 20;
-    SetNpcJumpscale(NPC_LAKILULU1, 0.0);
-    NpcJump0(NPC_LAKILULU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 7);
-    EVT_VAR(1) += -100;
-    EVT_VAR(2) += 10;
-    spawn {
-        SetNpcJumpscale(NPC_LAKILULU1, 1.5);
-        NpcJump0(NPC_LAKILULU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 15);
-        SetNpcPos(NPC_LAKILULU1, 0, -1000, 0);
-    }
-    spawn {
-        ShakeCam(0, 0, 10, 2.0);
-    }
-    PlaySoundAtPlayer(225, 0);
-    SetPlayerAnimation(ANIM_FALL_BACK);
-    EVT_VAR(0) = 90;
-    loop 20 {
-        EVT_VAR(0) += 144;
-        if (EVT_VAR(0) > 359) {
-            EVT_VAR(0) -= 360;
-        }
-        InterpPlayerYaw(EVT_VAR(0), 1);
-        sleep 1;
-    }
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_1);
-});
+EvtSource N(80244888) = {
+    EVT_EXEC(N(802446AC))
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_C)
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(1), -5)
+    EVT_ADD(EVT_VAR(2), 30)
+    EVT_ADD(EVT_VAR(3), 2)
+    EVT_CALL(SetNpcYaw, 2, 270)
+    EVT_CALL(SetNpcPos, 2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(SetPlayerAnimation, ANIM_1002B)
+    EVT_END_THREAD
+    EVT_CALL(ContinueSpeech, 1, -1, -1, 512, MESSAGE_ID(0x11, 0x00A8))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(EndSpeech, 1, -1, -1, 512)
+    EVT_END_THREAD
+    EVT_SET(EVT_MAP_VAR(10), 1)
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_MAP_VAR(10), 2)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_D)
+    EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(1), 5)
+    EVT_ADD(EVT_VAR(2), 20)
+    EVT_CALL(SetNpcJumpscale, 2, EVT_FIXED(0.0))
+    EVT_CALL(NpcJump0, 2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 7)
+    EVT_ADD(EVT_VAR(1), -100)
+    EVT_ADD(EVT_VAR(2), 10)
+    EVT_THREAD
+        EVT_CALL(SetNpcJumpscale, 2, EVT_FIXED(1.5))
+        EVT_CALL(NpcJump0, 2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 15)
+        EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 10, EVT_FIXED(2.0))
+    EVT_END_THREAD
+    EVT_CALL(PlaySoundAtPlayer, 225, 0)
+    EVT_CALL(SetPlayerAnimation, ANIM_FALL_BACK)
+    EVT_SET(EVT_VAR(0), 90)
+    EVT_LOOP(20)
+        EVT_ADD(EVT_VAR(0), 144)
+        EVT_IF_GT(EVT_VAR(0), 359)
+            EVT_SUB(EVT_VAR(0), 360)
+        EVT_END_IF
+        EVT_CALL(InterpPlayerYaw, EVT_VAR(0), 1)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80244BF8) = SCRIPT({
-    if (EVT_STORY_PROGRESS != STORY_CH6_SPOKE_WITH_THE_SUN) {
-        return;
-    }
-    AwaitPlayerApproach(200, 20, 275);
-    DisablePlayerInput(TRUE);
-    SetNpcPos(NPC_WORLD_LAKILESTER, -250, 120, 45);
-    SetMusicTrack(0, SONG_LAKILESTER_THEME, 0, 8);
-    ShowMessageAtScreenPos(MESSAGE_ID(0x11, 0x00A0), 160, 40);
-    func_802D2B6C();
-    SetPlayerAnimation(0x1002A);
-    sleep 20;
-    InterpPlayerYaw(270, 1);
-    sleep 20;
-    InterpPlayerYaw(90, 1);
-    sleep 20;
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    func_802CF56C(2);
-    SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_7);
-    spawn {
-        N(func_802434D4_CC6CE4)();
-    }
-    EVT_VAR(9) = spawn N(8024445C);
-    LoadPath(80, N(vectorList_802443A8), 5, 0);
-0:
-    GetNextPathPos();
-    SetNpcPos(NPC_WORLD_LAKILESTER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    sleep 1;
-    if (EVT_VAR(0) == 1) {
-        goto 0;
-    }
-    kill EVT_VAR(9);
-    SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_1);
-    PlayerFaceNpc(0, 0);
-    sleep 15;
-    GetNpcPos(NPC_WORLD_LAKILESTER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 200);
-    SetCamPitch(0, 18.0, -8.5);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    spawn {
-        PlayerMoveTo(-75, 65, 10);
-        PlayerFaceNpc(0, 0);
-    }
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00A1));
-    SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_7);
-    sleep 10;
-    SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_1);
-    spawn {
-        SetCamDistance(0, 1000);
-        SetCamPitch(0, 17.0, -6.0);
-        SetCamSpeed(0, 4.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-    }
-    DisablePlayerInput(FALSE);
-    StartBossBattle(3);
-});
+EvtSource N(idle_80244BF8) = {
+    EVT_IF_NE(EVT_SAVE_VAR(0), 50)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(AwaitPlayerApproach, 200, 20, 275)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(SetNpcPos, 0, -250, 120, 45)
+    EVT_CALL(SetMusicTrack, 0, SONG_LAKILESTER_THEME, 0, 8)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x11, 0x00A0), 160, 40)
+    EVT_CALL(func_802D2B6C)
+    EVT_CALL(SetPlayerAnimation, 65578)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(InterpPlayerYaw, 270, 1)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(InterpPlayerYaw, 90, 1)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_CALL(func_802CF56C, 2)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_7)
+    EVT_THREAD
+        EVT_CALL(N(func_802434D4_CC6CE4))
+    EVT_END_THREAD
+    EVT_EXEC_GET_TID(N(8024445C), EVT_VAR(9))
+    EVT_CALL(LoadPath, 80, EVT_PTR(N(vectorList_802443A8)), 5, 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetNextPathPos)
+    EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_KILL_THREAD(EVT_VAR(9))
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_1)
+    EVT_CALL(PlayerFaceNpc, 0, 0)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 200)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.0), EVT_FIXED(-8.5))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_THREAD
+        EVT_CALL(PlayerMoveTo, -75, 65, 10)
+        EVT_CALL(PlayerFaceNpc, 0, 0)
+    EVT_END_THREAD
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00A1))
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_7)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_1)
+    EVT_THREAD
+        EVT_CALL(SetCamDistance, 0, 1000)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_END_THREAD
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(StartBossBattle, 3)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245014) = SCRIPT({
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    AwaitPlayerLeave(EVT_VAR(0), EVT_VAR(2), 120);
-    DisablePlayerInput(TRUE);
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), 0, EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 250);
-    SetCamPitch(0, 5.5, -7.5);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    NpcFaceNpc(NPC_LAKILULU0, NPC_WORLD_LAKILESTER, 1);
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B4));
-    NpcFaceNpc(NPC_PARTNER, NPC_LAKILULU0, 1);
-    SetCamDistance(0, 600);
-    SetCamPitch(0, 10.0, -8.0);
-    SetCamPosA(0, 0, 0);
-    SetCamPosB(0, 130, -200);
-    SetCamPosC(0, 0, 0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    spawn {
-        N(func_802433C0_CC6BD0)(55);
-    }
-    SetNpcFlagBits(NPC_LAKILULU0, ((NPC_FLAG_100)), TRUE);
-    EVT_VAR(9) = spawn N(80244560);
-    LoadPath(55, N(vectorList_80244420), 5, 0);
-20:
-    GetNextPathPos();
-    SetNpcPos(NPC_LAKILULU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    sleep 1;
-    if (EVT_VAR(0) == 1) {
-        goto 20;
-    }
-    kill EVT_VAR(9);
-    GetCurrentPartnerID(EVT_VAR(0));
-    BringPartnerOut(8);
-    if (EVT_VAR(0) != 8) {
-        SetNpcJumpscale(NPC_PARTNER, 0.0);
-        GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        EVT_VAR(1) += 20;
-        EVT_VAR(2) += 20;
-        EVT_VAR(3) += 20;
-        NpcJump0(NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30);
-    }
-    DisablePartnerAI(0);
-    InterpNpcYaw(NPC_PARTNER, 270, 0);
-    sleep 5;
-    SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00B5));
-    EnablePartnerAI();
-    PutPartnerAway();
-    ResetCam(0, 90.0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80245014) = {
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(AwaitPlayerLeave, EVT_VAR(0), EVT_VAR(2), 120)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), 0, EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 250)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(5.5), EVT_FIXED(-7.5))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(NpcFaceNpc, 1, 0, 1)
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B4))
+    EVT_CALL(NpcFaceNpc, NPC_PARTNER, 1, 1)
+    EVT_CALL(SetCamDistance, 0, 600)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(10.0), EVT_FIXED(-8.0))
+    EVT_CALL(SetCamPosA, 0, 0, 0)
+    EVT_CALL(SetCamPosB, 0, 130, -200)
+    EVT_CALL(SetCamPosC, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_THREAD
+        EVT_CALL(N(func_802433C0_CC6BD0), 55)
+    EVT_END_THREAD
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), TRUE)
+    EVT_EXEC_GET_TID(N(80244560), EVT_VAR(9))
+    EVT_CALL(LoadPath, 55, EVT_PTR(N(vectorList_80244420)), 5, 0)
+    EVT_LABEL(20)
+    EVT_CALL(GetNextPathPos)
+    EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_GOTO(20)
+    EVT_END_IF
+    EVT_KILL_THREAD(EVT_VAR(9))
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_CALL(BringPartnerOut, 8)
+    EVT_IF_NE(EVT_VAR(0), 8)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_ADD(EVT_VAR(1), 20)
+        EVT_ADD(EVT_VAR(2), 20)
+        EVT_ADD(EVT_VAR(3), 20)
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30)
+    EVT_END_IF
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(InterpNpcYaw, NPC_PARTNER, 270, 0)
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00B5))
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(PutPartnerAway)
+    EVT_CALL(ResetCam, 0, EVT_FIXED(90.0))
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245444) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    sleep 30;
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_A, NPC_ANIM_world_lakilester_Palette_00_Anim_4, 0, MESSAGE_ID(0x11, 0x00A2));
-    SetNpcPos(NPC_LAKILULU0, -290, 120, 45);
-    spawn {
-        sleep 10;
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_world_lakilester_Palette_00_Anim_1);
-        SetPlayerAnimation(0x1002A);
-        sleep 20;
-        InterpPlayerYaw(270, 1);
-    }
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00A3));
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_7);
-    UseSettingsFrom(0, 0, 0, 0);
-    SetPanTarget(0, 0, 0, 0);
-    SetCamDistance(0, 500);
-    SetCamPitch(0, 5.5, -6.0);
-    SetCamPosA(0, 0, 0);
-    SetCamPosB(0, 130, -200);
-    SetCamPosC(0, 0, 0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    sleep 1;
-    spawn {
-        SetCamDistance(0, 400);
-        SetCamPosB(0, 130, 60);
-        SetCamSpeed(0, 1.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-    }
-    spawn {
-        N(func_802433C0_CC6BD0)(80);
-    }
-    EVT_VAR(9) = spawn N(80244560);
-    LoadPath(80, N(vectorList_802443E4), 5, 0);
-0:
-    GetNextPathPos();
-    SetNpcPos(NPC_LAKILULU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    sleep 1;
-    if (EVT_VAR(0) == 1) {
-        goto 0;
-    }
-    kill EVT_VAR(9);
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_9);
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    sleep 20;
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 20;
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 250);
-    SetCamPitch(0, 5.5, -7.5);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00A4));
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 40;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 300);
-    SetCamSpeed(0, 4.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_8, NPC_ANIM_lakilulu_Palette_00_Anim_8, 0, MESSAGE_ID(0x11, 0x00A5));
-    GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 20;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 250);
-    SetCamSpeed(0, 4.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00A6));
-    SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_1);
-    EndSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 40;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 350);
-    SetCamSpeed(0, 10.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-10:
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 0, MESSAGE_ID(0x11, 0x00A7));
-    ShowChoice(MESSAGE_ID(0x1E, 0x0020));
-    if (EVT_VAR(0) != 0) {
-        await N(80244888);
-        sleep 10;
-        goto 10;
-    } else {
-        ContinueSpeech(1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11,
-                       0x00A9));
-        SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_1);
-        SetPlayerAnimation(ANIM_NOD_YES);
-        sleep 10;
-        SetPlayerAnimation(ANIM_STAND_STILL);
-        sleep 20;
-        GetNpcPos(NPC_LAKILULU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(0) += 20;
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamDistance(0, 250);
-        SetCamSpeed(0, 90.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00AA));
-        SetNpcAnimation(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_1);
-        EndSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(0) += 40;
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamDistance(0, 350);
-        SetCamSpeed(0, 5.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        sleep 10;
-        SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00AB));
-        sleep 10;
-        ShowChoice(MESSAGE_ID(0x1E, 0x0021));
-        match EVT_VAR(0) {
-            == -1 {}
-            == 0 {
-                ContinueSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AC));
-            }
-            == 1 {
-                ContinueSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AD));
-            }
-            == 2 {
-                ContinueSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AE));
-            }
-            == 3 {
-                ContinueSpeech(0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AF));
-            }
-        }
-    }
-    InterpNpcYaw(NPC_LAKILULU0, 90, 1);
-    SetNpcAnimation(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_9);
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 5, MESSAGE_ID(0x11, 0x00B0));
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B1));
-    sleep 15;
-    SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 5, MESSAGE_ID(0x11, 0x00B2));
-    SpeakToPlayer(NPC_WORLD_LAKILESTER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B3));
-    sleep 10;
-    spawn {
-        ResetCam(0, 90.0);
-    }
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 30;
-    SetNpcSpeed(NPC_WORLD_LAKILESTER, 3.5);
-    NpcMoveTo(NPC_WORLD_LAKILESTER, EVT_VAR(0), 60, 0);
-    N(UnkFunc41)(0, 8);
-    N(LoadPartyImage)();
-    spawn N(802438CC);
-    sleep 15;
-    ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x0190), 160, 40);
-    spawn N(802438F8);
-    sleep 10;
-    PanToTarget(0, 0, 0);
-    EVT_STORY_PROGRESS = STORY_CH6_LAKILESTER_JOINED_PARTY;
-    EnablePartnerAI();
-    DisablePlayerInput(FALSE);
-    await N(80245014);
-});
+EvtSource N(80245444) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_A, NPC_ANIM_world_lakilester_Palette_00_Anim_4, 0, MESSAGE_ID(0x11, 0x00A2))
+    EVT_CALL(SetNpcPos, 1, -290, 120, 45)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_lakilester_Palette_00_Anim_1)
+        EVT_CALL(SetPlayerAnimation, 65578)
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(InterpPlayerYaw, 270, 1)
+    EVT_END_THREAD
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00A3))
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_7)
+    EVT_CALL(UseSettingsFrom, 0, 0, 0, 0)
+    EVT_CALL(SetPanTarget, 0, 0, 0, 0)
+    EVT_CALL(SetCamDistance, 0, 500)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(5.5), EVT_FIXED(-6.0))
+    EVT_CALL(SetCamPosA, 0, 0, 0)
+    EVT_CALL(SetCamPosB, 0, 130, -200)
+    EVT_CALL(SetCamPosC, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_WAIT_FRAMES(1)
+    EVT_THREAD
+        EVT_CALL(SetCamDistance, 0, 400)
+        EVT_CALL(SetCamPosB, 0, 130, 60)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(N(func_802433C0_CC6BD0), 80)
+    EVT_END_THREAD
+    EVT_EXEC_GET_TID(N(80244560), EVT_VAR(9))
+    EVT_CALL(LoadPath, 80, EVT_PTR(N(vectorList_802443E4)), 5, 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetNextPathPos)
+    EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_KILL_THREAD(EVT_VAR(9))
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_9)
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 20)
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 250)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(5.5), EVT_FIXED(-7.5))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00A4))
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 40)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_8, NPC_ANIM_lakilulu_Palette_00_Anim_8, 0, MESSAGE_ID(0x11, 0x00A5))
+    EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 20)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 250)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00A6))
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_1)
+    EVT_CALL(EndSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 40)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 350)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(10.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_LABEL(10)
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 0, MESSAGE_ID(0x11, 0x00A7))
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0020))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_EXEC_WAIT(N(80244888))
+        EVT_WAIT_FRAMES(10)
+        EVT_GOTO(10)
+    EVT_ELSE
+        EVT_CALL(ContinueSpeech, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00A9))
+        EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_1)
+        EVT_CALL(SetPlayerAnimation, ANIM_NOD_YES)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), 20)
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamDistance, 0, 250)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00AA))
+        EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_1)
+        EVT_CALL(EndSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), 40)
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamDistance, 0, 350)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(5.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_B, NPC_ANIM_world_lakilester_Palette_00_Anim_3, 0, MESSAGE_ID(0x11, 0x00AB))
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x0021))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_EQ(-1)
+            EVT_CASE_EQ(0)
+                EVT_CALL(ContinueSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AC))
+            EVT_CASE_EQ(1)
+                EVT_CALL(ContinueSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AD))
+            EVT_CASE_EQ(2)
+                EVT_CALL(ContinueSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AE))
+            EVT_CASE_EQ(3)
+                EVT_CALL(ContinueSpeech, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00AF))
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_CALL(InterpNpcYaw, 1, 90, 1)
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_lakilulu_Palette_00_Anim_9)
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 5, MESSAGE_ID(0x11, 0x00B0))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B1))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_A, NPC_ANIM_lakilulu_Palette_00_Anim_9, 5, MESSAGE_ID(0x11, 0x00B2))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x00B3))
+    EVT_WAIT_FRAMES(10)
+    EVT_THREAD
+        EVT_CALL(ResetCam, 0, EVT_FIXED(90.0))
+    EVT_END_THREAD
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 30)
+    EVT_CALL(SetNpcSpeed, 0, EVT_FIXED(3.5))
+    EVT_CALL(NpcMoveTo, 0, EVT_VAR(0), 60, 0)
+    EVT_CALL(N(UnkFunc41), 0, 8)
+    EVT_CALL(N(LoadPartyImage))
+    EVT_EXEC(N(802438CC))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x0190), 160, 40)
+    EVT_EXEC(N(802438F8))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_SET(EVT_SAVE_VAR(0), 51)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_EXEC_WAIT(N(80245014))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_80246038) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_world_lakilester_Palette_00_Anim_4);
-            SetCamType(0, 6, 1);
-            GetNpcPos(NPC_SELF, EVT_VAR(3), EVT_VAR(1), EVT_VAR(2));
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(0) += EVT_VAR(3);
-            EVT_VAR(0) /= 2;
-            UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 300);
-            SetCamPitch(0, 17.0, -7.5);
-            SetCamSpeed(0, 90.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            spawn N(80245444);
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_80246038) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_world_lakilester_Palette_00_Anim_4)
+            EVT_CALL(SetCamType, 0, 6, 1)
+            EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(3), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(0), EVT_VAR(3))
+            EVT_DIV(EVT_VAR(0), 2)
+            EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, 300)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-7.5))
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_EXEC(N(80245444))
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_802461C0) = SCRIPT({
-    if (EVT_STORY_PROGRESS <= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0,
-                      MESSAGE_ID(0x11, 0x0032));
-    } else {
-        GetCurrentPartnerID(EVT_VAR(0));
-        if (EVT_VAR(0) != 8) {
-            SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0,
-                          MESSAGE_ID(0x11, 0x0034));
-        } else {
-            SpeakToPlayer(NPC_LAKILULU0, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0,
-                          MESSAGE_ID(0x11, 0x0032));
-        }
-    }
-});
+EvtSource N(interact_802461C0) = {
+    EVT_IF_LE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0032))
+    EVT_ELSE
+        EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+        EVT_IF_NE(EVT_VAR(0), 8)
+            EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0034))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakilulu_Palette_00_Anim_4, NPC_ANIM_lakilulu_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0032))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80246280) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_LAKILESTER_JOINED_PARTY) {
-        BindNpcIdle(NPC_SELF, N(idle_80244BF8));
-        BindNpcDefeat(NPC_SELF, N(defeat_80246038));
-    }
-});
+EvtSource N(init_80246280) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 51)
+        EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80244BF8)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80246038)))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802462D0) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_BEGAN_PEACH_MISSION) {
-        BindNpcInteract(NPC_SELF, N(interact_802461C0));
-        SetNpcCollisionSize(-1, 36, 28);
-        if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-            SetNpcPos(NPC_SELF, -50, 180, -50);
-        }
-    } else {
-        RemoveNpc(NPC_SELF);
-    }
-});
+EvtSource N(init_802462D0) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 58)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802461C0)))
+        EVT_CALL(SetNpcCollisionSize, -1, 36, 28)
+        EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+            EVT_CALL(SetNpcPos, NPC_SELF, -50, 180, -50)
+        EVT_END_IF
+    EVT_ELSE
+        EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80246370) = SCRIPT({
-    SetNpcPos(NPC_LAKILULU1, 0, -1000, 0);
-    SetNpcAnimation(NPC_LAKILULU1, NPC_ANIM_lakilulu_Palette_00_Anim_B);
-});
+EvtSource N(init_80246370) = {
+    EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_lakilulu_Palette_00_Anim_B)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802463B0) = SCRIPT({
-    if (EVT_STORY_PROGRESS == STORY_CH6_SPOKE_WITH_THE_SUN) {
-        RemoveNpc(NPC_SELF);
-    }
-});
+EvtSource N(init_802463B0) = {
+    EVT_IF_EQ(EVT_SAVE_VAR(0), 50)
+        EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802463E8) = SCRIPT({
-    if (EVT_STORY_PROGRESS == STORY_CH6_SPOKE_WITH_THE_SUN) {
-        RemoveNpc(NPC_SELF);
-    }
-    SetSelfVar(13, 1);
-});
+EvtSource N(init_802463E8) = {
+    EVT_IF_EQ(EVT_SAVE_VAR(0), 50)
+        EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_IF
+    EVT_CALL(SetSelfVar, 13, 1)
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80246434) = {
     .id = NPC_WORLD_LAKILESTER,

--- a/src/world/area_flo/flo_14/CCB310.c
+++ b/src/world/area_flo/flo_14/CCB310.c
@@ -14,39 +14,44 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_14_tattle },
 };
 
-EvtSource N(802423F0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(802423F0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(updateTexturePan_80242460) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(updateTexturePan_80242460) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_802424FC) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  1);
 
 EvtSource N(exitWalk_80242558) = EXIT_WALK_SCRIPT(60,  1, "flo_13",  0);
 
-EvtSource N(802425B4) = SCRIPT({
-    bind N(exitWalk_80242558) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_802424FC) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(802425B4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80242558), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_802424FC), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_802425FC)[] = {
     0x0000001F, 0xC3FA0000, 0x00000000, 0xC2B40000, 0x00000019, 0xC3FF0000, 0x00000000, 0x00000000,
@@ -57,213 +62,223 @@ s32 N(lavaResetList_802425FC)[] = {
     0x00000023, 0xC2480000, 0x00000000, 0x42DC0000, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80244F00));
-    spawn N(80244F30);
-    ModifyColliderFlags(3, 9, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_802425FC));
-    }
-    EnableTexPanning(29, 1);
-    EnableTexPanning(31, 1);
-    EnableTexPanning(32, 1);
-    EnableTexPanning(35, 1);
-    EnableTexPanning(36, 1);
-    EnableTexPanning(39, 1);
-    EnableTexPanning(41, 1);
-    EnableTexPanning(43, 1);
-    EnableTexPanning(45, 1);
-    EnableTexPanning(47, 1);
-    EnableTexPanning(49, 1);
-    EnableTexPanning(51, 1);
-    EnableTexPanning(53, 1);
-    EnableTexPanning(30, 1);
-    EnableTexPanning(33, 1);
-    EnableTexPanning(34, 1);
-    EnableTexPanning(37, 1);
-    EnableTexPanning(38, 1);
-    EnableTexPanning(42, 1);
-    EnableTexPanning(44, 1);
-    EnableTexPanning(46, 1);
-    EnableTexPanning(48, 1);
-    EnableTexPanning(50, 1);
-    EnableTexPanning(52, 1);
-    EnableTexPanning(54, 1);
-    spawn {
-        EVT_VAR(0) = 1;
-        EVT_VAR(1) = 140;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_80242460);
-    }
-    spawn {
-        EVT_VAR(0) = 2;
-        EVT_VAR(1) = -200;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_80242460);
-    }
-    spawn N(80243E78);
-    spawn N(80245224);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(802425B4);
-    spawn EnterWalk;
-    await N(802423F0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_8024030C_CCB61C)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80244F00)))
+    EVT_EXEC(N(80244F30))
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_802425FC)))
+    EVT_END_THREAD
+    EVT_CALL(EnableTexPanning, 29, 1)
+    EVT_CALL(EnableTexPanning, 31, 1)
+    EVT_CALL(EnableTexPanning, 32, 1)
+    EVT_CALL(EnableTexPanning, 35, 1)
+    EVT_CALL(EnableTexPanning, 36, 1)
+    EVT_CALL(EnableTexPanning, 39, 1)
+    EVT_CALL(EnableTexPanning, 41, 1)
+    EVT_CALL(EnableTexPanning, 43, 1)
+    EVT_CALL(EnableTexPanning, 45, 1)
+    EVT_CALL(EnableTexPanning, 47, 1)
+    EVT_CALL(EnableTexPanning, 49, 1)
+    EVT_CALL(EnableTexPanning, 51, 1)
+    EVT_CALL(EnableTexPanning, 53, 1)
+    EVT_CALL(EnableTexPanning, 30, 1)
+    EVT_CALL(EnableTexPanning, 33, 1)
+    EVT_CALL(EnableTexPanning, 34, 1)
+    EVT_CALL(EnableTexPanning, 37, 1)
+    EVT_CALL(EnableTexPanning, 38, 1)
+    EVT_CALL(EnableTexPanning, 42, 1)
+    EVT_CALL(EnableTexPanning, 44, 1)
+    EVT_CALL(EnableTexPanning, 46, 1)
+    EVT_CALL(EnableTexPanning, 48, 1)
+    EVT_CALL(EnableTexPanning, 50, 1)
+    EVT_CALL(EnableTexPanning, 52, 1)
+    EVT_CALL(EnableTexPanning, 54, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 1)
+        EVT_SET(EVT_VAR(1), 140)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_80242460))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(1), -200)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_80242460))
+    EVT_END_THREAD
+    EVT_EXEC(N(80243E78))
+    EVT_EXEC(N(80245224))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(802425B4)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(802423F0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_8024030C_CCB61C))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2BF4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80242C00) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80242C00) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242EAC) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(6);
-    EVT_VAR(8) = EVT_VAR(5);
-    EVT_VAR(7) = EVT_VAR(4);
-    EVT_VAR(6) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(2);
-    EVT_VAR(4) = EVT_VAR(1);
-    EVT_VAR(3) = EVT_VAR(0);
-    EnableModel(EVT_VAR(6), 0);
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(UnkFunc43)();
-    if (EVT_VAR(0) == 0) {
-        sleep 1;
-        goto 0;
-    }
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    if (EVT_VAR(10) != 0) {
-        spawn {
-            sleep 5;
-            EVT_VAR(0) = EVT_VAR(3);
-            EVT_VAR(1) = EVT_VAR(4);
-            EVT_VAR(2) = EVT_VAR(5);
-            EVT_VAR(1) += 10;
-            EVT_VAR(2) += 8;
-            PlayEffect(0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) -= 10;
-            MakeItemEntity(EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0);
-        }
-    }
-    spawn {
-        sleep 10;
-        PlaySoundAt(0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 1, 0, 0);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 1, 0, 0);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(80242EAC) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(6))
+    EVT_SET(EVT_VAR(8), EVT_VAR(5))
+    EVT_SET(EVT_VAR(7), EVT_VAR(4))
+    EVT_SET(EVT_VAR(6), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(2))
+    EVT_SET(EVT_VAR(4), EVT_VAR(1))
+    EVT_SET(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(UnkFunc43))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(5)
+            EVT_SET(EVT_VAR(0), EVT_VAR(3))
+            EVT_SET(EVT_VAR(1), EVT_VAR(4))
+            EVT_SET(EVT_VAR(2), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_ADD(EVT_VAR(2), 8)
+            EVT_CALL(PlayEffect, 0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_SUB(EVT_VAR(1), 10)
+            EVT_CALL(MakeItemEntity, EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAt, 0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 1, 0, 0)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_802431CC_CCE4DC) = {
     0x00000000,
 };
 
-EvtSource N(802431D0) = SCRIPT({
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    MakeLerp(EVT_VAR(1), 48, 15, 0);
-    loop {
-        UpdateLerp();
-        GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        SetCamTarget(0, EVT_VAR(2), EVT_VAR(0), EVT_VAR(4));
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamTarget(0, EVT_VAR(0), 48, EVT_VAR(2));
-        sleep 1;
-    }
-});
+EvtSource N(802431D0) = {
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(MakeLerp, EVT_VAR(1), 48, 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_CALL(SetCamTarget, 0, EVT_VAR(2), EVT_VAR(0), EVT_VAR(4))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamTarget, 0, EVT_VAR(0), 48, EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802432E8) = SCRIPT({
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE);
-    loop {
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(1) += 20;
-        EVT_VAR(2) += -5;
-        SetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        sleep 1;
-    }
-});
+EvtSource N(802432E8) = {
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE)
+    EVT_LOOP(0)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(1), 20)
+        EVT_ADD(EVT_VAR(2), -5)
+        EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
 Vec3f N(vectorList_80243384)[] = {
     { 531.0, 75.0, 81.0 }, { 481.0, 80.0, 81.0 },
@@ -275,117 +290,123 @@ Vec3f N(vectorList_80243384)[] = {
     { -69.0, 75.0, 81.0 },
 };
 
-EvtSource N(80243420) = SCRIPT({
-    sleep 20;
-    PlaySound(0x80000023);
-    LoadPath(165, N(vectorList_80243384), 13, 10);
-0:
-    GetNextPathPos();
-    TranslateModel(123, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    EVT_VAR(2) += -27;
-    EVT_VAR(3) += -10;
-    SetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    N(func_8024046C_CCB77C)(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-    sleep 1;
-    if (EVT_VAR(0) == 1) {
-        goto 0;
-    }
-    StopSound(0x80000023);
-});
+EvtSource N(80243420) = {
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(PlaySound, 0x80000023)
+    EVT_CALL(LoadPath, 165, EVT_PTR(N(vectorList_80243384)), 13, 10)
+    EVT_LABEL(0)
+    EVT_CALL(GetNextPathPos)
+    EVT_CALL(TranslateModel, 123, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(2), -27)
+    EVT_ADD(EVT_VAR(3), -10)
+    EVT_CALL(SetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_CALL(N(func_8024046C_CCB77C), EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_CALL(StopSound, 0x80000023)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024352C) = SCRIPT({
-    IsPlayerWithin(531, 81, 30, EVT_VAR(0));
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    GetCurrentPartner(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        func_802D2B6C();
-        sleep 20;
-    }
-    DisablePlayerPhysics(TRUE);
-    DisablePartnerAI(0);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-    GetModelCenter(123);
-    spawn {
-        EVT_VAR(2) += -10;
-        SetPlayerJumpscale(0.2001953125);
-        PlayerJump(531, 48, EVT_VAR(2), 10);
-        SetPlayerActionState(10);
-    }
-    spawn {
-        sleep 5;
-        EVT_VAR(2) += -15;
-        SetNpcJumpscale(NPC_PARTNER, 0.2001953125);
-        NpcJump0(NPC_PARTNER, 531, 68, EVT_VAR(2), 10);
-    }
-    EVT_MAP_VAR(9) = spawn N(802431D0);
-    sleep 15;
-    N(func_802403D4_CCB6E4)();
-    if (EVT_VAR(14) != 0) {
-        EVT_VAR(14) = spawn N(802432E8);
-    }
-    await N(80243420);
-    if (EVT_VAR(14) != 0) {
-        kill EVT_VAR(14);
-        N(func_8024042C_CCB73C)();
-    }
-    GetModelCenter(123);
-    PlayEffect(0x43, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 2, 0, 0, 0, 0, 0, 0, 0, 0);
-    PlaySoundAt(0x2F3, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ClearPartnerMoveHistory(-4);
-    EnableModel(123, 0);
-    EVT_AREA_FLAG(37) = 0;
-    kill EVT_MAP_VAR(9);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_GRAVITY)), TRUE);
-    EnablePartnerAI();
-    DisablePlayerPhysics(FALSE);
-    DisablePlayerInput(FALSE);
-    unbind;
-});
+EvtSource N(8024352C) = {
+    EVT_CALL(IsPlayerWithin, 531, 81, 30, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(GetCurrentPartner, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(func_802D2B6C)
+        EVT_WAIT_FRAMES(20)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(GetModelCenter, 123)
+    EVT_THREAD
+        EVT_ADD(EVT_VAR(2), -10)
+        EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.2))
+        EVT_CALL(PlayerJump, 531, 48, EVT_VAR(2), 10)
+        EVT_CALL(SetPlayerActionState, 10)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_ADD(EVT_VAR(2), -15)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.2))
+        EVT_CALL(NpcJump0, NPC_PARTNER, 531, 68, EVT_VAR(2), 10)
+    EVT_END_THREAD
+    EVT_EXEC_GET_TID(N(802431D0), EVT_MAP_VAR(9))
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(N(func_802403D4_CCB6E4))
+    EVT_IF_NE(EVT_VAR(14), 0)
+        EVT_EXEC_GET_TID(N(802432E8), EVT_VAR(14))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80243420))
+    EVT_IF_NE(EVT_VAR(14), 0)
+        EVT_KILL_THREAD(EVT_VAR(14))
+        EVT_CALL(N(func_8024042C_CCB73C))
+    EVT_END_IF
+    EVT_CALL(GetModelCenter, 123)
+    EVT_CALL(PlayEffect, 0x43, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 2, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_CALL(PlaySoundAt, 0x2F3, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ClearPartnerMoveHistory, -4)
+    EVT_CALL(EnableModel, 123, 0)
+    EVT_SET(EVT_AREA_FLAG(37), 0)
+    EVT_KILL_THREAD(EVT_MAP_VAR(9))
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), TRUE)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243870) = SCRIPT({
-    PlaySoundAt(0x193, 0, 591, 55, 121);
-    EnableModel(123, 1);
-    EVT_VAR(2) = 1.0;
-    EVT_VAR(4) = 0.0;
-    EVT_VAR(5) = 0.0;
-    EVT_VAR(6) = 0.0;
-    EVT_VAR(7) = -30;
-    EVT_VAR(8) = 20;
-    EVT_VAR(7) /= 90.0;
-    EVT_VAR(8) /= 90.0;
-    EVT_VAR(9) = 180;
-    loop EVT_VAR(9) {
-        TranslateModel(123, 591, 55, 121);
-        EVT_VAR(3) = (float) EVT_VAR(2);
-        EVT_VAR(3) /= (float) 10;
-        ScaleModel(123, EVT_VAR(3), EVT_VAR(3), EVT_VAR(3));
-        TranslateModel(123, EVT_VAR(4), EVT_VAR(5), EVT_VAR(6));
-        EVT_VAR(2) += 0.05078125;
-        if (EVT_VAR(9) > 90) {
-            EVT_VAR(4) += (float) EVT_VAR(7);
-            EVT_VAR(5) += (float) EVT_VAR(8);
-        }
-        sleep 1;
-    }
-    EVT_VAR(7) = -30;
-    EVT_VAR(8) = -40;
-    EVT_VAR(7) /= 60.0;
-    EVT_VAR(8) /= 60.0;
-    loop 60 {
-        TranslateModel(123, 591, 55, 121);
-        ScaleModel(123, EVT_VAR(3), EVT_VAR(3), EVT_VAR(3));
-        TranslateModel(123, EVT_VAR(4), EVT_VAR(5), EVT_VAR(6));
-        EVT_VAR(4) += (float) EVT_VAR(7);
-        EVT_VAR(6) += (float) EVT_VAR(8);
-        sleep 1;
-    }
-    EVT_AREA_FLAG(36) = 0;
-    EVT_AREA_FLAG(37) = 1;
-});
+EvtSource N(80243870) = {
+    EVT_CALL(PlaySoundAt, 0x193, 0, 591, 55, 121)
+    EVT_CALL(EnableModel, 123, 1)
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(1.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(6), EVT_FIXED(0.0))
+    EVT_SET(EVT_VAR(7), -30)
+    EVT_SET(EVT_VAR(8), 20)
+    EVT_DIVF(EVT_VAR(7), EVT_FIXED(90.0))
+    EVT_DIVF(EVT_VAR(8), EVT_FIXED(90.0))
+    EVT_SET(EVT_VAR(9), 180)
+    EVT_LOOP(EVT_VAR(9))
+        EVT_CALL(TranslateModel, 123, 591, 55, 121)
+        EVT_SETF(EVT_VAR(3), EVT_VAR(2))
+        EVT_DIVF(EVT_VAR(3), 10)
+        EVT_CALL(ScaleModel, 123, EVT_VAR(3), EVT_VAR(3), EVT_VAR(3))
+        EVT_CALL(TranslateModel, 123, EVT_VAR(4), EVT_VAR(5), EVT_VAR(6))
+        EVT_ADDF(EVT_VAR(2), EVT_FIXED(0.05))
+        EVT_IF_GT(EVT_VAR(9), 90)
+            EVT_ADDF(EVT_VAR(4), EVT_VAR(7))
+            EVT_ADDF(EVT_VAR(5), EVT_VAR(8))
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SET(EVT_VAR(7), -30)
+    EVT_SET(EVT_VAR(8), -40)
+    EVT_DIVF(EVT_VAR(7), EVT_FIXED(60.0))
+    EVT_DIVF(EVT_VAR(8), EVT_FIXED(60.0))
+    EVT_LOOP(60)
+        EVT_CALL(TranslateModel, 123, 591, 55, 121)
+        EVT_CALL(ScaleModel, 123, EVT_VAR(3), EVT_VAR(3), EVT_VAR(3))
+        EVT_CALL(TranslateModel, 123, EVT_VAR(4), EVT_VAR(5), EVT_VAR(6))
+        EVT_ADDF(EVT_VAR(4), EVT_VAR(7))
+        EVT_ADDF(EVT_VAR(6), EVT_VAR(8))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SET(EVT_AREA_FLAG(36), 0)
+    EVT_SET(EVT_AREA_FLAG(37), 1)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_80243B14_CCEE24) = {
     0x00000000,
@@ -395,157 +416,161 @@ s32 N(D_80243B18_CCEE28) = {
     0x0000005A,
 };
 
-EvtSource N(80243B1C) = SCRIPT({
-    group 0;
-    EVT_VAR(15) = EVT_VAR(0);
-0:
-    if (EVT_AREA_FLAG(35) == 1) {
-        sleep 10;
-        goto 0;
-    }
-    buf_use N(D_802431CC_CCE4DC);
-    buf_read EVT_VAR(0);
-    if (EVT_VAR(0) == 0) {
-        RandInt(10, EVT_VAR(0));
-        EVT_VAR(0) += 1;
-        sleep EVT_VAR(0);
-        goto 0;
-    }
-    EnableModel(EVT_VAR(15), 1);
-    RandInt(4, EVT_VAR(0));
-    EVT_VAR(0) += 4.0;
-    EVT_VAR(0) *= -1.0;
-    EVT_VAR(1) = 2.0;
-    EVT_VAR(2) = (float) EVT_VAR(0);
-    EVT_VAR(2) /= 10.0;
-    EVT_VAR(3) = 0.4;
-    EVT_VAR(4) = 591.0;
-    EVT_VAR(5) = 60.0;
-    EVT_VAR(6) = 121.0;
-    RandInt(3, EVT_VAR(7));
-    EVT_VAR(7) += 3.0;
-    EVT_VAR(7) *= 0.04;
-    EVT_VAR(9) = (float) EVT_VAR(7);
-    EVT_VAR(9) /= 5.0;
-    RandInt(50, EVT_VAR(8));
-    EVT_VAR(8) += 50;
-    loop EVT_VAR(8) {
-        EVT_VAR(14) = (float) EVT_VAR(2);
-        EVT_VAR(14) -= (float) EVT_VAR(0);
-        EVT_VAR(14) *= 0.046875;
-        EVT_VAR(0) += (float) EVT_VAR(14);
-        EVT_VAR(14) = (float) EVT_VAR(3);
-        EVT_VAR(14) -= (float) EVT_VAR(1);
-        EVT_VAR(14) *= 0.046875;
-        EVT_VAR(1) += (float) EVT_VAR(14);
-        EVT_VAR(4) += (float) EVT_VAR(0);
-        EVT_VAR(5) += (float) EVT_VAR(1);
-        EVT_VAR(14) = (float) EVT_VAR(7);
-        EVT_VAR(14) -= (float) EVT_VAR(9);
-        EVT_VAR(14) *= 0.203125;
-        EVT_VAR(9) += (float) EVT_VAR(14);
-        TranslateModel(EVT_VAR(15), EVT_VAR(4), EVT_VAR(5), EVT_VAR(6));
-        ScaleModel(EVT_VAR(15), EVT_VAR(9), EVT_VAR(9), EVT_VAR(9));
-        sleep 1;
-    }
-    EnableModel(EVT_VAR(15), 0);
-    goto 0;
-});
+EvtSource N(80243B1C) = {
+    EVT_SET_GROUP(0)
+    EVT_SET(EVT_VAR(15), EVT_VAR(0))
+    EVT_LABEL(0)
+    EVT_IF_EQ(EVT_AREA_FLAG(35), 1)
+        EVT_WAIT_FRAMES(10)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_USE_BUF(EVT_PTR(N(D_802431CC_CCE4DC)))
+    EVT_BUF_READ1(EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_CALL(RandInt, 10, EVT_VAR(0))
+        EVT_ADD(EVT_VAR(0), 1)
+        EVT_WAIT_FRAMES(EVT_VAR(0))
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(15), 1)
+    EVT_CALL(RandInt, 4, EVT_VAR(0))
+    EVT_ADDF(EVT_VAR(0), EVT_FIXED(4.0))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-1.0))
+    EVT_SETF(EVT_VAR(1), EVT_FIXED(2.0))
+    EVT_SETF(EVT_VAR(2), EVT_VAR(0))
+    EVT_DIVF(EVT_VAR(2), EVT_FIXED(10.0))
+    EVT_SETF(EVT_VAR(3), EVT_FIXED(0.4))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(591.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(60.0))
+    EVT_SETF(EVT_VAR(6), EVT_FIXED(121.0))
+    EVT_CALL(RandInt, 3, EVT_VAR(7))
+    EVT_ADDF(EVT_VAR(7), EVT_FIXED(3.0))
+    EVT_MULF(EVT_VAR(7), EVT_FIXED(0.04))
+    EVT_SETF(EVT_VAR(9), EVT_VAR(7))
+    EVT_DIVF(EVT_VAR(9), EVT_FIXED(5.0))
+    EVT_CALL(RandInt, 50, EVT_VAR(8))
+    EVT_ADD(EVT_VAR(8), 50)
+    EVT_LOOP(EVT_VAR(8))
+        EVT_SETF(EVT_VAR(14), EVT_VAR(2))
+        EVT_SUBF(EVT_VAR(14), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(14), EVT_FIXED(0.046875))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(14))
+        EVT_SETF(EVT_VAR(14), EVT_VAR(3))
+        EVT_SUBF(EVT_VAR(14), EVT_VAR(1))
+        EVT_MULF(EVT_VAR(14), EVT_FIXED(0.046875))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(14))
+        EVT_ADDF(EVT_VAR(4), EVT_VAR(0))
+        EVT_ADDF(EVT_VAR(5), EVT_VAR(1))
+        EVT_SETF(EVT_VAR(14), EVT_VAR(7))
+        EVT_SUBF(EVT_VAR(14), EVT_VAR(9))
+        EVT_MULF(EVT_VAR(14), EVT_FIXED(0.203125))
+        EVT_ADDF(EVT_VAR(9), EVT_VAR(14))
+        EVT_CALL(TranslateModel, EVT_VAR(15), EVT_VAR(4), EVT_VAR(5), EVT_VAR(6))
+        EVT_CALL(ScaleModel, EVT_VAR(15), EVT_VAR(9), EVT_VAR(9), EVT_VAR(9))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(EnableModel, EVT_VAR(15), 0)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 
-EvtSource N(80243E78) = SCRIPT({
-    ModifyColliderFlags(3, 31, 0x00000006);
-    ModifyColliderFlags(3, 32, 0x00000006);
-    ModifyColliderFlags(3, 33, 0x00000006);
-    ModifyColliderFlags(3, 34, 0x00000006);
-    ModifyColliderFlags(3, 35, 0x00000006);
-    EVT_VAR(0) = -730;
-    EVT_VAR(1) = -130;
-    EVT_VAR(2) = -470;
-    EVT_VAR(3) = -70;
-    EVT_VAR(4) = 0;
-    spawn N(80242C00);
-    EVT_VAR(0) = -730;
-    EVT_VAR(1) = 70;
-    EVT_VAR(2) = -470;
-    EVT_VAR(3) = 140;
-    EVT_VAR(4) = 0;
-    spawn N(80242C00);
-    EVT_VAR(0) = -280;
-    EVT_VAR(1) = 130;
-    EVT_VAR(2) = -110;
-    EVT_VAR(3) = -70;
-    EVT_VAR(4) = 0;
-    spawn N(80242C00);
-    EVT_VAR(0) = -280;
-    EVT_VAR(1) = 70;
-    EVT_VAR(2) = -10;
-    EVT_VAR(3) = 140;
-    EVT_VAR(4) = 0;
-    spawn N(80242C00);
-    GetModelCenter(96);
-    EVT_VAR(3) = 96;
-    EVT_VAR(4) = 97;
-    EVT_VAR(5) = 98;
-    EVT_VAR(6) = 99;
-    EVT_VAR(10) = 174;
-    spawn N(80242EAC);
-    GetModelCenter(82);
-    EVT_VAR(3) = 82;
-    EVT_VAR(4) = 83;
-    EVT_VAR(5) = 84;
-    EVT_VAR(6) = 85;
-    EVT_VAR(10) = 0;
-    spawn N(80242EAC);
-    GetModelCenter(76);
-    EVT_VAR(3) = 76;
-    EVT_VAR(4) = 77;
-    EVT_VAR(5) = 78;
-    EVT_VAR(6) = 79;
-    EVT_VAR(10) = 0;
-    spawn N(80242EAC);
-    GetModelCenter(90);
-    EVT_VAR(3) = 90;
-    EVT_VAR(4) = 91;
-    EVT_VAR(5) = 92;
-    EVT_VAR(6) = 93;
-    EVT_VAR(10) = 0;
-    spawn N(80242EAC);
-    ModifyColliderFlags(0, 15, 0x7FFFFE00);
-    CloneModel(124, 10001);
-    CloneModel(124, 10002);
-    CloneModel(124, 10003);
-    CloneModel(124, 10004);
-    CloneModel(124, 10005);
-    EnableModel(123, 0);
-    EnableModel(124, 0);
-    EnableModel(10001, 0);
-    EnableModel(10002, 0);
-    EnableModel(10003, 0);
-    EnableModel(10004, 0);
-    EnableModel(10005, 0);
-    EVT_VAR(0) = 10001;
-    spawn N(80243B1C);
-    EVT_VAR(0) = 10002;
-    spawn N(80243B1C);
-    EVT_VAR(0) = 10003;
-    spawn N(80243B1C);
-    EVT_VAR(0) = 10004;
-    spawn N(80243B1C);
-    EVT_VAR(0) = 10005;
-    spawn N(80243B1C);
-    MakeLocalVertexCopy(0, 123, 1);
-    SetCustomGfxBuilders(1, N(func_80240504_CCB814), 0);
-    SetModelCustomGfx(123, 1, -1);
-    SetModelCustomGfx(10001, 1, -1);
-    SetModelCustomGfx(10002, 1, -1);
-    SetModelCustomGfx(10003, 1, -1);
-    SetModelCustomGfx(10004, 1, -1);
-    SetModelCustomGfx(10005, 1, -1);
-    MakeLocalVertexCopy(1, 57, 1);
-    SetCustomGfxBuilders(2, N(func_802407D4_CCBAE4), 0);
-    SetModelCustomGfx(57, 2, -1);
-});
+EvtSource N(80243E78) = {
+    EVT_CALL(ModifyColliderFlags, 3, 31, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 32, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 33, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 34, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 35, 0x00000006)
+    EVT_SET(EVT_VAR(0), -730)
+    EVT_SET(EVT_VAR(1), -130)
+    EVT_SET(EVT_VAR(2), -470)
+    EVT_SET(EVT_VAR(3), -70)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242C00))
+    EVT_SET(EVT_VAR(0), -730)
+    EVT_SET(EVT_VAR(1), 70)
+    EVT_SET(EVT_VAR(2), -470)
+    EVT_SET(EVT_VAR(3), 140)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242C00))
+    EVT_SET(EVT_VAR(0), -280)
+    EVT_SET(EVT_VAR(1), 130)
+    EVT_SET(EVT_VAR(2), -110)
+    EVT_SET(EVT_VAR(3), -70)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242C00))
+    EVT_SET(EVT_VAR(0), -280)
+    EVT_SET(EVT_VAR(1), 70)
+    EVT_SET(EVT_VAR(2), -10)
+    EVT_SET(EVT_VAR(3), 140)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80242C00))
+    EVT_CALL(GetModelCenter, 96)
+    EVT_SET(EVT_VAR(3), 96)
+    EVT_SET(EVT_VAR(4), 97)
+    EVT_SET(EVT_VAR(5), 98)
+    EVT_SET(EVT_VAR(6), 99)
+    EVT_SET(EVT_VAR(10), 174)
+    EVT_EXEC(N(80242EAC))
+    EVT_CALL(GetModelCenter, 82)
+    EVT_SET(EVT_VAR(3), 82)
+    EVT_SET(EVT_VAR(4), 83)
+    EVT_SET(EVT_VAR(5), 84)
+    EVT_SET(EVT_VAR(6), 85)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80242EAC))
+    EVT_CALL(GetModelCenter, 76)
+    EVT_SET(EVT_VAR(3), 76)
+    EVT_SET(EVT_VAR(4), 77)
+    EVT_SET(EVT_VAR(5), 78)
+    EVT_SET(EVT_VAR(6), 79)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80242EAC))
+    EVT_CALL(GetModelCenter, 90)
+    EVT_SET(EVT_VAR(3), 90)
+    EVT_SET(EVT_VAR(4), 91)
+    EVT_SET(EVT_VAR(5), 92)
+    EVT_SET(EVT_VAR(6), 93)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(80242EAC))
+    EVT_CALL(ModifyColliderFlags, 0, 15, 0x7FFFFE00)
+    EVT_CALL(CloneModel, 124, 10001)
+    EVT_CALL(CloneModel, 124, 10002)
+    EVT_CALL(CloneModel, 124, 10003)
+    EVT_CALL(CloneModel, 124, 10004)
+    EVT_CALL(CloneModel, 124, 10005)
+    EVT_CALL(EnableModel, 123, 0)
+    EVT_CALL(EnableModel, 124, 0)
+    EVT_CALL(EnableModel, 10001, 0)
+    EVT_CALL(EnableModel, 10002, 0)
+    EVT_CALL(EnableModel, 10003, 0)
+    EVT_CALL(EnableModel, 10004, 0)
+    EVT_CALL(EnableModel, 10005, 0)
+    EVT_SET(EVT_VAR(0), 10001)
+    EVT_EXEC(N(80243B1C))
+    EVT_SET(EVT_VAR(0), 10002)
+    EVT_EXEC(N(80243B1C))
+    EVT_SET(EVT_VAR(0), 10003)
+    EVT_EXEC(N(80243B1C))
+    EVT_SET(EVT_VAR(0), 10004)
+    EVT_EXEC(N(80243B1C))
+    EVT_SET(EVT_VAR(0), 10005)
+    EVT_EXEC(N(80243B1C))
+    EVT_CALL(MakeLocalVertexCopy, 0, 123, 1)
+    EVT_CALL(SetCustomGfxBuilders, 1, EVT_PTR(N(func_80240504_CCB814)), 0)
+    EVT_CALL(SetModelCustomGfx, 123, 1, -1)
+    EVT_CALL(SetModelCustomGfx, 10001, 1, -1)
+    EVT_CALL(SetModelCustomGfx, 10002, 1, -1)
+    EVT_CALL(SetModelCustomGfx, 10003, 1, -1)
+    EVT_CALL(SetModelCustomGfx, 10004, 1, -1)
+    EVT_CALL(SetModelCustomGfx, 10005, 1, -1)
+    EVT_CALL(MakeLocalVertexCopy, 1, 57, 1)
+    EVT_CALL(SetCustomGfxBuilders, 2, EVT_PTR(N(func_802407D4_CCBAE4)), 0)
+    EVT_CALL(SetModelCustomGfx, 57, 2, -1)
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkTexturePanFunc.inc.c"
 

--- a/src/world/area_flo/flo_14/CCBE20.c
+++ b/src/world/area_flo/flo_14/CCBE20.c
@@ -29,13 +29,15 @@ NpcAISettings N(npcAISettings_802444D8) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80244508) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -630);
-    SetSelfVar(6, 50);
-    SetSelfVar(1, 200);
-    N(func_80241E1C_CCD12C)(N(npcAISettings_802444D8));
-});
+EvtSource N(npcAI_80244508) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -630)
+    EVT_CALL(SetSelfVar, 6, 50)
+    EVT_CALL(SetSelfVar, 1, 200)
+    EVT_CALL(N(func_80241E1C_CCD12C), EVT_PTR(N(npcAISettings_802444D8)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80244578) = {
     .height = 26,
@@ -66,95 +68,102 @@ s32 N(D_80244600_CCF910) = {
     0x00000000,
 };
 
-EvtSource N(80244604) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowConsumableChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_80242288_CCD598)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80244604) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80242288_CCD598), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244738) = SCRIPT({
-    N(func_802422C0_CCD5D0)(EVT_VAR(0));
-    bind_padlock N(80244604) 0x10 0 N(D_802453B0_EF79C0);
-    N(func_80242234_CCD544)(EVT_VAR(0));
-});
+EvtSource N(80244738) = {
+    EVT_CALL(N(func_802422C0_CCD5D0), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80244604), 0x10, 0, EVT_PTR(N(D_802453B0_EF79C0)), 0, 1)
+    EVT_CALL(N(func_80242234_CCD544), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
 
 s32 N(D_80244788_CCFA98)[] = {
     0x000000A1, 0x00000000,
 };
 
-EvtSource N(interact_80244790) = SCRIPT({
-    if (EVT_AREA_FLAG(37) == 1) {
-        EVT_AREA_FLAG(35) = 1;
-        SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0063));
-        EVT_AREA_FLAG(35) = 0;
-        return;
-    }
-    EVT_AREA_FLAG(35) = 1;
-    if (EVT_SAVE_FLAG(1412) == 0) {
-        SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x005F));
-    } else {
-        SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0060));
-    }
-    FindItem(161, EVT_VAR(0));
-    if (EVT_VAR(0) != -1) {
-        EVT_VAR(0) = N(D_80244788_CCFA98);
-        EVT_VAR(1) = 0;
-        await N(80244738);
-        if (EVT_VAR(0) == -1) {
-            SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0064));
-        } else {
-            SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0061));
-            EVT_AREA_FLAG(36) = 1;
-            SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), TRUE);
-            PlayerMoveTo(555, 110, 20);
-            SetNpcFlagBits(NPC_SELF, ((NPC_FLAG_100)), FALSE);
-            InterpPlayerYaw(90, 0);
-            func_802CF56C(2);
-            sleep 5;
-            AdjustCam(0, 1.0, 0, 350, 17.0, -6.0);
-            spawn N(80243870);
-            SpeakToPlayer(NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0062));
-            spawn {
-                sleep 40;
-                InterpPlayerYaw(315, 0);
-            }
-10:
-            if (EVT_AREA_FLAG(37) == 0) {
-                sleep 1;
-                goto 10;
-            }
-            ResetCam(0, 4.0);
-            SpeakToPlayer(NPC_SELF, -1, -1, 5, MESSAGE_ID(0x11, 0x0063));
-            EVT_SAVE_FLAG(1412) = 1;
-            bind N(8024352C) TRIGGER_FLOOR_PRESS_A 30;
-        }
-    }
-    EVT_AREA_FLAG(35) = 0;
-});
+EvtSource N(interact_80244790) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(37), 1)
+        EVT_SET(EVT_AREA_FLAG(35), 1)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0063))
+        EVT_SET(EVT_AREA_FLAG(35), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_AREA_FLAG(35), 1)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1412), 0)
+        EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x005F))
+    EVT_ELSE
+        EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0060))
+    EVT_END_IF
+    EVT_CALL(FindItem, 161, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), -1)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(D_80244788_CCFA98)))
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_EXEC_WAIT(N(80244738))
+        EVT_IF_EQ(EVT_VAR(0), -1)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0064))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0061))
+            EVT_SET(EVT_AREA_FLAG(36), 1)
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(PlayerMoveTo, 555, 110, 20)
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_100)), FALSE)
+            EVT_CALL(InterpPlayerYaw, 90, 0)
+            EVT_CALL(func_802CF56C, 2)
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(AdjustCam, 0, EVT_FIXED(1.0), 0, 350, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+            EVT_EXEC(N(80243870))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 0, MESSAGE_ID(0x11, 0x0062))
+            EVT_THREAD
+                EVT_WAIT_FRAMES(40)
+                EVT_CALL(InterpPlayerYaw, 315, 0)
+            EVT_END_THREAD
+            EVT_LABEL(10)
+            EVT_IF_EQ(EVT_AREA_FLAG(37), 0)
+                EVT_WAIT_FRAMES(1)
+                EVT_GOTO(10)
+            EVT_END_IF
+            EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+            EVT_CALL(SpeakToPlayer, NPC_SELF, -1, -1, 5, MESSAGE_ID(0x11, 0x0063))
+            EVT_SET(EVT_SAVE_FLAG(1412), 1)
+            EVT_BIND_TRIGGER(N(8024352C), TRIGGER_FLOOR_PRESS_A, 30, 1, 0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_SET(EVT_AREA_FLAG(35), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80244ADC) = SCRIPT({
-    EVT_AREA_FLAG(36) = 0;
-    EVT_AREA_FLAG(37) = 0;
-    BindNpcInteract(NPC_SELF, N(interact_80244790));
-});
+EvtSource N(init_80244ADC) = {
+    EVT_SET(EVT_AREA_FLAG(36), 0)
+    EVT_SET(EVT_AREA_FLAG(37), 0)
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80244790)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80244B20) = {
     .id = NPC_BUBULB,
@@ -235,78 +244,84 @@ static s32 N(pad_4F24)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80244F30) = SCRIPT({
-    MakeItemEntity(ITEM_STAR_PIECE, 675, 60, -100, 17, EVT_SAVE_FLAG(1387));
-});
+EvtSource N(80244F30) = {
+    EVT_CALL(MakeItemEntity, ITEM_STAR_PIECE, 675, 60, -100, 17, EVT_SAVE_FLAG(1387))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_4F64)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80244F70) = SCRIPT({
-    loop {
-        N(func_80242360_CCD670)(EVT_VAR(0));
-        if (EVT_VAR(0) == EVT_VAR(4)) {
-            GetPlayerActionState(EVT_VAR(0));
-            if (EVT_VAR(0) != 23) {
-                if (EVT_VAR(8) == 0) {
-                    spawn {
-                        GetModelCenter(EVT_VAR(5));
-                        PlaySoundAt(0x1DB, 4194304, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    }
-                }
-                if (EVT_VAR(7) < 90) {
-                    if (EVT_VAR(7) == 0) {
-                        sleep 5;
-                        EVT_VAR(8) = 6;
-                        ModifyColliderFlags(0, EVT_VAR(9), 0x7FFFFE00);
-                    }
-                    EVT_VAR(8) += 1;
-                    EVT_VAR(7) += EVT_VAR(8);
-                }
-                goto 50;
-            }
-        }
-        if (EVT_VAR(7) != 0) {
-            EVT_VAR(8) -= 1;
-            EVT_VAR(7) += EVT_VAR(8);
-            if (EVT_VAR(7) <= 0) {
-                EVT_VAR(8) = 0;
-                EVT_VAR(7) = 0;
-                spawn {
-                    GetModelCenter(EVT_VAR(5));
-                    PlaySoundAt(0x1DC, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                }
-                ModifyColliderFlags(1, EVT_VAR(9), 0x7FFFFE00);
-            }
-        }
-50:
-        if (EVT_VAR(7) >= 90) {
-            EVT_VAR(8) = -1;
-            EVT_VAR(7) = 90;
-        }
-        RotateModel(EVT_VAR(5), EVT_VAR(7), -1, 0, 0);
-        RotateModel(EVT_VAR(6), EVT_VAR(7), -1, 0, 0);
-        sleep 1;
-    }
-});
+EvtSource N(80244F70) = {
+    EVT_LOOP(0)
+        EVT_CALL(N(func_80242360_CCD670), EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), EVT_VAR(4))
+            EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+            EVT_IF_NE(EVT_VAR(0), 23)
+                EVT_IF_EQ(EVT_VAR(8), 0)
+                    EVT_THREAD
+                        EVT_CALL(GetModelCenter, EVT_VAR(5))
+                        EVT_CALL(PlaySoundAt, 0x1DB, 4194304, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_END_THREAD
+                EVT_END_IF
+                EVT_IF_LT(EVT_VAR(7), 90)
+                    EVT_IF_EQ(EVT_VAR(7), 0)
+                        EVT_WAIT_FRAMES(5)
+                        EVT_SET(EVT_VAR(8), 6)
+                        EVT_CALL(ModifyColliderFlags, 0, EVT_VAR(9), 0x7FFFFE00)
+                    EVT_END_IF
+                    EVT_ADD(EVT_VAR(8), 1)
+                    EVT_ADD(EVT_VAR(7), EVT_VAR(8))
+                EVT_END_IF
+                EVT_GOTO(50)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_IF_NE(EVT_VAR(7), 0)
+            EVT_SUB(EVT_VAR(8), 1)
+            EVT_ADD(EVT_VAR(7), EVT_VAR(8))
+            EVT_IF_LE(EVT_VAR(7), 0)
+                EVT_SET(EVT_VAR(8), 0)
+                EVT_SET(EVT_VAR(7), 0)
+                EVT_THREAD
+                    EVT_CALL(GetModelCenter, EVT_VAR(5))
+                    EVT_CALL(PlaySoundAt, 0x1DC, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_END_THREAD
+                EVT_CALL(ModifyColliderFlags, 1, EVT_VAR(9), 0x7FFFFE00)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_LABEL(50)
+        EVT_IF_GE(EVT_VAR(7), 90)
+            EVT_SET(EVT_VAR(8), -1)
+            EVT_SET(EVT_VAR(7), 90)
+        EVT_END_IF
+        EVT_CALL(RotateModel, EVT_VAR(5), EVT_VAR(7), -1, 0, 0)
+        EVT_CALL(RotateModel, EVT_VAR(6), EVT_VAR(7), -1, 0, 0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245224) = SCRIPT({
-    EVT_VAR(4) = 21;
-    EVT_VAR(5) = 21;
-    EVT_VAR(6) = 20;
-    EVT_VAR(7) = EVT_MAP_VAR(10);
-    EVT_VAR(8) = EVT_MAP_VAR(11);
-    EVT_VAR(9) = 22;
-    spawn N(80244F70);
-    EVT_VAR(4) = 17;
-    EVT_VAR(5) = 26;
-    EVT_VAR(6) = 25;
-    EVT_VAR(7) = EVT_MAP_VAR(12);
-    EVT_VAR(8) = EVT_MAP_VAR(13);
-    EVT_VAR(9) = 18;
-    spawn N(80244F70);
-});
+EvtSource N(80245224) = {
+    EVT_SET(EVT_VAR(4), 21)
+    EVT_SET(EVT_VAR(5), 21)
+    EVT_SET(EVT_VAR(6), 20)
+    EVT_SET(EVT_VAR(7), EVT_MAP_VAR(10))
+    EVT_SET(EVT_VAR(8), EVT_MAP_VAR(11))
+    EVT_SET(EVT_VAR(9), 22)
+    EVT_EXEC(N(80244F70))
+    EVT_SET(EVT_VAR(4), 17)
+    EVT_SET(EVT_VAR(5), 26)
+    EVT_SET(EVT_VAR(6), 25)
+    EVT_SET(EVT_VAR(7), EVT_MAP_VAR(12))
+    EVT_SET(EVT_VAR(8), EVT_MAP_VAR(13))
+    EVT_SET(EVT_VAR(9), 18)
+    EVT_EXEC(N(80244F70))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc23.inc.c"
 

--- a/src/world/area_flo/flo_15/CD06C0.c
+++ b/src/world/area_flo/flo_15/CD06C0.c
@@ -20,20 +20,21 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_15_tattle },
 };
 
-EvtSource N(80240060) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        SetMusicTrack(0, SONG_SUNSHINE_RETURNS, 0, 8);
-    } else {
-        match EVT_STORY_PROGRESS {
-            < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-                SetMusicTrack(0, SONG_SUN_TOWER_CLOUDY, 0, 8);
-            } else {
-                SetMusicTrack(0, SONG_SUN_TOWER_SUNNY, 0, 8);
-            }
-        }
-    }
-});
+EvtSource N(80240060) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_CALL(SetMusicTrack, 0, SONG_SUNSHINE_RETURNS, 0, 8)
+    EVT_ELSE
+        EVT_SWITCH(EVT_SAVE_VAR(0))
+            EVT_CASE_LT(53)
+                EVT_CALL(SetMusicTrack, 0, SONG_SUN_TOWER_CLOUDY, 0, 8)
+            EVT_CASE_DEFAULT
+                EVT_CALL(SetMusicTrack, 0, SONG_SUN_TOWER_SUNNY, 0, 8)
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_11C) = {
     0x00000000,
@@ -41,31 +42,35 @@ static s32 N(pad_11C) = {
 
 EvtSource N(exitWalk_80240120) = EXIT_WALK_SCRIPT(60,  0, "flo_13",  1);
 
-EvtSource N(8024017C) = SCRIPT({
-    bind N(exitWalk_80240120) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(8024017C) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240120), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_802412C0));
-    await N(makeEntities);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        spawn N(802404D8);
-    } else {
-        ModifyColliderFlags(0, 1, 0x7FFFFE00);
-        EVT_VAR(0) = N(8024017C);
-        spawn EnterWalk;
-    }
-    ModifyColliderFlags(0, 14, 0x7FFFFE00);
-    spawn N(802413B0);
-    await N(80240060);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_802412C0)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_EXEC(N(802404D8))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(8024017C)))
+        EVT_EXEC(EnterWalk)
+    EVT_END_IF
+    EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+    EVT_EXEC(N(802413B0))
+    EVT_EXEC_WAIT(N(80240060))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_2FC) = {
     0x00000000,
@@ -77,192 +82,200 @@ NpcSettings N(npcSettings_80240300) = {
     .level = 99,
 };
 
-EvtSource N(8024032C) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        EVT_VAR(3) = 7;
-        EVT_VAR(4) = 5;
-    } else {
-        EVT_VAR(3) = 15;
-        EVT_VAR(4) = 1;
-    }
-    loop {
-        EVT_VAR(5) = EVT_VAR(3);
-        loop EVT_VAR(5) {
-            GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += 1;
-            SetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetNpcPos(NPC_SUN1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep EVT_VAR(4);
-        }
-        EVT_VAR(5) = EVT_VAR(3);
-        loop EVT_VAR(5) {
-            GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(1) += -1;
-            SetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetNpcPos(NPC_SUN1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            sleep EVT_VAR(4);
-        }
-    }
-});
+EvtSource N(8024032C) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 53)
+        EVT_SET(EVT_VAR(3), 7)
+        EVT_SET(EVT_VAR(4), 5)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(3), 15)
+        EVT_SET(EVT_VAR(4), 1)
+    EVT_END_IF
+    EVT_LOOP(0)
+        EVT_SET(EVT_VAR(5), EVT_VAR(3))
+        EVT_LOOP(EVT_VAR(5))
+            EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), 1)
+            EVT_CALL(SetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetNpcPos, 11, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(EVT_VAR(4))
+        EVT_END_LOOP
+        EVT_SET(EVT_VAR(5), EVT_VAR(3))
+        EVT_LOOP(EVT_VAR(5))
+            EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(1), -1)
+            EVT_CALL(SetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetNpcPos, 11, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_WAIT_FRAMES(EVT_VAR(4))
+        EVT_END_LOOP
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802404D8) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    SetNpcPos(NPC_SUN0, 0, 270, 0);
-    SetNpcPos(NPC_SUN1, 0, -1000, 0);
-    sleep 1;
-    GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 1050);
-    SetCamPitch(0, 10.0, 4.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SetCamDistance(0, 300);
-    SetCamPitch(0, 15.0, -10.0);
-    SetCamSpeed(0, 6.5);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_9, NPC_ANIM_sun_Palette_00_Anim_9, 517, MESSAGE_ID(0x11, 0x00C3));
-    SetNpcAnimation(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_9);
-    spawn {
-        SetCamDistance(0, 1000);
-        SetCamSpeed(0, 5.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-    }
-    sleep 15;
-    SetNpcJumpscale(NPC_SUN0, 0.0);
-    GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += 400;
-    NpcJump0(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 40);
-    GotoMap("flo_00", 9);
-    sleep 70;
-});
+EvtSource N(802404D8) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetNpcPos, 10, 0, 270, 0)
+    EVT_CALL(SetNpcPos, 11, 0, -1000, 0)
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 1050)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(10.0), EVT_FIXED(4.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(15.0), EVT_FIXED(-10.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(6.5))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_9, NPC_ANIM_sun_Palette_00_Anim_9, 517, MESSAGE_ID(0x11, 0x00C3))
+    EVT_CALL(SetNpcAnimation, 10, NPC_ANIM_sun_Palette_00_Anim_9)
+    EVT_THREAD
+        EVT_CALL(SetCamDistance, 0, 1000)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(5.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcJumpscale, 10, EVT_FIXED(0.0))
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), 400)
+    EVT_CALL(NpcJump0, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 40)
+    EVT_CALL(GotoMap, EVT_PTR("flo_00"), 9)
+    EVT_WAIT_FRAMES(70)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(aux_8024079C) = SCRIPT({
-    func_802CDE68(11, 48);
-    loop {
-        MakeLerp(-30, 30, 20, 11);
-        loop {
-            UpdateLerp();
-            SetNpcRotation(NPC_SUN1, 0, 0, EVT_VAR(0));
-            GetNpcPos(NPC_SUN0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-            SetNpcPos(NPC_SUN1, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        MakeLerp(30, -30, 20, 11);
-        loop {
-            UpdateLerp();
-            SetNpcRotation(NPC_SUN1, 0, 0, EVT_VAR(0));
-            GetNpcPos(NPC_SUN0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-            SetNpcPos(NPC_SUN1, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-    }
-});
+EvtSource N(aux_8024079C) = {
+    EVT_CALL(func_802CDE68, 11, 48)
+    EVT_LOOP(0)
+        EVT_CALL(MakeLerp, -30, 30, 20, 11)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(SetNpcRotation, 11, 0, 0, EVT_VAR(0))
+            EVT_CALL(GetNpcPos, 10, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+            EVT_CALL(SetNpcPos, 11, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(MakeLerp, 30, -30, 20, 11)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(SetNpcRotation, 11, 0, 0, EVT_VAR(0))
+            EVT_CALL(GetNpcPos, 10, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+            EVT_CALL(SetNpcPos, 11, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024094C) = SCRIPT({
-    loop {
-        sleep 1;
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_VAR(1) > 220) {
-            break loop;
-        }
-    }
-    spawn {
-        sleep 15;
-        PlayerFaceNpc(10, 0);
-    }
-    SetNpcJumpscale(NPC_SUN0, 0.0);
-    GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) -= 400;
-    NpcJump0(NPC_SUN0, EVT_VAR(0), 275, EVT_VAR(2), 30);
-    EVT_VAR(9) = spawn N(8024032C);
-    loop {
-        sleep 1;
-        if (EVT_AREA_FLAG(38) == 1) {
-            break loop;
-        }
-    }
-    DisablePlayerInput(TRUE);
-    sleep 10;
-    kill EVT_VAR(9);
-    SetNpcFlagBits(NPC_SUN0, ((NPC_FLAG_100)), TRUE);
-    GetNpcPos(NPC_SUN0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    NpcJump0(NPC_SUN0, EVT_VAR(0), 450, EVT_VAR(2), 30);
-    DisablePlayerInput(FALSE);
-    unbind;
-});
+EvtSource N(8024094C) = {
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_GT(EVT_VAR(1), 220)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlayerFaceNpc, 10, 0)
+    EVT_END_THREAD
+    EVT_CALL(SetNpcJumpscale, 10, EVT_FIXED(0.0))
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SUB(EVT_VAR(1), 400)
+    EVT_CALL(NpcJump0, 10, EVT_VAR(0), 275, EVT_VAR(2), 30)
+    EVT_EXEC_GET_TID(N(8024032C), EVT_VAR(9))
+    EVT_LOOP(0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_AREA_FLAG(38), 1)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(10)
+    EVT_KILL_THREAD(EVT_VAR(9))
+    EVT_CALL(SetNpcFlagBits, 10, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(GetNpcPos, 10, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(NpcJump0, 10, EVT_VAR(0), 450, EVT_VAR(2), 30)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80240B28) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_SPOKE_WITH_THE_SUN {
-            SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009A));
-            SetPlayerAnimation(ANIM_THINKING);
-            sleep 20;
-            SetPlayerAnimation(ANIM_80007);
-            sleep 20;
-            SetPlayerAnimation(ANIM_10002);
-            SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009B));
-            EVT_STORY_PROGRESS = STORY_CH6_SPOKE_WITH_THE_SUN;
-        }
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009C));
-        }
-        < STORY_CH6_STAR_SPIRIT_RESCUED {
-            if (EVT_SAVE_FLAG(1410) == 0) {
-                SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11,
-                              0x009D));
-                EVT_SAVE_FLAG(1410) = 1;
-            } else {
-                SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11,
-                              0x009E));
-            }
-        } else {
-            SpeakToPlayer(NPC_SUN0, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11,
-                          0x009F));
-        }
-    }
-    EVT_AREA_FLAG(38) = 1;
-});
+EvtSource N(interact_80240B28) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(50)
+            EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009A))
+            EVT_CALL(SetPlayerAnimation, ANIM_THINKING)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetPlayerAnimation, ANIM_80007)
+            EVT_WAIT_FRAMES(20)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009B))
+            EVT_SET(EVT_SAVE_VAR(0), 50)
+        EVT_CASE_LT(53)
+            EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009C))
+        EVT_CASE_LT(57)
+            EVT_IF_EQ(EVT_SAVE_FLAG(1410), 0)
+                EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009D))
+                EVT_SET(EVT_SAVE_FLAG(1410), 1)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009E))
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_CALL(SpeakToPlayer, 10, NPC_ANIM_sun_Palette_00_Anim_7, NPC_ANIM_sun_Palette_00_Anim_1, 517, MESSAGE_ID(0x11, 0x009F))
+    EVT_END_SWITCH
+    EVT_SET(EVT_AREA_FLAG(38), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80240CD0) = SCRIPT({
-    SetNpcCollisionSize(10, 64, 40);
-    EnableNpcShadow(NPC_SUN0, FALSE);
-    if (EVT_STORY_PROGRESS < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        SetNpcPos(NPC_SUN0, 0, 270, 0);
-        BindNpcInteract(NPC_SELF, N(interact_80240B28));
-        spawn N(8024032C);
-    } else {
-        SetNpcPos(NPC_SUN0, 0, 450, 0);
-        BindNpcInteract(NPC_SELF, N(interact_80240B28));
-        EVT_AREA_FLAG(38) = 0;
-        spawn N(8024094C);
-    }
-});
+EvtSource N(init_80240CD0) = {
+    EVT_CALL(SetNpcCollisionSize, 10, 64, 40)
+    EVT_CALL(EnableNpcShadow, 10, FALSE)
+    EVT_IF_LT(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(SetNpcPos, 10, 0, 270, 0)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80240B28)))
+        EVT_EXEC(N(8024032C))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, 10, 0, 450, 0)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80240B28)))
+        EVT_SET(EVT_AREA_FLAG(38), 0)
+        EVT_EXEC(N(8024094C))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80240DB4) = SCRIPT({
-    EnableNpcShadow(NPC_SUN1, FALSE);
-    SetNpcAnimation(NPC_SUN1, NPC_ANIM_sun_Palette_00_Anim_2);
-    SetNpcPaletteSwapMode(10, 3);
-    SetNpcPaletteSwapMode(11, 3);
-    SetNpcPaletteSwapping(10, 0, 1, 5, 5, 13, 5, 0, 0);
-    SetNpcPaletteSwapping(11, 0, 1, 5, 5, 13, 5, 0, 0);
-    if (EVT_STORY_PROGRESS < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        SetNpcPos(NPC_SUN1, 0, 270, -5);
-    } else {
-        SetNpcPos(NPC_SUN1, 0, 450, -5);
-        BindNpcAux(-1, N(aux_8024079C));
-    }
-});
+EvtSource N(init_80240DB4) = {
+    EVT_CALL(EnableNpcShadow, 11, FALSE)
+    EVT_CALL(SetNpcAnimation, 11, NPC_ANIM_sun_Palette_00_Anim_2)
+    EVT_CALL(SetNpcPaletteSwapMode, 10, 3)
+    EVT_CALL(SetNpcPaletteSwapMode, 11, 3)
+    EVT_CALL(SetNpcPaletteSwapping, 10, 0, 1, 5, 5, 13, 5, 0, 0)
+    EVT_CALL(SetNpcPaletteSwapping, 11, 0, 1, 5, 5, 13, 5, 0, 0)
+    EVT_IF_LT(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(SetNpcPos, 11, 0, 270, -5)
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, 11, 0, 450, -5)
+        EVT_CALL(BindNpcAux, -1, EVT_PTR(N(aux_8024079C)))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80240EE0)[] = {
     {
@@ -336,16 +349,20 @@ static s32 N(pad_12D8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(802412E0) = SCRIPT({
-    EVT_SAVE_FLAG(1401) = 1;
-});
+EvtSource N(802412E0) = {
+    EVT_SET(EVT_SAVE_FLAG(1401), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    if (EVT_SAVE_FLAG(1401) == 0) {
-        MakeEntity(0x802BCF00, -180, 0, -18, 0, MAKE_ENTITY_END);
-        AssignScript(N(802412E0));
-    }
-});
+EvtSource N(makeEntities) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1401), 0)
+        EVT_CALL(MakeEntity, 0x802BCF00, -180, 0, -18, 0, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(802412E0)))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_135C) = {
     0x00000000,
@@ -357,57 +374,59 @@ s32 N(intTable_80241360)[] = {
     0x00000018, 0xF24A7CE7, 0x0000000A, 0xF24A814D,
 };
 
-EvtSource N(802413B0) = SCRIPT({
-    if (EVT_SAVE_FLAG(1401) == 0) {
-    0:
-        if (EVT_SAVE_FLAG(1401) == 0) {
-            sleep 1;
-            goto 0;
-        }
-        DisablePlayerInput(TRUE);
-        spawn {
-            buf_use N(intTable_80241360);
-            loop 10 {
-                buf_read EVT_VAR(1) EVT_VAR(2);
-                ShakeCam(0, 0, EVT_VAR(1), EVT_VAR(2));
-            }
-        }
-        UseSettingsFrom(0, -170, 0, 35);
-        SetPanTarget(0, -170, 0, 35);
-        SetCamDistance(0, 600);
-        SetCamPitch(0, 25.0, -9.0);
-        SetCamPosA(0, -50.0, 25.0);
-        SetCamSpeed(0, 1.5);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        spawn {
-            sleep 100;
-            PlayEffect(0x6, 4, -180, 0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            PlayEffect(0x6, 4, -190, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        }
-        spawn {
-            loop 6 {
-                PlaySoundAtCollider(11, 391, 0);
-                sleep 20;
-            }
-        }
-        MakeLerp(0, -50, 120, 2);
-        loop {
-            UpdateLerp();
-            TranslateGroup(16, 0, EVT_VAR(0), 0);
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        ModifyColliderFlags(0, 12, 0x7FFFFE00);
-        ModifyColliderFlags(1, 14, 0x7FFFFE00);
-        sleep 15;
-        ResetCam(0, 90.0);
-        DisablePlayerInput(FALSE);
-    } else {
-        ModifyColliderFlags(0, 12, 0x7FFFFE00);
-        ModifyColliderFlags(1, 14, 0x7FFFFE00);
-        TranslateGroup(16, 0, -50, 0);
-    }
-});
+EvtSource N(802413B0) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1401), 0)
+        EVT_LABEL(0)
+        EVT_IF_EQ(EVT_SAVE_FLAG(1401), 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_GOTO(0)
+        EVT_END_IF
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_THREAD
+            EVT_USE_BUF(EVT_PTR(N(intTable_80241360)))
+            EVT_LOOP(10)
+                EVT_BUF_READ2(EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ShakeCam, 0, 0, EVT_VAR(1), EVT_VAR(2))
+            EVT_END_LOOP
+        EVT_END_THREAD
+        EVT_CALL(UseSettingsFrom, 0, -170, 0, 35)
+        EVT_CALL(SetPanTarget, 0, -170, 0, 35)
+        EVT_CALL(SetCamDistance, 0, 600)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(25.0), EVT_FIXED(-9.0))
+        EVT_CALL(SetCamPosA, 0, EVT_FIXED(-50.0), EVT_FIXED(25.0))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.5))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_THREAD
+            EVT_WAIT_FRAMES(100)
+            EVT_CALL(PlayEffect, 0x6, 4, -180, 0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x6, 4, -190, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_LOOP(6)
+                EVT_CALL(PlaySoundAtCollider, 11, 391, 0)
+                EVT_WAIT_FRAMES(20)
+            EVT_END_LOOP
+        EVT_END_THREAD
+        EVT_CALL(MakeLerp, 0, -50, 120, 2)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(TranslateGroup, 16, 0, EVT_VAR(0), 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(ModifyColliderFlags, 0, 12, 0x7FFFFE00)
+        EVT_CALL(ModifyColliderFlags, 1, 14, 0x7FFFFE00)
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(ResetCam, 0, EVT_FIXED(90.0))
+        EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 12, 0x7FFFFE00)
+        EVT_CALL(ModifyColliderFlags, 1, 14, 0x7FFFFE00)
+        EVT_CALL(TranslateGroup, 16, 0, -50, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_16/CD1F10.c
+++ b/src/world/area_flo/flo_16/CD1F10.c
@@ -18,213 +18,224 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_16_tattle },
 };
 
-EvtSource N(802429D0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(802429D0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80242A40) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  4);
 
 EvtSource N(exitWalk_80242A9C) = EXIT_WALK_SCRIPT(60,  1, "flo_17",  0);
 
-EvtSource N(80242AF8) = SCRIPT({
-    bind N(exitWalk_80242A40) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80242A9C) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80242AF8) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80242A40), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80242A9C), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_80242B40)[] = {
     0x0000000A, 0xC39B0000, 0x00000000, 0x00000000, 0x0000000B, 0x43988000, 0x42C80000, 0x00000000,
     0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_802444D4));
-    await N(makeEntities);
-    spawn N(8024346C);
-    ModifyColliderFlags(3, 9, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_80242B40));
-    }
-    EnableTexPanning(16, 1);
-    EnableTexPanning(17, 1);
-    EnableTexPanning(18, 1);
-    EnableTexPanning(20, 1);
-    EnableTexPanning(22, 1);
-    EnableTexPanning(24, 1);
-    EnableTexPanning(19, 1);
-    EnableTexPanning(21, 1);
-    EnableTexPanning(23, 1);
-    EnableTexPanning(25, 1);
-    spawn {
-        EVT_VAR(0) = 0;
-        EVT_VAR(1) = 0;
-0:
-        EVT_VAR(0) += 140;
-        if (EVT_VAR(0) > 65536) {
-            EVT_VAR(0) += -65536;
-        }
-        SetTexPanOffset(1, 0, EVT_VAR(0), 0);
-        EVT_VAR(1) += -200;
-        if (EVT_VAR(1) < 0) {
-            EVT_VAR(1) += 65536;
-        }
-        SetTexPanOffset(2, 0, EVT_VAR(1), 0);
-        sleep 1;
-        goto 0;
-    }
-    spawn N(802451C4);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80242AF8);
-    spawn EnterWalk;
-    await N(802429D0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CD1E30)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_802444D4)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(8024346C))
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_80242B40)))
+    EVT_END_THREAD
+    EVT_CALL(EnableTexPanning, 16, 1)
+    EVT_CALL(EnableTexPanning, 17, 1)
+    EVT_CALL(EnableTexPanning, 18, 1)
+    EVT_CALL(EnableTexPanning, 20, 1)
+    EVT_CALL(EnableTexPanning, 22, 1)
+    EVT_CALL(EnableTexPanning, 24, 1)
+    EVT_CALL(EnableTexPanning, 19, 1)
+    EVT_CALL(EnableTexPanning, 21, 1)
+    EVT_CALL(EnableTexPanning, 23, 1)
+    EVT_CALL(EnableTexPanning, 25, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_LABEL(0)
+        EVT_ADD(EVT_VAR(0), 140)
+        EVT_IF_GT(EVT_VAR(0), 65536)
+            EVT_ADD(EVT_VAR(0), -65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 1, 0, EVT_VAR(0), 0)
+        EVT_ADD(EVT_VAR(1), -200)
+        EVT_IF_LT(EVT_VAR(1), 0)
+            EVT_ADD(EVT_VAR(1), 65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 2, 0, EVT_VAR(1), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_EXEC(N(802451C4))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80242AF8)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(802429D0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CD1E30))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242EA0) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80242EA0) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024314C) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(6);
-    EVT_VAR(8) = EVT_VAR(5);
-    EVT_VAR(7) = EVT_VAR(4);
-    EVT_VAR(6) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(2);
-    EVT_VAR(4) = EVT_VAR(1);
-    EVT_VAR(3) = EVT_VAR(0);
-    EnableModel(EVT_VAR(6), 0);
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(UnkFunc43)();
-    if (EVT_VAR(0) == 0) {
-        sleep 1;
-        goto 0;
-    }
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    if (EVT_VAR(10) != 0) {
-        spawn {
-            sleep 5;
-            EVT_VAR(0) = EVT_VAR(3);
-            EVT_VAR(1) = EVT_VAR(4);
-            EVT_VAR(2) = EVT_VAR(5);
-            EVT_VAR(1) += 10;
-            EVT_VAR(2) += 8;
-            PlayEffect(0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) -= 10;
-            MakeItemEntity(EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0);
-        }
-    }
-    spawn {
-        sleep 10;
-        PlaySoundAt(0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 1, 0, 0);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 1, 0, 0);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(8024314C) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(6))
+    EVT_SET(EVT_VAR(8), EVT_VAR(5))
+    EVT_SET(EVT_VAR(7), EVT_VAR(4))
+    EVT_SET(EVT_VAR(6), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(2))
+    EVT_SET(EVT_VAR(4), EVT_VAR(1))
+    EVT_SET(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(UnkFunc43))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(5)
+            EVT_SET(EVT_VAR(0), EVT_VAR(3))
+            EVT_SET(EVT_VAR(1), EVT_VAR(4))
+            EVT_SET(EVT_VAR(2), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_ADD(EVT_VAR(2), 8)
+            EVT_CALL(PlayEffect, 0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_SUB(EVT_VAR(1), 10)
+            EVT_CALL(MakeItemEntity, EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAt, 0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 1, 0, 0)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024346C) = SCRIPT({
-    ModifyColliderFlags(3, 20, 0x00000006);
-    EVT_VAR(0) = -740;
-    EVT_VAR(1) = -140;
-    EVT_VAR(2) = -260;
-    EVT_VAR(3) = -55;
-    EVT_VAR(4) = 100;
-    spawn N(80242EA0);
-    EVT_VAR(0) = 250;
-    EVT_VAR(1) = -140;
-    EVT_VAR(2) = 725;
-    EVT_VAR(3) = -55;
-    EVT_VAR(4) = 180;
-    spawn N(80242EA0);
-    GetModelCenter(65);
-    EVT_VAR(3) = 65;
-    EVT_VAR(4) = 66;
-    EVT_VAR(5) = 67;
-    EVT_VAR(6) = 68;
-    EVT_VAR(10) = 0;
-    spawn N(8024314C);
-    GetModelCenter(71);
-    EVT_VAR(3) = 71;
-    EVT_VAR(4) = 72;
-    EVT_VAR(5) = 73;
-    EVT_VAR(6) = 74;
-    EVT_VAR(10) = 174;
-    spawn N(8024314C);
-    GetModelCenter(79);
-    EVT_VAR(3) = 79;
-    EVT_VAR(4) = 80;
-    EVT_VAR(5) = 81;
-    EVT_VAR(6) = 82;
-    EVT_VAR(10) = 0;
-    spawn N(8024314C);
-    GetModelCenter(85);
-    EVT_VAR(3) = 85;
-    EVT_VAR(4) = 86;
-    EVT_VAR(5) = 87;
-    EVT_VAR(6) = 88;
-    EVT_VAR(10) = 0;
-    spawn N(8024314C);
-});
+EvtSource N(8024346C) = {
+    EVT_CALL(ModifyColliderFlags, 3, 20, 0x00000006)
+    EVT_SET(EVT_VAR(0), -740)
+    EVT_SET(EVT_VAR(1), -140)
+    EVT_SET(EVT_VAR(2), -260)
+    EVT_SET(EVT_VAR(3), -55)
+    EVT_SET(EVT_VAR(4), 100)
+    EVT_EXEC(N(80242EA0))
+    EVT_SET(EVT_VAR(0), 250)
+    EVT_SET(EVT_VAR(1), -140)
+    EVT_SET(EVT_VAR(2), 725)
+    EVT_SET(EVT_VAR(3), -55)
+    EVT_SET(EVT_VAR(4), 180)
+    EVT_EXEC(N(80242EA0))
+    EVT_CALL(GetModelCenter, 65)
+    EVT_SET(EVT_VAR(3), 65)
+    EVT_SET(EVT_VAR(4), 66)
+    EVT_SET(EVT_VAR(5), 67)
+    EVT_SET(EVT_VAR(6), 68)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(8024314C))
+    EVT_CALL(GetModelCenter, 71)
+    EVT_SET(EVT_VAR(3), 71)
+    EVT_SET(EVT_VAR(4), 72)
+    EVT_SET(EVT_VAR(5), 73)
+    EVT_SET(EVT_VAR(6), 74)
+    EVT_SET(EVT_VAR(10), 174)
+    EVT_EXEC(N(8024314C))
+    EVT_CALL(GetModelCenter, 79)
+    EVT_SET(EVT_VAR(3), 79)
+    EVT_SET(EVT_VAR(4), 80)
+    EVT_SET(EVT_VAR(5), 81)
+    EVT_SET(EVT_VAR(6), 82)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(8024314C))
+    EVT_CALL(GetModelCenter, 85)
+    EVT_SET(EVT_VAR(3), 85)
+    EVT_SET(EVT_VAR(4), 86)
+    EVT_SET(EVT_VAR(5), 87)
+    EVT_SET(EVT_VAR(6), 88)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(8024314C))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_36FC) = {
     0x00000000,
@@ -250,166 +261,177 @@ f32 N(D_80243758_CD5588)[] = {
     140.0f, 180.0f, 220.0f,
 };
 
-EvtSource N(80243764) = SCRIPT({
-    sleep 10;
-    PlaySound(0x212D);
-    N(UnkFunc21)(EVT_MAP_VAR(0));
-    sleep 85;
-    spawn {
-        PlaySound(0x212E);
-        N(UnkFunc23)(70, 70);
-        sleep 27;
-        PlaySound(SOUND_208E);
-        N(UnkFunc23)(50, 50);
-    }
-    spawn {
-        sleep 3;
-        N(func_8024011C_CD1F4C)(EVT_MAP_VAR(0));
-    }
-    spawn {
-        sleep 47;
-        N(UnkFunc22)();
-        N(UnkPartnerPosFunc)();
-        sleep 5;
-        N(UnkPartnerPosFunc2)();
-        sleep 5;
-        N(UnkPartnerPosFunc)();
-    }
-    sleep 3;
-    N(func_802406E0_CD2510)(EVT_MAP_VAR(0));
-    sleep 30;
-});
+EvtSource N(80243764) = {
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PlaySound, 0x212D)
+    EVT_CALL(N(UnkFunc21), EVT_MAP_VAR(0))
+    EVT_WAIT_FRAMES(85)
+    EVT_THREAD
+        EVT_CALL(PlaySound, 0x212E)
+        EVT_CALL(N(UnkFunc23), 70, 70)
+        EVT_WAIT_FRAMES(27)
+        EVT_CALL(PlaySound, SOUND_208E)
+        EVT_CALL(N(UnkFunc23), 50, 50)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(3)
+        EVT_CALL(N(func_8024011C_CD1F4C), EVT_MAP_VAR(0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(47)
+        EVT_CALL(N(UnkFunc22))
+        EVT_CALL(N(UnkPartnerPosFunc))
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(N(UnkPartnerPosFunc2))
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(N(UnkPartnerPosFunc))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(3)
+    EVT_CALL(N(func_802406E0_CD2510), EVT_MAP_VAR(0))
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802438C8) = SCRIPT({
-    if (EVT_SAVE_FLAG(1403) == 1) {
-        return;
-    }
-    IsStartingConversation(EVT_VAR(0));
-    if (EVT_VAR(0) == 1) {
-        return;
-    }
-    N(UnkFunc24)();
-    if (EVT_VAR(0) == 1) {
-        return;
-    }
-    ModifyGlobalOverrideFlags(1, 2097152);
-    N(SetOverrideFlags_40)();
-    DisablePlayerInput(TRUE);
-    DisablePartnerAI(0);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-    N(UnkFunc20)(EVT_MAP_VAR(0), EVT_VAR(9));
-    FindKeyItem(ITEM_ULTRA_STONE, EVT_VAR(12));
-    N(UnkFunc38)();
-    if (EVT_VAR(0) == -1) {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DC), 160, 40);
-        sleep 10;
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    if (EVT_SAVE_FLAG(438) == 0) {
-        EVT_SAVE_FLAG(438) = 1;
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DA), 160, 40);
-    } else {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DB), 160, 40);
-    }
-    N(func_802402AC_CD20DC)();
-    if (EVT_VAR(0) == -1) {
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EnablePartnerAI();
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != EVT_VAR(11)) {
-        N(SwitchToPartner)(EVT_VAR(11));
-    } else {
-        func_802CF56C(2);
-    }
-    sleep 10;
-    ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DF), 160, 40);
-    ShowChoice(MESSAGE_ID(0x1E, 0x000D));
-    CloseMessage();
-    if (EVT_VAR(0) != 0) {
-        N(UnkFunc39)(EVT_VAR(9));
-        DisablePlayerInput(FALSE);
-        EnablePartnerAI();
-        ModifyGlobalOverrideFlags(0, 2097152);
-        N(UnkFunc17)();
-        return;
-    }
-    await N(80243764);
-    N(UnkFunc18)(EVT_VAR(11), EVT_VAR(13));
-    EVT_SAVE_FLAG(1403) = 1;
-    N(UnkFunc39)(EVT_VAR(9));
-    N(UnkFunc19)();
-    if (EVT_VAR(13) == 1) {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DD), 160, 40);
-    } else {
-        ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x00DE), 160, 40);
-    }
-    DisablePlayerInput(FALSE);
-    EnablePartnerAI();
-    ModifyGlobalOverrideFlags(0, 2097152);
-    N(UnkFunc17)();
-});
+EvtSource N(802438C8) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(1403), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(IsStartingConversation, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(N(UnkFunc24))
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(ModifyGlobalOverrideFlags, 1, 2097152)
+    EVT_CALL(N(SetOverrideFlags_40))
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(N(UnkFunc20), EVT_MAP_VAR(0), EVT_VAR(9))
+    EVT_CALL(FindKeyItem, ITEM_ULTRA_STONE, EVT_VAR(12))
+    EVT_CALL(N(UnkFunc38))
+    EVT_IF_EQ(EVT_VAR(0), -1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DC), 160, 40)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(438), 0)
+        EVT_SET(EVT_SAVE_FLAG(438), 1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DA), 160, 40)
+    EVT_ELSE
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DB), 160, 40)
+    EVT_END_IF
+    EVT_CALL(N(func_802402AC_CD20DC))
+    EVT_IF_EQ(EVT_VAR(0), -1)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), EVT_VAR(11))
+        EVT_CALL(N(SwitchToPartner), EVT_VAR(11))
+    EVT_ELSE
+        EVT_CALL(func_802CF56C, 2)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DF), 160, 40)
+    EVT_CALL(ShowChoice, MESSAGE_ID(0x1E, 0x000D))
+    EVT_CALL(CloseMessage)
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+        EVT_CALL(N(UnkFunc17))
+        EVT_RETURN
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80243764))
+    EVT_CALL(N(UnkFunc18), EVT_VAR(11), EVT_VAR(13))
+    EVT_SET(EVT_SAVE_FLAG(1403), 1)
+    EVT_CALL(N(UnkFunc39), EVT_VAR(9))
+    EVT_CALL(N(UnkFunc19))
+    EVT_IF_EQ(EVT_VAR(13), 1)
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DD), 160, 40)
+    EVT_ELSE
+        EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x00DE), 160, 40)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(ModifyGlobalOverrideFlags, 0, 2097152)
+    EVT_CALL(N(UnkFunc17))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243D48) = SCRIPT({
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    sleep 1;
-    goto 0;
-});
+EvtSource N(80243D48) = {
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243DB0) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    SetPlayerActionState(6);
-    sleep 2;
-    GetPlayerPos(EVT_VAR(7), EVT_VAR(8), EVT_VAR(9));
-    EVT_VAR(10) = spawn N(80243D48);
-    SetPlayerJumpscale(0.7001953125);
-    PlayerJump(450, 180, -120, 30);
-    SetPlayerActionState(0);
-    DisablePlayerPhysics(FALSE);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80243DB0) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetPlayerActionState, 6)
+    EVT_WAIT_FRAMES(2)
+    EVT_CALL(GetPlayerPos, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9))
+    EVT_EXEC_GET_TID(N(80243D48), EVT_VAR(10))
+    EVT_CALL(SetPlayerJumpscale, EVT_FIXED(0.7))
+    EVT_CALL(PlayerJump, 450, 180, -120, 30)
+    EVT_CALL(SetPlayerActionState, 0)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243E80) = SCRIPT({
-    if (EVT_AREA_FLAG(39) == 0) {
-        N(UnkFunc44)();
-        if (EVT_VAR(0) == 0) {
-            return;
-        }
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        match EVT_VAR(0) {
-            620 ... 660 {
-                MakeItemEntity(ITEM_STAR_PIECE, 640, 145, -100, 13, EVT_SAVE_FLAG(1388));
-                EVT_AREA_FLAG(39) = 1;
-            }
-        }
-    }
-});
+EvtSource N(80243E80) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(39), 0)
+        EVT_CALL(N(UnkFunc44))
+        EVT_IF_EQ(EVT_VAR(0), 0)
+            EVT_RETURN
+        EVT_END_IF
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_RANGE(620, 660)
+                EVT_CALL(MakeItemEntity, ITEM_STAR_PIECE, 640, 145, -100, 13, EVT_SAVE_FLAG(1388))
+                EVT_SET(EVT_AREA_FLAG(39), 1)
+        EVT_END_SWITCH
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    EVT_AREA_FLAG(39) = 0;
-    bind N(80243E80) TRIGGER_FLOOR_TOUCH 20;
-    MakeEntity(0x802EA910, 350, 240, -100, 0, MAKE_ENTITY_END);
-    EVT_MAP_VAR(0) = EVT_VAR(0);
-    AssignBlockFlag(EVT_SAVE_FLAG(1403));
-    AssignScript(N(802438C8));
-    MakeEntity(0x802EAA30, 472, 100, -100, 0, MAKE_ENTITY_END);
-    AssignScript(N(80243DB0));
-});
+EvtSource N(makeEntities) = {
+    EVT_SET(EVT_AREA_FLAG(39), 0)
+    EVT_BIND_TRIGGER(N(80243E80), TRIGGER_FLOOR_TOUCH, 20, 1, 0)
+    EVT_CALL(MakeEntity, 0x802EA910, 350, 240, -100, 0, MAKE_ENTITY_END)
+    EVT_SET(EVT_MAP_VAR(0), EVT_VAR(0))
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1403))
+    EVT_CALL(AssignScript, EVT_PTR(N(802438C8)))
+    EVT_CALL(MakeEntity, 0x802EAA30, 472, 100, -100, 0, MAKE_ENTITY_END)
+    EVT_CALL(AssignScript, EVT_PTR(N(80243DB0)))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/SetOverrideFlags_40.inc.c"
 

--- a/src/world/area_flo/flo_16/CD2C80.c
+++ b/src/world/area_flo/flo_16/CD2C80.c
@@ -24,13 +24,15 @@ NpcAISettings N(npcAISettings_80244028) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80244058) = SCRIPT({
-    SetSelfVar(0, 1);
-    SetSelfVar(5, 0);
-    SetSelfVar(6, 0);
-    SetSelfVar(1, 600);
-    N(func_80242754_CD4584)(N(npcAISettings_80244028));
-});
+EvtSource N(npcAI_80244058) = {
+    EVT_CALL(SetSelfVar, 0, 1)
+    EVT_CALL(SetSelfVar, 5, 0)
+    EVT_CALL(SetSelfVar, 6, 0)
+    EVT_CALL(SetSelfVar, 1, 600)
+    EVT_CALL(N(func_80242754_CD4584), EVT_PTR(N(npcAISettings_80244028)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802440C8) = {
     .height = 24,
@@ -123,223 +125,231 @@ static s32 N(pad_44F8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80244500) = SCRIPT({
-    N(func_80242940_CD4770)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    if (EVT_AREA_FLAG(41) == 0) {
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 50;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 180;
-        EVT_AREA_FLAG(41) = 1;
-    } else {
-        EVT_VAR(5) = 50;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 180;
-        EVT_VAR(8) = 0;
-        EVT_AREA_FLAG(41) = 0;
-    }
-    sleep 15;
-    PlaySound(0x204D);
-    spawn {
-        ShakeCam(0, 0, 30, 0.80078125);
-        ShakeCam(0, 0, 5, 0.2001953125);
-    }
-    MakeLerp(EVT_VAR(5), EVT_VAR(6), 30, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(94, 0, EVT_VAR(0), 0);
-        TranslateGroup(97, 0, EVT_VAR(0), 0);
-        TranslateModel(108, 0, EVT_VAR(0), 0);
-        TranslateGroup(111, 0, EVT_VAR(0), 0);
-        RotateGroup(97, EVT_VAR(7), 1, 0, 0);
-        RotateGroup(111, EVT_VAR(7), 1, 0, 0);
-        UpdateColliderTransform(26);
-        UpdateColliderTransform(27);
-        UpdateColliderTransform(32);
-        UpdateColliderTransform(33);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    DisablePlayerInput(FALSE);
-    sleep 10;
-    MakeLerp(EVT_VAR(7), EVT_VAR(8), 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(94, 0, EVT_VAR(6), 0);
-        TranslateGroup(97, 0, EVT_VAR(6), 0);
-        TranslateModel(108, 0, EVT_VAR(6), 0);
-        TranslateGroup(111, 0, EVT_VAR(6), 0);
-        RotateGroup(97, EVT_VAR(0), 1, 0, 0);
-        RotateGroup(111, EVT_VAR(0), 1, 0, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80244500) = {
+    EVT_CALL(N(func_80242940_CD4770))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_AREA_FLAG(41), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 50)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 180)
+        EVT_SET(EVT_AREA_FLAG(41), 1)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(5), 50)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 180)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_AREA_FLAG(41), 0)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(PlaySound, 0x204D)
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 30, EVT_FIXED(0.8))
+        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.2))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, EVT_VAR(5), EVT_VAR(6), 30, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 94, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 97, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateModel, 108, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 111, 0, EVT_VAR(0), 0)
+        EVT_CALL(RotateGroup, 97, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(RotateGroup, 111, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(UpdateColliderTransform, 26)
+        EVT_CALL(UpdateColliderTransform, 27)
+        EVT_CALL(UpdateColliderTransform, 32)
+        EVT_CALL(UpdateColliderTransform, 33)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(MakeLerp, EVT_VAR(7), EVT_VAR(8), 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 94, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 97, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateModel, 108, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 111, 0, EVT_VAR(6), 0)
+        EVT_CALL(RotateGroup, 97, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateGroup, 111, EVT_VAR(0), 1, 0, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802448FC) = SCRIPT({
-    N(func_80242940_CD4770)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    if (EVT_AREA_FLAG(42) == 0) {
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 50;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 180;
-        EVT_AREA_FLAG(42) = 1;
-    } else {
-        EVT_VAR(5) = 50;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 180;
-        EVT_VAR(8) = 0;
-        EVT_AREA_FLAG(42) = 0;
-    }
-    sleep 15;
-    PlaySound(0x204D);
-    spawn {
-        ShakeCam(0, 0, 30, 0.80078125);
-        ShakeCam(0, 0, 5, 0.2001953125);
-    }
-    MakeLerp(EVT_VAR(5), EVT_VAR(6), 30, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(101, 0, EVT_VAR(0), 0);
-        TranslateGroup(104, 0, EVT_VAR(0), 0);
-        TranslateModel(115, 0, EVT_VAR(0), 0);
-        TranslateGroup(118, 0, EVT_VAR(0), 0);
-        TranslateModel(129, 0, EVT_VAR(0), 0);
-        TranslateGroup(132, 0, EVT_VAR(0), 0);
-        RotateGroup(104, EVT_VAR(7), 1, 0, 0);
-        RotateGroup(118, EVT_VAR(7), 1, 0, 0);
-        RotateGroup(132, EVT_VAR(7), 1, 0, 0);
-        UpdateColliderTransform(29);
-        UpdateColliderTransform(30);
-        UpdateColliderTransform(35);
-        UpdateColliderTransform(36);
-        UpdateColliderTransform(41);
-        UpdateColliderTransform(42);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    DisablePlayerInput(FALSE);
-    sleep 10;
-    MakeLerp(EVT_VAR(7), EVT_VAR(8), 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(101, 0, EVT_VAR(6), 0);
-        TranslateGroup(104, 0, EVT_VAR(6), 0);
-        TranslateModel(115, 0, EVT_VAR(6), 0);
-        TranslateGroup(118, 0, EVT_VAR(6), 0);
-        TranslateModel(129, 0, EVT_VAR(6), 0);
-        TranslateGroup(132, 0, EVT_VAR(6), 0);
-        RotateGroup(104, EVT_VAR(0), 1, 0, 0);
-        RotateGroup(118, EVT_VAR(0), 1, 0, 0);
-        RotateGroup(132, EVT_VAR(0), 1, 0, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(802448FC) = {
+    EVT_CALL(N(func_80242940_CD4770))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_AREA_FLAG(42), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 50)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 180)
+        EVT_SET(EVT_AREA_FLAG(42), 1)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(5), 50)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 180)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_AREA_FLAG(42), 0)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(PlaySound, 0x204D)
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 30, EVT_FIXED(0.8))
+        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.2))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, EVT_VAR(5), EVT_VAR(6), 30, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 101, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 104, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateModel, 115, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 118, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateModel, 129, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 132, 0, EVT_VAR(0), 0)
+        EVT_CALL(RotateGroup, 104, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(RotateGroup, 118, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(RotateGroup, 132, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(UpdateColliderTransform, 29)
+        EVT_CALL(UpdateColliderTransform, 30)
+        EVT_CALL(UpdateColliderTransform, 35)
+        EVT_CALL(UpdateColliderTransform, 36)
+        EVT_CALL(UpdateColliderTransform, 41)
+        EVT_CALL(UpdateColliderTransform, 42)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(MakeLerp, EVT_VAR(7), EVT_VAR(8), 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 101, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 104, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateModel, 115, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 118, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateModel, 129, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 132, 0, EVT_VAR(6), 0)
+        EVT_CALL(RotateGroup, 104, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateGroup, 118, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateGroup, 132, EVT_VAR(0), 1, 0, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244DC8) = SCRIPT({
-    N(func_80242940_CD4770)();
-    if (EVT_VAR(0) == 0) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    if (EVT_AREA_FLAG(43) == 0) {
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = -50;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 180;
-        EVT_AREA_FLAG(43) = 1;
-    } else {
-        EVT_VAR(5) = -50;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 180;
-        EVT_VAR(8) = 0;
-        EVT_AREA_FLAG(43) = 0;
-    }
-    sleep 15;
-    PlaySound(0x204D);
-    spawn {
-        ShakeCam(0, 0, 30, 0.80078125);
-        ShakeCam(0, 0, 5, 0.2001953125);
-    }
-    MakeLerp(EVT_VAR(5), EVT_VAR(6), 30, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(122, 0, EVT_VAR(0), 0);
-        TranslateGroup(125, 0, EVT_VAR(0), 0);
-        TranslateModel(136, 0, EVT_VAR(0), 0);
-        TranslateGroup(139, 0, EVT_VAR(0), 0);
-        RotateGroup(125, EVT_VAR(7), 1, 0, 0);
-        RotateGroup(139, EVT_VAR(7), 1, 0, 0);
-        UpdateColliderTransform(38);
-        UpdateColliderTransform(39);
-        UpdateColliderTransform(44);
-        UpdateColliderTransform(45);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-    DisablePlayerInput(FALSE);
-    sleep 10;
-    MakeLerp(EVT_VAR(7), EVT_VAR(8), 15, 0);
-    loop {
-        UpdateLerp();
-        TranslateModel(122, 0, EVT_VAR(6), 0);
-        TranslateGroup(125, 0, EVT_VAR(6), 0);
-        TranslateModel(136, 0, EVT_VAR(6), 0);
-        TranslateGroup(139, 0, EVT_VAR(6), 0);
-        RotateGroup(125, EVT_VAR(0), 1, 0, 0);
-        RotateGroup(139, EVT_VAR(0), 1, 0, 0);
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80244DC8) = {
+    EVT_CALL(N(func_80242940_CD4770))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_AREA_FLAG(43), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), -50)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 180)
+        EVT_SET(EVT_AREA_FLAG(43), 1)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(5), -50)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 180)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_AREA_FLAG(43), 0)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(PlaySound, 0x204D)
+    EVT_THREAD
+        EVT_CALL(ShakeCam, 0, 0, 30, EVT_FIXED(0.8))
+        EVT_CALL(ShakeCam, 0, 0, 5, EVT_FIXED(0.2))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, EVT_VAR(5), EVT_VAR(6), 30, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 122, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 125, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateModel, 136, 0, EVT_VAR(0), 0)
+        EVT_CALL(TranslateGroup, 139, 0, EVT_VAR(0), 0)
+        EVT_CALL(RotateGroup, 125, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(RotateGroup, 139, EVT_VAR(7), 1, 0, 0)
+        EVT_CALL(UpdateColliderTransform, 38)
+        EVT_CALL(UpdateColliderTransform, 39)
+        EVT_CALL(UpdateColliderTransform, 44)
+        EVT_CALL(UpdateColliderTransform, 45)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(MakeLerp, EVT_VAR(7), EVT_VAR(8), 15, 0)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(TranslateModel, 122, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 125, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateModel, 136, 0, EVT_VAR(6), 0)
+        EVT_CALL(TranslateGroup, 139, 0, EVT_VAR(6), 0)
+        EVT_CALL(RotateGroup, 125, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateGroup, 139, EVT_VAR(0), 1, 0, 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802451C4) = SCRIPT({
-    EVT_AREA_FLAG(41) = 0;
-    EVT_AREA_FLAG(42) = 0;
-    EVT_AREA_FLAG(43) = 0;
-    ParentColliderToModel(26, 94);
-    ParentColliderToModel(27, 94);
-    ParentColliderToModel(29, 101);
-    ParentColliderToModel(30, 101);
-    ParentColliderToModel(32, 108);
-    ParentColliderToModel(33, 108);
-    ParentColliderToModel(35, 115);
-    ParentColliderToModel(36, 115);
-    ParentColliderToModel(38, 122);
-    ParentColliderToModel(39, 122);
-    ParentColliderToModel(41, 129);
-    ParentColliderToModel(42, 129);
-    ParentColliderToModel(44, 136);
-    ParentColliderToModel(45, 136);
-    bind N(80244500) TRIGGER_FLOOR_TOUCH 26;
-    bind N(802448FC) TRIGGER_FLOOR_TOUCH 29;
-    bind N(80244500) TRIGGER_FLOOR_TOUCH 32;
-    bind N(802448FC) TRIGGER_FLOOR_TOUCH 35;
-    bind N(80244DC8) TRIGGER_FLOOR_TOUCH 38;
-    bind N(802448FC) TRIGGER_FLOOR_TOUCH 41;
-    bind N(80244DC8) TRIGGER_FLOOR_TOUCH 44;
-});
+EvtSource N(802451C4) = {
+    EVT_SET(EVT_AREA_FLAG(41), 0)
+    EVT_SET(EVT_AREA_FLAG(42), 0)
+    EVT_SET(EVT_AREA_FLAG(43), 0)
+    EVT_CALL(ParentColliderToModel, 26, 94)
+    EVT_CALL(ParentColliderToModel, 27, 94)
+    EVT_CALL(ParentColliderToModel, 29, 101)
+    EVT_CALL(ParentColliderToModel, 30, 101)
+    EVT_CALL(ParentColliderToModel, 32, 108)
+    EVT_CALL(ParentColliderToModel, 33, 108)
+    EVT_CALL(ParentColliderToModel, 35, 115)
+    EVT_CALL(ParentColliderToModel, 36, 115)
+    EVT_CALL(ParentColliderToModel, 38, 122)
+    EVT_CALL(ParentColliderToModel, 39, 122)
+    EVT_CALL(ParentColliderToModel, 41, 129)
+    EVT_CALL(ParentColliderToModel, 42, 129)
+    EVT_CALL(ParentColliderToModel, 44, 136)
+    EVT_CALL(ParentColliderToModel, 45, 136)
+    EVT_BIND_TRIGGER(N(80244500), TRIGGER_FLOOR_TOUCH, 26, 1, 0)
+    EVT_BIND_TRIGGER(N(802448FC), TRIGGER_FLOOR_TOUCH, 29, 1, 0)
+    EVT_BIND_TRIGGER(N(80244500), TRIGGER_FLOOR_TOUCH, 32, 1, 0)
+    EVT_BIND_TRIGGER(N(802448FC), TRIGGER_FLOOR_TOUCH, 35, 1, 0)
+    EVT_BIND_TRIGGER(N(80244DC8), TRIGGER_FLOOR_TOUCH, 38, 1, 0)
+    EVT_BIND_TRIGGER(N(802448FC), TRIGGER_FLOOR_TOUCH, 41, 1, 0)
+    EVT_BIND_TRIGGER(N(80244DC8), TRIGGER_FLOOR_TOUCH, 44, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc23.inc.c"
 

--- a/src/world/area_flo/flo_17/CD7350.c
+++ b/src/world/area_flo/flo_17/CD7350.c
@@ -25,63 +25,68 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_17_tattle },
 };
 
-EvtSource N(80243280) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80243280) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802432F0) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(802432F0) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024359C) = EXIT_WALK_SCRIPT(60,  0, "flo_16",  1);
 
 EvtSource N(exitWalk_802435F8) = EXIT_WALK_SCRIPT(60,  1, "flo_18",  0);
 
-EvtSource N(80243654) = SCRIPT({
-    bind N(exitWalk_8024359C) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_802435F8) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80243654) = {
+    EVT_BIND_TRIGGER(N(exitWalk_8024359C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_802435F8), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_8024369C)[] = {
     0x0000000F, 0xC4048000, 0x00000000, 0xC2DC0000, 0x00000011, 0xC4070000, 0x00000000, 0xC2480000,
@@ -96,199 +101,205 @@ s32 N(lavaResetList_8024369C)[] = {
     0x00000020, 0x44034000, 0x00000000, 0x42480000, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80245228));
-    await N(makeEntities);
-    spawn N(80244284);
-    ModifyColliderFlags(3, 15, 0x00000006);
-    ModifyColliderFlags(3, 16, 0x00000006);
-    ModifyColliderFlags(3, 20, 0x00000006);
-    ModifyColliderFlags(3, 23, 0x00000006);
-    ModifyColliderFlags(3, 25, 0x00000006);
-    ModifyColliderFlags(3, 27, 0x00000006);
-    ModifyColliderFlags(3, 28, 0x00000006);
-    ModifyColliderFlags(3, 31, 0x00000006);
-    ModifyColliderFlags(3, 32, 0x00000006);
-    EVT_VAR(0) = -736;
-    EVT_VAR(1) = -137;
-    EVT_VAR(2) = -522;
-    EVT_VAR(3) = -118;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    EVT_VAR(0) = -728;
-    EVT_VAR(1) = 76;
-    EVT_VAR(2) = -496;
-    EVT_VAR(3) = 137;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    EVT_VAR(0) = -160;
-    EVT_VAR(1) = -117;
-    EVT_VAR(2) = -92;
-    EVT_VAR(3) = -54;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    EVT_VAR(0) = 76;
-    EVT_VAR(1) = -124;
-    EVT_VAR(2) = 150;
-    EVT_VAR(3) = -55;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    EVT_VAR(0) = 192;
-    EVT_VAR(1) = 60;
-    EVT_VAR(2) = 309;
-    EVT_VAR(3) = 133;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    EVT_VAR(0) = 488;
-    EVT_VAR(1) = 46;
-    EVT_VAR(2) = 733;
-    EVT_VAR(3) = 137;
-    EVT_VAR(4) = 0;
-    spawn N(802432F0);
-    ModifyColliderFlags(3, 9, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_8024369C));
-    }
-    EnableTexPanning(30, 1);
-    EnableTexPanning(32, 1);
-    EnableTexPanning(33, 1);
-    EnableTexPanning(36, 1);
-    EnableTexPanning(37, 1);
-    EnableTexPanning(40, 1);
-    EnableTexPanning(42, 1);
-    EnableTexPanning(44, 1);
-    EnableTexPanning(45, 1);
-    EnableTexPanning(48, 1);
-    EnableTexPanning(49, 1);
-    EnableTexPanning(52, 1);
-    EnableTexPanning(54, 1);
-    EnableTexPanning(56, 1);
-    EnableTexPanning(57, 1);
-    EnableTexPanning(60, 1);
-    EnableTexPanning(61, 1);
-    EnableTexPanning(64, 1);
-    EnableTexPanning(31, 1);
-    EnableTexPanning(34, 1);
-    EnableTexPanning(35, 1);
-    EnableTexPanning(38, 1);
-    EnableTexPanning(39, 1);
-    EnableTexPanning(43, 1);
-    EnableTexPanning(46, 1);
-    EnableTexPanning(47, 1);
-    EnableTexPanning(50, 1);
-    EnableTexPanning(51, 1);
-    EnableTexPanning(55, 1);
-    EnableTexPanning(58, 1);
-    EnableTexPanning(59, 1);
-    EnableTexPanning(62, 1);
-    EnableTexPanning(63, 1);
-    spawn {
-        EVT_VAR(0) = 0;
-        EVT_VAR(1) = 0;
-0:
-        EVT_VAR(0) += 140;
-        if (EVT_VAR(0) > 65536) {
-            EVT_VAR(0) += -65536;
-        }
-        SetTexPanOffset(1, 0, EVT_VAR(0), 0);
-        EVT_VAR(1) += -200;
-        if (EVT_VAR(1) < 0) {
-            EVT_VAR(1) += 65536;
-        }
-        SetTexPanOffset(2, 0, EVT_VAR(1), 0);
-        sleep 1;
-        goto 0;
-    }
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80243654);
-    spawn EnterWalk;
-    await N(80243280);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CD72E0)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80245228)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80244284))
+    EVT_CALL(ModifyColliderFlags, 3, 15, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 16, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 20, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 23, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 25, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 27, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 28, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 31, 0x00000006)
+    EVT_CALL(ModifyColliderFlags, 3, 32, 0x00000006)
+    EVT_SET(EVT_VAR(0), -736)
+    EVT_SET(EVT_VAR(1), -137)
+    EVT_SET(EVT_VAR(2), -522)
+    EVT_SET(EVT_VAR(3), -118)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_SET(EVT_VAR(0), -728)
+    EVT_SET(EVT_VAR(1), 76)
+    EVT_SET(EVT_VAR(2), -496)
+    EVT_SET(EVT_VAR(3), 137)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_SET(EVT_VAR(0), -160)
+    EVT_SET(EVT_VAR(1), -117)
+    EVT_SET(EVT_VAR(2), -92)
+    EVT_SET(EVT_VAR(3), -54)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_SET(EVT_VAR(0), 76)
+    EVT_SET(EVT_VAR(1), -124)
+    EVT_SET(EVT_VAR(2), 150)
+    EVT_SET(EVT_VAR(3), -55)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_SET(EVT_VAR(0), 192)
+    EVT_SET(EVT_VAR(1), 60)
+    EVT_SET(EVT_VAR(2), 309)
+    EVT_SET(EVT_VAR(3), 133)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_SET(EVT_VAR(0), 488)
+    EVT_SET(EVT_VAR(1), 46)
+    EVT_SET(EVT_VAR(2), 733)
+    EVT_SET(EVT_VAR(3), 137)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(802432F0))
+    EVT_CALL(ModifyColliderFlags, 3, 9, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_8024369C)))
+    EVT_END_THREAD
+    EVT_CALL(EnableTexPanning, 30, 1)
+    EVT_CALL(EnableTexPanning, 32, 1)
+    EVT_CALL(EnableTexPanning, 33, 1)
+    EVT_CALL(EnableTexPanning, 36, 1)
+    EVT_CALL(EnableTexPanning, 37, 1)
+    EVT_CALL(EnableTexPanning, 40, 1)
+    EVT_CALL(EnableTexPanning, 42, 1)
+    EVT_CALL(EnableTexPanning, 44, 1)
+    EVT_CALL(EnableTexPanning, 45, 1)
+    EVT_CALL(EnableTexPanning, 48, 1)
+    EVT_CALL(EnableTexPanning, 49, 1)
+    EVT_CALL(EnableTexPanning, 52, 1)
+    EVT_CALL(EnableTexPanning, 54, 1)
+    EVT_CALL(EnableTexPanning, 56, 1)
+    EVT_CALL(EnableTexPanning, 57, 1)
+    EVT_CALL(EnableTexPanning, 60, 1)
+    EVT_CALL(EnableTexPanning, 61, 1)
+    EVT_CALL(EnableTexPanning, 64, 1)
+    EVT_CALL(EnableTexPanning, 31, 1)
+    EVT_CALL(EnableTexPanning, 34, 1)
+    EVT_CALL(EnableTexPanning, 35, 1)
+    EVT_CALL(EnableTexPanning, 38, 1)
+    EVT_CALL(EnableTexPanning, 39, 1)
+    EVT_CALL(EnableTexPanning, 43, 1)
+    EVT_CALL(EnableTexPanning, 46, 1)
+    EVT_CALL(EnableTexPanning, 47, 1)
+    EVT_CALL(EnableTexPanning, 50, 1)
+    EVT_CALL(EnableTexPanning, 51, 1)
+    EVT_CALL(EnableTexPanning, 55, 1)
+    EVT_CALL(EnableTexPanning, 58, 1)
+    EVT_CALL(EnableTexPanning, 59, 1)
+    EVT_CALL(EnableTexPanning, 62, 1)
+    EVT_CALL(EnableTexPanning, 63, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 0)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_LABEL(0)
+        EVT_ADD(EVT_VAR(0), 140)
+        EVT_IF_GT(EVT_VAR(0), 65536)
+            EVT_ADD(EVT_VAR(0), -65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 1, 0, EVT_VAR(0), 0)
+        EVT_ADD(EVT_VAR(1), -200)
+        EVT_IF_LT(EVT_VAR(1), 0)
+            EVT_ADD(EVT_VAR(1), 65536)
+        EVT_END_IF
+        EVT_CALL(SetTexPanOffset, 2, 0, EVT_VAR(1), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80243654)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80243280))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CD72E0))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3FCC) = {
     0x00000000,
 };
 
-EvtSource N(80243FD0) = SCRIPT({
-    loop {
-        N(func_80240040_CD7320)(EVT_VAR(0));
-        if (EVT_VAR(0) == EVT_VAR(4)) {
-            GetPlayerActionState(EVT_VAR(0));
-            if (EVT_VAR(0) != 23) {
-                if (EVT_VAR(8) == 0) {
-                    spawn {
-                        GetModelCenter(EVT_VAR(5));
-                        PlaySoundAt(0x1DB, 4194304, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    }
-                }
-                if (EVT_VAR(7) < 90) {
-                    if (EVT_VAR(7) == 0) {
-                        sleep 5;
-                        EVT_VAR(8) = 6;
-                        ModifyColliderFlags(0, EVT_VAR(9), 0x7FFFFE00);
-                    }
-                    EVT_VAR(8) += 1;
-                    EVT_VAR(7) += EVT_VAR(8);
-                }
-                goto 50;
-            }
-        }
-        if (EVT_VAR(7) != 0) {
-            EVT_VAR(8) -= 1;
-            EVT_VAR(7) += EVT_VAR(8);
-            if (EVT_VAR(7) <= 0) {
-                EVT_VAR(8) = 0;
-                EVT_VAR(7) = 0;
-                spawn {
-                    GetModelCenter(EVT_VAR(5));
-                    PlaySoundAt(0x1DC, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                }
-                ModifyColliderFlags(1, EVT_VAR(9), 0x7FFFFE00);
-            }
-        }
-50:
-        if (EVT_VAR(7) >= 90) {
-            EVT_VAR(8) = -1;
-            EVT_VAR(7) = 90;
-        }
-        RotateModel(EVT_VAR(5), EVT_VAR(7), -1, 0, 0);
-        RotateModel(EVT_VAR(6), EVT_VAR(7), -1, 0, 0);
-        sleep 1;
-    }
-});
+EvtSource N(80243FD0) = {
+    EVT_LOOP(0)
+        EVT_CALL(N(func_80240040_CD7320), EVT_VAR(0))
+        EVT_IF_EQ(EVT_VAR(0), EVT_VAR(4))
+            EVT_CALL(GetPlayerActionState, EVT_VAR(0))
+            EVT_IF_NE(EVT_VAR(0), 23)
+                EVT_IF_EQ(EVT_VAR(8), 0)
+                    EVT_THREAD
+                        EVT_CALL(GetModelCenter, EVT_VAR(5))
+                        EVT_CALL(PlaySoundAt, 0x1DB, 4194304, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_END_THREAD
+                EVT_END_IF
+                EVT_IF_LT(EVT_VAR(7), 90)
+                    EVT_IF_EQ(EVT_VAR(7), 0)
+                        EVT_WAIT_FRAMES(5)
+                        EVT_SET(EVT_VAR(8), 6)
+                        EVT_CALL(ModifyColliderFlags, 0, EVT_VAR(9), 0x7FFFFE00)
+                    EVT_END_IF
+                    EVT_ADD(EVT_VAR(8), 1)
+                    EVT_ADD(EVT_VAR(7), EVT_VAR(8))
+                EVT_END_IF
+                EVT_GOTO(50)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_IF_NE(EVT_VAR(7), 0)
+            EVT_SUB(EVT_VAR(8), 1)
+            EVT_ADD(EVT_VAR(7), EVT_VAR(8))
+            EVT_IF_LE(EVT_VAR(7), 0)
+                EVT_SET(EVT_VAR(8), 0)
+                EVT_SET(EVT_VAR(7), 0)
+                EVT_THREAD
+                    EVT_CALL(GetModelCenter, EVT_VAR(5))
+                    EVT_CALL(PlaySoundAt, 0x1DC, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_END_THREAD
+                EVT_CALL(ModifyColliderFlags, 1, EVT_VAR(9), 0x7FFFFE00)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_LABEL(50)
+        EVT_IF_GE(EVT_VAR(7), 90)
+            EVT_SET(EVT_VAR(8), -1)
+            EVT_SET(EVT_VAR(7), 90)
+        EVT_END_IF
+        EVT_CALL(RotateModel, EVT_VAR(5), EVT_VAR(7), -1, 0, 0)
+        EVT_CALL(RotateModel, EVT_VAR(6), EVT_VAR(7), -1, 0, 0)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244284) = SCRIPT({
-    EVT_VAR(4) = 35;
-    EVT_VAR(5) = 14;
-    EVT_VAR(6) = 15;
-    EVT_VAR(7) = EVT_MAP_VAR(10);
-    EVT_VAR(8) = EVT_MAP_VAR(11);
-    EVT_VAR(9) = 38;
-    spawn N(80243FD0);
-    EVT_VAR(4) = 36;
-    EVT_VAR(5) = 19;
-    EVT_VAR(6) = 20;
-    EVT_VAR(7) = EVT_MAP_VAR(12);
-    EVT_VAR(8) = EVT_MAP_VAR(13);
-    EVT_VAR(9) = 39;
-    spawn N(80243FD0);
-    EVT_VAR(4) = 37;
-    EVT_VAR(5) = 24;
-    EVT_VAR(6) = 25;
-    EVT_VAR(7) = EVT_MAP_VAR(14);
-    EVT_VAR(8) = EVT_MAP_VAR(15);
-    EVT_VAR(9) = 40;
-    spawn N(80243FD0);
-});
+EvtSource N(80244284) = {
+    EVT_SET(EVT_VAR(4), 35)
+    EVT_SET(EVT_VAR(5), 14)
+    EVT_SET(EVT_VAR(6), 15)
+    EVT_SET(EVT_VAR(7), EVT_MAP_VAR(10))
+    EVT_SET(EVT_VAR(8), EVT_MAP_VAR(11))
+    EVT_SET(EVT_VAR(9), 38)
+    EVT_EXEC(N(80243FD0))
+    EVT_SET(EVT_VAR(4), 36)
+    EVT_SET(EVT_VAR(5), 19)
+    EVT_SET(EVT_VAR(6), 20)
+    EVT_SET(EVT_VAR(7), EVT_MAP_VAR(12))
+    EVT_SET(EVT_VAR(8), EVT_MAP_VAR(13))
+    EVT_SET(EVT_VAR(9), 39)
+    EVT_EXEC(N(80243FD0))
+    EVT_SET(EVT_VAR(4), 37)
+    EVT_SET(EVT_VAR(5), 24)
+    EVT_SET(EVT_VAR(6), 25)
+    EVT_SET(EVT_VAR(7), EVT_MAP_VAR(14))
+    EVT_SET(EVT_VAR(8), EVT_MAP_VAR(15))
+    EVT_SET(EVT_VAR(9), 40)
+    EVT_EXEC(N(80243FD0))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_XXX)[] = { 0, 0};
 
@@ -318,13 +329,15 @@ NpcAISettings N(npcAISettings_80244424) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80244454) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -650);
-    SetSelfVar(6, 30);
-    SetSelfVar(1, 400);
-    N(func_80241C64_CD8F44)(N(npcAISettings_80244424));
-});
+EvtSource N(npcAI_80244454) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -650)
+    EVT_CALL(SetSelfVar, 6, 30)
+    EVT_CALL(SetSelfVar, 1, 400)
+    EVT_CALL(N(func_80241C64_CD8F44), EVT_PTR(N(npcAISettings_80244424)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802444C4) = {
     .height = 28,
@@ -348,31 +361,32 @@ NpcAISettings N(npcAISettings_802444F0) = {
     .unk_2C = 3,
 };
 
-EvtSource N(npcAI_80244520) = SCRIPT({
-    SetSelfVar(2, 3);
-    SetSelfVar(3, 18);
-    SetSelfVar(5, 3);
-    SetSelfVar(7, 4);
-    N(func_80242918_CD9BF8)(N(npcAISettings_802444F0));
-});
+EvtSource N(npcAI_80244520) = {
+    EVT_CALL(SetSelfVar, 2, 3)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(SetSelfVar, 5, 3)
+    EVT_CALL(SetSelfVar, 7, 4)
+    EVT_CALL(N(func_80242918_CD9BF8), EVT_PTR(N(npcAISettings_802444F0)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244590) = SCRIPT({
-    SetNpcRotation(NPC_SELF, 0, 0, 0);
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetSelfVar(10, 100);
-            DoNpcDefeat();
-        }
-        == 2 {
-            func_80045900(0);
-        }
-        == 3 {
-            SetEnemyFlagBits(-1, 16, 1);
-            RemoveNpc(NPC_SELF);
-        }
-    }
-});
+EvtSource N(80244590) = {
+    EVT_CALL(SetNpcRotation, NPC_SELF, 0, 0, 0)
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetSelfVar, 10, 100)
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(2)
+            EVT_CALL(func_80045900, 0)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetEnemyFlagBits, -1, 16, 1)
+            EVT_CALL(RemoveNpc, NPC_SELF)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024465C) = {
     .height = 21,
@@ -603,11 +617,13 @@ static s32 N(pad_527C) = {
     0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA588, 660, 60, -115, 0, ITEM_THUNDER_RAGE, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1390));
-    MakeItemEntity(ITEM_LETTER09, -245, 0, 105, 17, EVT_SAVE_FLAG(1389));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA588, 660, 60, -115, 0, 130, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1390))
+    EVT_CALL(MakeItemEntity, ITEM_LETTER09, -245, 0, 105, 17, EVT_SAVE_FLAG(1389))
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkNpcAIFunc23.inc.c"
 

--- a/src/world/area_flo/flo_18/CDC6A0.c
+++ b/src/world/area_flo/flo_18/CDC6A0.c
@@ -26,378 +26,395 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_18_tattle },
 };
 
-EvtSource N(80240830) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_PUFF_PUFF_MACHINE, 0, 8);
-            PlaySoundAtCollider(20, 0x80000025, 0);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80240830) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_PUFF_PUFF_MACHINE, 0, 8)
+            EVT_CALL(PlaySoundAtCollider, 20, 0x80000025, 0)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_8B8)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(updateTexturePan_802408C0) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(updateTexturePan_802408C0) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024095C) = EXIT_WALK_SCRIPT(60,  0, "flo_17",  1);
 
-EvtSource N(802409B8) = SCRIPT({
-    bind N(exitWalk_8024095C) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(802409B8) = {
+    EVT_BIND_TRIGGER(N(exitWalk_8024095C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(lavaResetList_802409E4)[] = {
     0x0000000B, 0xC3480000, 0x00000000, 0x42F00000, 0x0000000C, 0x00000000, 0x00000000, 0x42F00000,
     0x0000000D, 0x432A0000, 0x00000000, 0x42F00000, 0xFFFFFFFF, 0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_8024669C));
-    spawn N(80247024);
-    spawn N(802436BC);
-    spawn N(802456D4);
-    ModifyColliderFlags(3, 8, 0x00000002);
-    spawn {
-        ResetFromLava(N(lavaResetList_802409E4));
-    }
-    EnableTexPanning(9, 1);
-    EnableTexPanning(11, 1);
-    EnableTexPanning(12, 1);
-    EnableTexPanning(13, 1);
-    EnableTexPanning(14, 1);
-    EnableTexPanning(15, 1);
-    EnableTexPanning(7, 1);
-    EnableTexPanning(8, 1);
-    EnableTexPanning(10, 1);
-    EnableTexPanning(16, 1);
-    EnableTexPanning(17, 1);
-    spawn {
-        EVT_VAR(0) = 1;
-        EVT_VAR(1) = -140;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802408C0);
-    }
-    spawn {
-        EVT_VAR(0) = 2;
-        EVT_VAR(1) = -200;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802408C0);
-    }
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 0) {
-        ModifyColliderFlags(0, 1, 0x7FFFFE00);
-        EVT_VAR(0) = N(802409B8);
-        spawn EnterWalk;
-    } else {
-        spawn N(80244058);
-        spawn N(802409B8);
-    }
-    await N(80240830);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_8024030C_CDC9AC)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_8024669C)))
+    EVT_EXEC(N(80247024))
+    EVT_EXEC(N(802436BC))
+    EVT_EXEC(N(802456D4))
+    EVT_CALL(ModifyColliderFlags, 3, 8, 0x00000002)
+    EVT_THREAD
+        EVT_CALL(ResetFromLava, EVT_PTR(N(lavaResetList_802409E4)))
+    EVT_END_THREAD
+    EVT_CALL(EnableTexPanning, 9, 1)
+    EVT_CALL(EnableTexPanning, 11, 1)
+    EVT_CALL(EnableTexPanning, 12, 1)
+    EVT_CALL(EnableTexPanning, 13, 1)
+    EVT_CALL(EnableTexPanning, 14, 1)
+    EVT_CALL(EnableTexPanning, 15, 1)
+    EVT_CALL(EnableTexPanning, 7, 1)
+    EVT_CALL(EnableTexPanning, 8, 1)
+    EVT_CALL(EnableTexPanning, 10, 1)
+    EVT_CALL(EnableTexPanning, 16, 1)
+    EVT_CALL(EnableTexPanning, 17, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 1)
+        EVT_SET(EVT_VAR(1), -140)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802408C0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(1), -200)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802408C0))
+    EVT_END_THREAD
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(802409B8)))
+        EVT_EXEC(EnterWalk)
+    EVT_ELSE
+        EVT_EXEC(N(80244058))
+        EVT_EXEC(N(802409B8))
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80240830))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_8024030C_CDC9AC))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_E88)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80240E90) = SCRIPT({
-    group 11;
-    loop {
-        PlayEffect(0x5E, 0, -16.0, 102.0, -4.099609375, 80.900390625, 102.0, -4.099609375, 0.5, 6, 0, 0, 0, 0);
-        N(func_80240340_CDC9E0)();
-        sleep 4;
-        PlayEffect(0x5E, 0, 80.900390625, 102.0, -4.099609375, -16.0, 102.0, -4.099609375, 0.5, 6, 0, 0, 0, 0);
-        N(func_80240340_CDC9E0)();
-        sleep 4;
-        if (EVT_SAVE_VAR(253) >= 3) {
-            break loop;
-        }
-    }
-    EVT_VAR(0) = 6;
-    loop 5 {
-        PlayEffect(0x5E, 0, -16.0, 102.0, -4.099609375, 80.900390625, 102.0, -4.099609375, 0.5, 6, 0, 0, 0, 0);
-        N(func_80240340_CDC9E0)();
-        sleep EVT_VAR(0);
-        EVT_VAR(0) += 2;
-        PlayEffect(0x5E, 0, 80.900390625, 102.0, -4.099609375, -16.0, 102.0, -4.099609375, 0.5, 6, 0, 0, 0, 0);
-        N(func_80240340_CDC9E0)();
-        sleep EVT_VAR(0);
-        EVT_VAR(0) += 2;
-    }
-});
+EvtSource N(80240E90) = {
+    EVT_SET_GROUP(11)
+    EVT_LOOP(0)
+        EVT_CALL(PlayEffect, 0x5E, 0, EVT_FIXED(-16.0), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(80.9), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(0.5), 6, 0, 0, 0, 0)
+        EVT_CALL(N(func_80240340_CDC9E0))
+        EVT_WAIT_FRAMES(4)
+        EVT_CALL(PlayEffect, 0x5E, 0, EVT_FIXED(80.9), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(-16.0), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(0.5), 6, 0, 0, 0, 0)
+        EVT_CALL(N(func_80240340_CDC9E0))
+        EVT_WAIT_FRAMES(4)
+        EVT_IF_GE(EVT_SAVE_VAR(253), 3)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_SET(EVT_VAR(0), 6)
+    EVT_LOOP(5)
+        EVT_CALL(PlayEffect, 0x5E, 0, EVT_FIXED(-16.0), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(80.9), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(0.5), 6, 0, 0, 0, 0)
+        EVT_CALL(N(func_80240340_CDC9E0))
+        EVT_WAIT_FRAMES(EVT_VAR(0))
+        EVT_ADD(EVT_VAR(0), 2)
+        EVT_CALL(PlayEffect, 0x5E, 0, EVT_FIXED(80.9), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(-16.0), EVT_FIXED(102.0), EVT_FIXED(-4.1), EVT_FIXED(0.5), 6, 0, 0, 0, 0)
+        EVT_CALL(N(func_80240340_CDC9E0))
+        EVT_WAIT_FRAMES(EVT_VAR(0))
+        EVT_ADD(EVT_VAR(0), 2)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241094) = SCRIPT({
-    EnableModel(EVT_VAR(15), 1);
-    EVT_VAR(14) = 159;
-    loop EVT_VAR(14) {
-        EVT_VAR(3) += (float) 0;
-        EVT_VAR(4) += 0.0;
-        EVT_VAR(5) = 0.0107421875;
-        EVT_VAR(0) += (float) EVT_VAR(3);
-        EVT_VAR(1) += (float) EVT_VAR(4);
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        EVT_VAR(6) *= 1.0107421875;
-        EVT_VAR(7) += 0.0107421875;
-        EVT_VAR(8) = (float) EVT_VAR(6);
-        N(UnkFloatFunc)(EVT_VAR(14), EVT_VAR(10), 0.0, 0.203125, 15, 0, 0);
-        EVT_VAR(8) += (float) EVT_VAR(10);
-        EVT_VAR(9) = (float) EVT_VAR(7);
-        N(UnkFloatFunc)(EVT_VAR(14), EVT_VAR(10), 0.0, 0.203125, 20, 0, 90);
-        EVT_VAR(9) += (float) EVT_VAR(10);
-        EVT_VAR(10) = (float) EVT_VAR(0);
-        EVT_VAR(10) *= 10.0;
-        TranslateModel(EVT_VAR(15), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(EVT_VAR(15), EVT_VAR(8), EVT_VAR(9), 1);
-        RotateModel(EVT_VAR(15), EVT_VAR(10), 0, 0, 1);
-        sleep 1;
-    }
-    EnableModel(EVT_VAR(15), 0);
-});
+EvtSource N(80241094) = {
+    EVT_CALL(EnableModel, EVT_VAR(15), 1)
+    EVT_SET(EVT_VAR(14), 159)
+    EVT_LOOP(EVT_VAR(14))
+        EVT_ADDF(EVT_VAR(3), 0)
+        EVT_ADDF(EVT_VAR(4), EVT_FIXED(0.0))
+        EVT_SETF(EVT_VAR(5), EVT_FIXED(0.01))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(3))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(4))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_MULF(EVT_VAR(6), EVT_FIXED(1.01))
+        EVT_ADDF(EVT_VAR(7), EVT_FIXED(0.01))
+        EVT_SETF(EVT_VAR(8), EVT_VAR(6))
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(14), EVT_VAR(10), EVT_FIXED(0.0), EVT_FIXED(0.203125), 15, 0, 0)
+        EVT_ADDF(EVT_VAR(8), EVT_VAR(10))
+        EVT_SETF(EVT_VAR(9), EVT_VAR(7))
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(14), EVT_VAR(10), EVT_FIXED(0.0), EVT_FIXED(0.203125), 20, 0, 90)
+        EVT_ADDF(EVT_VAR(9), EVT_VAR(10))
+        EVT_SETF(EVT_VAR(10), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(10), EVT_FIXED(10.0))
+        EVT_CALL(TranslateModel, EVT_VAR(15), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, EVT_VAR(15), EVT_VAR(8), EVT_VAR(9), 1)
+        EVT_CALL(RotateModel, EVT_VAR(15), EVT_VAR(10), 0, 0, 1)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(EnableModel, EVT_VAR(15), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241284) = SCRIPT({
-    EVT_VAR(14) = 0;
-0:
-    if (EVT_SAVE_VAR(253) >= 3) {
-        return;
-    }
-    EVT_VAR(0) = 132.0;
-    EVT_VAR(1) = 90.0;
-    EVT_VAR(2) = -30.0;
-    RandInt(100, EVT_VAR(3));
-    EVT_VAR(3) += (float) -50;
-    EVT_VAR(3) /= (float) 200.0;
-    EVT_VAR(4) = 1.0;
-    EVT_VAR(5) = (float) 0;
-    EVT_VAR(6) = 0.296875;
-    EVT_VAR(7) = 0.296875;
-    EVT_VAR(15) = EVT_VAR(14);
-    EVT_VAR(15) += 10000;
-    spawn N(80241094);
-    EVT_VAR(14) += 1;
-    if (EVT_VAR(14) >= 16) {
-        EVT_VAR(14) = 0;
-    }
-    sleep 10;
-    goto 0;
-});
+EvtSource N(80241284) = {
+    EVT_SET(EVT_VAR(14), 0)
+    EVT_LABEL(0)
+    EVT_IF_GE(EVT_SAVE_VAR(253), 3)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(132.0))
+    EVT_SETF(EVT_VAR(1), EVT_FIXED(90.0))
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(-30.0))
+    EVT_CALL(RandInt, 100, EVT_VAR(3))
+    EVT_ADDF(EVT_VAR(3), -50)
+    EVT_DIVF(EVT_VAR(3), EVT_FIXED(200.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(1.0))
+    EVT_SETF(EVT_VAR(5), 0)
+    EVT_SETF(EVT_VAR(6), EVT_FIXED(0.296875))
+    EVT_SETF(EVT_VAR(7), EVT_FIXED(0.296875))
+    EVT_SET(EVT_VAR(15), EVT_VAR(14))
+    EVT_ADD(EVT_VAR(15), 10000)
+    EVT_EXEC(N(80241094))
+    EVT_ADD(EVT_VAR(14), 1)
+    EVT_IF_GE(EVT_VAR(14), 16)
+        EVT_SET(EVT_VAR(14), 0)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(10)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802413F0) = SCRIPT({
-    if (EVT_MAP_FLAG(2) == 1) {
-        return;
-    }
-    EVT_MAP_FLAG(2) = 1;
-    EVT_VAR(15) = 0;
-    loop 12 {
-        RandInt(80, EVT_VAR(0));
-        EVT_VAR(0) -= 40;
-        RandInt(50, EVT_VAR(1));
-        RandInt(50, EVT_VAR(2));
-        EVT_VAR(2) -= 25;
-        PlayEffect(0x0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 5, 10, 1, 1, 0, 0, 0, 0, 0, 0);
-        EVT_VAR(15) += 1;
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(14), 1.0, 1.09375, 2, 0, 0);
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(13), 1.09375, 1.0, 2, 0, 0);
-        EVT_VAR(0) = (float) EVT_VAR(14);
-        EVT_VAR(1) = (float) EVT_VAR(13);
-        EVT_VAR(2) = (float) EVT_VAR(14);
-        if (EVT_SAVE_VAR(252) == 0) {
-            ScaleModel(31, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        }
-        if (EVT_SAVE_VAR(253) == 0) {
-            ScaleModel(19, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(20, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        }
-        if (EVT_SAVE_VAR(252) <= 1) {
-            ScaleModel(21, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        }
-        if (EVT_SAVE_VAR(252) <= 2) {
-            if (EVT_SAVE_VAR(253) <= 1) {
-                ScaleModel(22, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(23, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(24, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(25, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(26, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            }
-        }
-        ScaleModel(27, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        if (EVT_SAVE_VAR(252) <= 2) {
-            if (EVT_SAVE_VAR(253) <= 2) {
-                ScaleModel(29, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(41, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                ScaleModel(33, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            }
-        }
-        ScaleModel(36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(37, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(38, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(39, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(34, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(0) -= 1.046875;
-        EVT_VAR(0) *= 100.0;
-        if (EVT_SAVE_VAR(252) == 0) {
-            RotateModel(31, EVT_VAR(0), 0, 0, 1);
-            RotateModel(32, EVT_VAR(0), 0, 0, 1);
-        }
-        if (EVT_SAVE_VAR(253) == 0) {
-            RotateModel(19, EVT_VAR(0), 0, 0, 1);
-            RotateModel(20, EVT_VAR(0), 0, 0, 1);
-        }
-        if (EVT_SAVE_VAR(252) <= 1) {
-            RotateModel(21, EVT_VAR(0), 0, 0, 1);
-        }
-        if (EVT_SAVE_VAR(252) <= 2) {
-            if (EVT_SAVE_VAR(253) <= 1) {
-                RotateModel(22, EVT_VAR(0), 0, 0, 1);
-                RotateModel(23, EVT_VAR(0), 0, 0, 1);
-                RotateModel(24, EVT_VAR(0), 0, 0, 1);
-                RotateModel(25, EVT_VAR(0), 0, 0, 1);
-                RotateModel(26, EVT_VAR(0), 0, 0, 1);
-            }
-        }
-        RotateModel(27, EVT_VAR(0), 0, 0, 1);
-        if (EVT_SAVE_VAR(252) <= 2) {
-            if (EVT_SAVE_VAR(253) <= 2) {
-                RotateModel(29, EVT_VAR(0), 0, 0, 1);
-                RotateModel(41, EVT_VAR(0), 0, 0, 1);
-                RotateModel(33, EVT_VAR(0), 0, 0, 1);
-            }
-        }
-        RotateModel(36, EVT_VAR(0), 0, 0, 1);
-        RotateModel(37, EVT_VAR(0), 0, 0, 1);
-        RotateModel(38, EVT_VAR(0), 0, 0, 1);
-        RotateModel(39, EVT_VAR(0), 0, 0, 1);
-        RotateModel(40, EVT_VAR(0), 0, 0, 1);
-        RotateModel(34, EVT_VAR(0), 0, 0, 1);
-        sleep 1;
-    }
-    EVT_VAR(0) = (float) 1;
-    EVT_VAR(1) = (float) 1;
-    EVT_VAR(2) = (float) 1;
-    if (EVT_SAVE_VAR(252) == 0) {
-        ScaleModel(31, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    }
-    if (EVT_SAVE_VAR(253) == 0) {
-        ScaleModel(19, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        ScaleModel(20, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    }
-    if (EVT_SAVE_VAR(252) <= 1) {
-        ScaleModel(21, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    }
-    if (EVT_SAVE_VAR(252) <= 2) {
-        if (EVT_SAVE_VAR(253) <= 1) {
-            ScaleModel(22, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(23, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(24, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(25, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(26, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        }
-    }
-    ScaleModel(27, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_SAVE_VAR(252) <= 2) {
-        if (EVT_SAVE_VAR(253) <= 2) {
-            ScaleModel(29, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(41, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            ScaleModel(33, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        }
-    }
-    ScaleModel(36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ScaleModel(37, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ScaleModel(38, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ScaleModel(39, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ScaleModel(40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    ScaleModel(34, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    sleep 1;
-    EVT_MAP_FLAG(2) = 0;
-});
+EvtSource N(802413F0) = {
+    EVT_IF_EQ(EVT_MAP_FLAG(2), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_MAP_FLAG(2), 1)
+    EVT_SET(EVT_VAR(15), 0)
+    EVT_LOOP(12)
+        EVT_CALL(RandInt, 80, EVT_VAR(0))
+        EVT_SUB(EVT_VAR(0), 40)
+        EVT_CALL(RandInt, 50, EVT_VAR(1))
+        EVT_CALL(RandInt, 50, EVT_VAR(2))
+        EVT_SUB(EVT_VAR(2), 25)
+        EVT_CALL(PlayEffect, 0x0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 5, 10, 1, 1, 0, 0, 0, 0, 0, 0)
+        EVT_ADD(EVT_VAR(15), 1)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(14), EVT_FIXED(1.0), EVT_FIXED(1.09375), 2, 0, 0)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(13), EVT_FIXED(1.09375), EVT_FIXED(1.0), 2, 0, 0)
+        EVT_SETF(EVT_VAR(0), EVT_VAR(14))
+        EVT_SETF(EVT_VAR(1), EVT_VAR(13))
+        EVT_SETF(EVT_VAR(2), EVT_VAR(14))
+        EVT_IF_EQ(EVT_SAVE_VAR(252), 0)
+            EVT_CALL(ScaleModel, 31, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_END_IF
+        EVT_IF_EQ(EVT_SAVE_VAR(253), 0)
+            EVT_CALL(ScaleModel, 19, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 20, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_END_IF
+        EVT_IF_LE(EVT_SAVE_VAR(252), 1)
+            EVT_CALL(ScaleModel, 21, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_END_IF
+        EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+            EVT_IF_LE(EVT_SAVE_VAR(253), 1)
+                EVT_CALL(ScaleModel, 22, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 23, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 24, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 25, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 26, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(ScaleModel, 27, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+            EVT_IF_LE(EVT_SAVE_VAR(253), 2)
+                EVT_CALL(ScaleModel, 29, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 41, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_CALL(ScaleModel, 33, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(ScaleModel, 36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 37, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 38, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 39, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 34, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_SUBF(EVT_VAR(0), EVT_FIXED(1.046875))
+        EVT_MULF(EVT_VAR(0), EVT_FIXED(100.0))
+        EVT_IF_EQ(EVT_SAVE_VAR(252), 0)
+            EVT_CALL(RotateModel, 31, EVT_VAR(0), 0, 0, 1)
+            EVT_CALL(RotateModel, 32, EVT_VAR(0), 0, 0, 1)
+        EVT_END_IF
+        EVT_IF_EQ(EVT_SAVE_VAR(253), 0)
+            EVT_CALL(RotateModel, 19, EVT_VAR(0), 0, 0, 1)
+            EVT_CALL(RotateModel, 20, EVT_VAR(0), 0, 0, 1)
+        EVT_END_IF
+        EVT_IF_LE(EVT_SAVE_VAR(252), 1)
+            EVT_CALL(RotateModel, 21, EVT_VAR(0), 0, 0, 1)
+        EVT_END_IF
+        EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+            EVT_IF_LE(EVT_SAVE_VAR(253), 1)
+                EVT_CALL(RotateModel, 22, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 23, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 24, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 25, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 26, EVT_VAR(0), 0, 0, 1)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(RotateModel, 27, EVT_VAR(0), 0, 0, 1)
+        EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+            EVT_IF_LE(EVT_SAVE_VAR(253), 2)
+                EVT_CALL(RotateModel, 29, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 41, EVT_VAR(0), 0, 0, 1)
+                EVT_CALL(RotateModel, 33, EVT_VAR(0), 0, 0, 1)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(RotateModel, 36, EVT_VAR(0), 0, 0, 1)
+        EVT_CALL(RotateModel, 37, EVT_VAR(0), 0, 0, 1)
+        EVT_CALL(RotateModel, 38, EVT_VAR(0), 0, 0, 1)
+        EVT_CALL(RotateModel, 39, EVT_VAR(0), 0, 0, 1)
+        EVT_CALL(RotateModel, 40, EVT_VAR(0), 0, 0, 1)
+        EVT_CALL(RotateModel, 34, EVT_VAR(0), 0, 0, 1)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SETF(EVT_VAR(0), 1)
+    EVT_SETF(EVT_VAR(1), 1)
+    EVT_SETF(EVT_VAR(2), 1)
+    EVT_IF_EQ(EVT_SAVE_VAR(252), 0)
+        EVT_CALL(ScaleModel, 31, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_VAR(253), 0)
+        EVT_CALL(ScaleModel, 19, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(ScaleModel, 20, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_END_IF
+    EVT_IF_LE(EVT_SAVE_VAR(252), 1)
+        EVT_CALL(ScaleModel, 21, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_END_IF
+    EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+        EVT_IF_LE(EVT_SAVE_VAR(253), 1)
+            EVT_CALL(ScaleModel, 22, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 23, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 24, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 25, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 26, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(ScaleModel, 27, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_LE(EVT_SAVE_VAR(252), 2)
+        EVT_IF_LE(EVT_SAVE_VAR(253), 2)
+            EVT_CALL(ScaleModel, 29, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 41, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(ScaleModel, 33, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(ScaleModel, 36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ScaleModel, 37, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ScaleModel, 38, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ScaleModel, 39, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ScaleModel, 40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(ScaleModel, 34, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_SET(EVT_MAP_FLAG(2), 0)
+    EVT_RETURN
+    EVT_END
+};
 
 #ifdef NON_EQUIVALENT
-EvtSource N(80241ED4) = SCRIPT({
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 0;
-    EVT_VAR(2) = 0;
-    EVT_VAR(3) = -1.0;
-    EVT_VAR(4) = 0.0;
-    EVT_VAR(5) = 3.0;
-    spawn {
-        sleep 10;
-        PlaySoundAtCollider(19, 486, 0);
-    }
-    loop 300 {
-        EVT_VAR(4) += -0.5;
-        EVT_VAR(5) += 0.09375;
-        EVT_VAR(0) += (float) EVT_VAR(3);
-        EVT_VAR(1) += (float) EVT_VAR(4);
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(1) < -10) {
-            EVT_VAR(1) = -10.0;
-            EVT_VAR(3) = 0.0;
-            EVT_VAR(4) = 0.0;
-            if (EVT_VAR(2) >= 80) {
-                goto 0;
-            }
-        }
-    }
-    TranslateModel(31, -78, 19, 2);
-    TranslateModel(32, -78, 19, 2);
-    TranslateModel(31, EVT_VAR(0), EVT_VAR(1), 0);
-    TranslateModel(32, EVT_VAR(0), EVT_VAR(1), 0);
-    RotateModel(31, EVT_VAR(2), 0, 0, 1);
-    RotateModel(32, EVT_VAR(2), 0, 0, 1);
-    TranslateModel(31, 78, -19, -2);
-    TranslateModel(32, 78, -19, -2);
-    sleep 1;
-}
-0:
-    sleep 30;
-    ModifyColliderFlags(0, 19, 0x7FFFFE00);
-});
+EvtSource N(80241ED4) = {
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(3), EVT_FIXED(-1.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(3.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAtCollider, 19, 486, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(4), EVT_FIXED(-0.5))
+        EVT_ADDF(EVT_VAR(5), EVT_FIXED(0.09375))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(3))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(4))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_LT(EVT_VAR(1), -10)
+            EVT_SETF(EVT_VAR(1), EVT_FIXED(-10.0))
+            EVT_SETF(EVT_VAR(3), EVT_FIXED(0.0))
+            EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+            EVT_IF_GE(EVT_VAR(2), 80)
+                EVT_GOTO(0)
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(TranslateModel, 31, -78, 19, 2)
+    EVT_CALL(TranslateModel, 32, -78, 19, 2)
+    EVT_CALL(TranslateModel, 31, EVT_VAR(0), EVT_VAR(1), 0)
+    EVT_CALL(TranslateModel, 32, EVT_VAR(0), EVT_VAR(1), 0)
+    EVT_CALL(RotateModel, 31, EVT_VAR(2), 0, 0, 1)
+    EVT_CALL(RotateModel, 32, EVT_VAR(2), 0, 0, 1)
+    EVT_CALL(TranslateModel, 31, 78, -19, -2)
+    EVT_CALL(TranslateModel, 32, 78, -19, -2)
+    EVT_WAIT_FRAMES(1)
+EVT_END_LOOP
+EVT_LABEL(0)
+EVT_WAIT_FRAMES(30)
+EVT_CALL(ModifyColliderFlags, 0, 19, 0x7FFFFE00)
+EVT_RETURN
+EVT_END
+};
 #else
 EvtSource N(80241ED4) = {
     EVT_CMD(EVT_OP_SETF, EVT_VAR(0), 0),
@@ -443,158 +460,164 @@ EVT_CMD(EVT_OP_END)
 };
 #endif
 
-EvtSource N(80242174) = SCRIPT({
-    EVT_VAR(0) = (float) 0;
-    EVT_VAR(1) = (float) 0;
-    EVT_VAR(2) = (float) 0;
-    EVT_VAR(3) = 0.0;
-    EVT_VAR(4) = 0.0;
-    EVT_VAR(5) = -5.0;
-    spawn {
-        sleep 12;
-        PlaySoundAtCollider(21, 487, 0);
-    }
-    loop 300 {
-        EVT_VAR(4) += -0.5;
-        EVT_VAR(0) += (float) EVT_VAR(3);
-        EVT_VAR(1) += (float) EVT_VAR(4);
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(2) < -45) {
-            EVT_VAR(5) = 5;
-        }
-        if (EVT_VAR(2) > 0) {
-            EVT_VAR(2) = 0;
-            EVT_VAR(3) = 5;
-        }
-        if (EVT_VAR(1) < -25) {
-            EVT_VAR(4) = 0;
-            EVT_VAR(1) = -25;
-        }
-        if (EVT_VAR(0) > 90) {
-            goto 0;
-        }
-        TranslateModel(19, 50, 28, 27);
-        TranslateModel(20, 50, 28, 27);
-        TranslateModel(19, 0, EVT_VAR(1), 1);
-        TranslateModel(20, 0, EVT_VAR(1), 1);
-        RotateModel(19, EVT_VAR(0), 1, 0, 0);
-        RotateModel(20, EVT_VAR(0), 1, 0, 0);
-        RotateModel(19, EVT_VAR(2), 0, 0, 1);
-        RotateModel(20, EVT_VAR(2), 0, 0, 1);
-        TranslateModel(19, -50, -28, -27);
-        TranslateModel(20, -50, -28, -27);
-        sleep 1;
-    }
-0:
-    sleep 30;
-});
+EvtSource N(80242174) = {
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(3), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(-5.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(12)
+        EVT_CALL(PlaySoundAtCollider, 21, 487, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(4), EVT_FIXED(-0.5))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(3))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(4))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_LT(EVT_VAR(2), -45)
+            EVT_SET(EVT_VAR(5), 5)
+        EVT_END_IF
+        EVT_IF_GT(EVT_VAR(2), 0)
+            EVT_SET(EVT_VAR(2), 0)
+            EVT_SET(EVT_VAR(3), 5)
+        EVT_END_IF
+        EVT_IF_LT(EVT_VAR(1), -25)
+            EVT_SET(EVT_VAR(4), 0)
+            EVT_SET(EVT_VAR(1), -25)
+        EVT_END_IF
+        EVT_IF_GT(EVT_VAR(0), 90)
+            EVT_GOTO(0)
+        EVT_END_IF
+        EVT_CALL(TranslateModel, 19, 50, 28, 27)
+        EVT_CALL(TranslateModel, 20, 50, 28, 27)
+        EVT_CALL(TranslateModel, 19, 0, EVT_VAR(1), 1)
+        EVT_CALL(TranslateModel, 20, 0, EVT_VAR(1), 1)
+        EVT_CALL(RotateModel, 19, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateModel, 20, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateModel, 19, EVT_VAR(2), 0, 0, 1)
+        EVT_CALL(RotateModel, 20, EVT_VAR(2), 0, 0, 1)
+        EVT_CALL(TranslateModel, 19, -50, -28, -27)
+        EVT_CALL(TranslateModel, 20, -50, -28, -27)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_LABEL(0)
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242474) = SCRIPT({
-    EVT_VAR(2) = (float) 0;
-    EVT_VAR(1) = (float) 0;
-    EVT_VAR(0) = (float) 0;
-    EVT_VAR(5) = 0.0;
-    spawn {
-        sleep 15;
-        PlaySoundAtCollider(23, 487, 0);
-    }
-    loop 300 {
-        EVT_VAR(5) += 0.5;
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(2) >= 80) {
-            EVT_VAR(2) = (float) 80;
-            EVT_VAR(5) *= -0.5;
-            if (EVT_VAR(5) == 0) {
-                goto 0;
-            }
-        }
-        TranslateModel(21, -55, 5, 16);
-        TranslateModel(21, EVT_VAR(0), EVT_VAR(1), 0);
-        RotateModel(21, EVT_VAR(2), 0, 0, 1);
-        TranslateModel(21, 55, -5, -16);
-        sleep 1;
-    }
-0:
-    sleep 30;
-});
+EvtSource N(80242474) = {
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(0.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlaySoundAtCollider, 23, 487, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(5), EVT_FIXED(0.5))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_GE(EVT_VAR(2), 80)
+            EVT_SETF(EVT_VAR(2), 80)
+            EVT_MULF(EVT_VAR(5), EVT_FIXED(-0.5))
+            EVT_IF_EQ(EVT_VAR(5), 0)
+                EVT_GOTO(0)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(TranslateModel, 21, -55, 5, 16)
+        EVT_CALL(TranslateModel, 21, EVT_VAR(0), EVT_VAR(1), 0)
+        EVT_CALL(RotateModel, 21, EVT_VAR(2), 0, 0, 1)
+        EVT_CALL(TranslateModel, 21, 55, -5, -16)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_LABEL(0)
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242620) = SCRIPT({
-    EVT_VAR(2) = (float) 0;
-    EVT_VAR(1) = (float) 0;
-    EVT_VAR(0) = (float) 0;
-    EVT_VAR(5) = 0.0;
-    spawn {
-        sleep 15;
-        PlaySoundAtCollider(22, 487, 0);
-    }
-    loop 300 {
-        EVT_VAR(5) += 0.5;
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(2) >= 80) {
-            EVT_VAR(2) = (float) 80;
-            EVT_VAR(5) *= -0.5;
-            if (EVT_VAR(5) == 0) {
-                goto 0;
-            }
-        }
-        TranslateModel(24, 60, 0, 16);
-        RotateModel(24, EVT_VAR(2), 0, 0, -1);
-        TranslateModel(24, -60, 0, -16);
-        TranslateModel(22, 0, 0, 27);
-        TranslateModel(23, 0, 0, 27);
-        RotateModel(22, EVT_VAR(2), 1, 0, 0);
-        RotateModel(23, EVT_VAR(2), 1, 0, 0);
-        TranslateModel(22, 0, 0, -27);
-        TranslateModel(23, 0, 0, -27);
-        TranslateModel(25, 0, 0, -41);
-        TranslateModel(26, 0, 0, -41);
-        RotateModel(25, EVT_VAR(2), -1, 0, 0);
-        RotateModel(26, EVT_VAR(2), -1, 0, 0);
-        TranslateModel(25, 0, 0, 41);
-        TranslateModel(26, 0, 0, 41);
-        sleep 1;
-    }
-0:
-    sleep 30;
-});
+EvtSource N(80242620) = {
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(0.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlaySoundAtCollider, 22, 487, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(5), EVT_FIXED(0.5))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_GE(EVT_VAR(2), 80)
+            EVT_SETF(EVT_VAR(2), 80)
+            EVT_MULF(EVT_VAR(5), EVT_FIXED(-0.5))
+            EVT_IF_EQ(EVT_VAR(5), 0)
+                EVT_GOTO(0)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_CALL(TranslateModel, 24, 60, 0, 16)
+        EVT_CALL(RotateModel, 24, EVT_VAR(2), 0, 0, -1)
+        EVT_CALL(TranslateModel, 24, -60, 0, -16)
+        EVT_CALL(TranslateModel, 22, 0, 0, 27)
+        EVT_CALL(TranslateModel, 23, 0, 0, 27)
+        EVT_CALL(RotateModel, 22, EVT_VAR(2), 1, 0, 0)
+        EVT_CALL(RotateModel, 23, EVT_VAR(2), 1, 0, 0)
+        EVT_CALL(TranslateModel, 22, 0, 0, -27)
+        EVT_CALL(TranslateModel, 23, 0, 0, -27)
+        EVT_CALL(TranslateModel, 25, 0, 0, -41)
+        EVT_CALL(TranslateModel, 26, 0, 0, -41)
+        EVT_CALL(RotateModel, 25, EVT_VAR(2), -1, 0, 0)
+        EVT_CALL(RotateModel, 26, EVT_VAR(2), -1, 0, 0)
+        EVT_CALL(TranslateModel, 25, 0, 0, 41)
+        EVT_CALL(TranslateModel, 26, 0, 0, 41)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_LABEL(0)
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
 #ifdef NON_EQUIVALENT
-EvtSource N(80242910) = SCRIPT({
-    EVT_VAR(0) = 0;
-    EVT_VAR(1) = 0;
-    EVT_VAR(2) = 0;
-    EVT_VAR(3) = -1.0;
-    EVT_VAR(4) = 0.0;
-    EVT_VAR(5) = 3.0;
-    spawn {
-        sleep 15;
-        PlaySoundAtCollider(18, 486, 0);
-    }
-    loop 300 {
-        EVT_VAR(4) += -0.5;
-        EVT_VAR(5) += 0.09375;
-        EVT_VAR(0) += (float) EVT_VAR(3);
-        EVT_VAR(1) += (float) EVT_VAR(4);
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(1) < -25) {
-            EVT_VAR(1) = -25.0;
-            EVT_VAR(3) = 0.0;
-            EVT_VAR(4) = 0.0;
-            if (EVT_VAR(2) >= 80) {
-                goto 0;
-            }
-        }
-    }
-    TranslateModel(29, 124, 17, 3);
-    TranslateModel(29, EVT_VAR(0), EVT_VAR(1), 0);
-    RotateModel(29, EVT_VAR(2), 0, 0, -1);
-    TranslateModel(29, -124, -17, -3);
-    sleep 1;
-}
-0:
-    return;
-    break;
-});
+EvtSource N(80242910) = {
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(3), EVT_FIXED(-1.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(3.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlaySoundAtCollider, 18, 486, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(4), EVT_FIXED(-0.5))
+        EVT_ADDF(EVT_VAR(5), EVT_FIXED(0.09375))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(3))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(4))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_LT(EVT_VAR(1), -25)
+            EVT_SETF(EVT_VAR(1), EVT_FIXED(-25.0))
+            EVT_SETF(EVT_VAR(3), EVT_FIXED(0.0))
+            EVT_SETF(EVT_VAR(4), EVT_FIXED(0.0))
+            EVT_IF_GE(EVT_VAR(2), 80)
+                EVT_GOTO(0)
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(TranslateModel, 29, 124, 17, 3)
+    EVT_CALL(TranslateModel, 29, EVT_VAR(0), EVT_VAR(1), 0)
+    EVT_CALL(RotateModel, 29, EVT_VAR(2), 0, 0, -1)
+    EVT_CALL(TranslateModel, 29, -124, -17, -3)
+    EVT_WAIT_FRAMES(1)
+EVT_END_LOOP
+EVT_LABEL(0)
+EVT_RETURN
+EVT_END
+};
 #else
 EvtSource N(80242910) = {
     EVT_CMD(EVT_OP_SETF, EVT_VAR(0), 0),
@@ -634,47 +657,49 @@ EVT_CMD(EVT_OP_END)
 };
 #endif
 
-EvtSource N(80242B18) = SCRIPT({
-    ModifyColliderFlags(0, 18, 0x7FFFFE00);
-    EVT_VAR(0) = (float) 0;
-    EVT_VAR(1) = (float) 0;
-    EVT_VAR(2) = (float) 0;
-    EVT_VAR(3) = 3.0;
-    EVT_VAR(4) = 1.0;
-    EVT_VAR(5) = 5.0;
-    spawn {
-        sleep 15;
-        PlaySoundAtCollider(20, 486, 0);
-    }
-    loop 300 {
-        EVT_VAR(4) += -0.5;
-        EVT_VAR(0) += (float) EVT_VAR(3);
-        EVT_VAR(1) += (float) EVT_VAR(4);
-        EVT_VAR(2) += (float) EVT_VAR(5);
-        if (EVT_VAR(1) <= -40) {
-            EVT_VAR(1) = (float) -40;
-            EVT_VAR(4) *= -0.5;
-            if (EVT_VAR(4) <= 1) {
-                goto 1;
-            }
-        }
-        if (EVT_VAR(2) >= 60) {
-            EVT_VAR(2) = (float) 60;
-            EVT_VAR(5) = (float) 0;
-        }
-        TranslateModel(41, -34, 50, 10);
-        TranslateModel(33, -34, 50, 10);
-        TranslateModel(41, 0, EVT_VAR(1), EVT_VAR(0));
-        RotateModel(41, EVT_VAR(2), 0, 0, 1);
-        TranslateModel(33, 0, EVT_VAR(1), EVT_VAR(0));
-        RotateModel(33, EVT_VAR(2), 0, 0, 1);
-        TranslateModel(41, 34, -50, -10);
-        TranslateModel(33, 34, -50, -10);
-        sleep 1;
-    }
-1:
-    sleep 30;
-});
+EvtSource N(80242B18) = {
+    EVT_CALL(ModifyColliderFlags, 0, 18, 0x7FFFFE00)
+    EVT_SETF(EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), 0)
+    EVT_SETF(EVT_VAR(2), 0)
+    EVT_SETF(EVT_VAR(3), EVT_FIXED(3.0))
+    EVT_SETF(EVT_VAR(4), EVT_FIXED(1.0))
+    EVT_SETF(EVT_VAR(5), EVT_FIXED(5.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(PlaySoundAtCollider, 20, 486, 0)
+    EVT_END_THREAD
+    EVT_LOOP(300)
+        EVT_ADDF(EVT_VAR(4), EVT_FIXED(-0.5))
+        EVT_ADDF(EVT_VAR(0), EVT_VAR(3))
+        EVT_ADDF(EVT_VAR(1), EVT_VAR(4))
+        EVT_ADDF(EVT_VAR(2), EVT_VAR(5))
+        EVT_IF_LE(EVT_VAR(1), -40)
+            EVT_SETF(EVT_VAR(1), -40)
+            EVT_MULF(EVT_VAR(4), EVT_FIXED(-0.5))
+            EVT_IF_LE(EVT_VAR(4), 1)
+                EVT_GOTO(1)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_IF_GE(EVT_VAR(2), 60)
+            EVT_SETF(EVT_VAR(2), 60)
+            EVT_SETF(EVT_VAR(5), 0)
+        EVT_END_IF
+        EVT_CALL(TranslateModel, 41, -34, 50, 10)
+        EVT_CALL(TranslateModel, 33, -34, 50, 10)
+        EVT_CALL(TranslateModel, 41, 0, EVT_VAR(1), EVT_VAR(0))
+        EVT_CALL(RotateModel, 41, EVT_VAR(2), 0, 0, 1)
+        EVT_CALL(TranslateModel, 33, 0, EVT_VAR(1), EVT_VAR(0))
+        EVT_CALL(RotateModel, 33, EVT_VAR(2), 0, 0, 1)
+        EVT_CALL(TranslateModel, 41, 34, -50, -10)
+        EVT_CALL(TranslateModel, 33, 34, -50, -10)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_LABEL(1)
+    EVT_WAIT_FRAMES(30)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(intTable_80242DC8)[] = {
     0x00000000, 0x00000000, 0x0000001B, 0x00000050, 0x00000023, 0x0000001B, 0x0000003C, 0x0000000A,
@@ -682,123 +707,125 @@ s32 N(intTable_80242DC8)[] = {
     0x00000000, 0x0000001B, 0x00000055, 0x00000000, 0x0000001B, 0x00000050, 0x00000023, 0x0000001B,
 };
 
-EvtSource N(80242E28) = SCRIPT({
-    EVT_VAR(10) = EVT_VAR(0);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(0) < -210) {
-        return;
-    }
-    PlaySound(0x1E5);
-    await N(802413F0);
-    EVT_VAR(0) = EVT_VAR(10);
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        EVT_MAP_FLAG(1) = 1;
-        return;
-    }
-    if (EVT_MAP_FLAG(3) == 1) {
-        return;
-    }
-    EVT_MAP_FLAG(3) = 1;
-    if (EVT_VAR(0) > 2) {
-        goto 0;
-    }
-    if (EVT_VAR(0) == 2) {
-        goto 11;
-    }
-    if (EVT_VAR(0) == 0) {
-    11:
-        if (EVT_SAVE_VAR(252) == 0) {
-            EVT_SAVE_VAR(252) = 1;
-            spawn N(80241ED4);
-            goto 0;
-        }
-    }
-    if (EVT_VAR(0) == 1) {
-        if (EVT_SAVE_VAR(253) == 0) {
-            EVT_SAVE_VAR(253) = 1;
-            spawn N(80242174);
-            goto 0;
-        }
-    }
-    if (EVT_VAR(0) == 0) {
-        if (EVT_SAVE_VAR(252) == 1) {
-            EVT_SAVE_VAR(252) = 2;
-            spawn N(80242474);
-            goto 0;
-        }
-    }
-    if (EVT_SAVE_VAR(252) == 2) {
-        if (EVT_SAVE_VAR(253) == 1) {
-            EVT_SAVE_VAR(253) = 2;
-            spawn N(80242620);
-            goto 0;
-        }
-    }
-    if (EVT_SAVE_VAR(252) == 2) {
-        if (EVT_SAVE_VAR(253) == 2) {
-            DisablePlayerInput(TRUE);
-            UseSettingsFrom(0, 40, 0, 0);
-            SetPanTarget(0, 40, 0, 0);
-            SetCamSpeed(0, 1.5);
-            PanToTarget(0, 0, 1);
-            EVT_SAVE_VAR(253) = 3;
-            await N(802413F0);
-            await N(802413F0);
-            await N(802413F0);
-            sleep 30;
-            GetModelCenter(27);
-            PlayEffect(0x1D, 0, EVT_VAR(0), 50, EVT_VAR(2), 100, 20, 0, 30, 0, 0, 0, 0, 0);
-            PlayEffect(0x1D, 0, EVT_VAR(0), 30, EVT_VAR(2), 120, 20, 0, 30, 0, 0, 0, 0, 0);
-            PlayEffect(0x1D, 0, EVT_VAR(0), 10, EVT_VAR(2), 100, 20, 0, 30, 0, 0, 0, 0, 0);
-            sleep 15;
-            spawn {
-                EVT_VAR(3) = 6;
-                buf_use N(intTable_80242DC8);
-                loop 8 {
-                    buf_read EVT_VAR(0) EVT_VAR(1) EVT_VAR(2);
-                    PlaySoundAt(0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    PlayEffect(0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 6, 0, 0, 0, 0, 0, 0, 0);
-                    sleep 2;
-                    EVT_VAR(1) += 5;
-                    PlaySoundAt(0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                    PlayEffect(0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 2, 15, 0, 0, 0, 0, 0, 0, 0);
-                    sleep EVT_VAR(3);
-                    EVT_VAR(3) += 1;
-                }
-                EVT_VAR(4) = 2.0;
-                loop 2 {
-                    buf_use N(intTable_80242DC8);
-                    loop 8 {
-                        buf_read EVT_VAR(0) EVT_VAR(1) EVT_VAR(2);
-                        PlaySoundAt(0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                        PlayEffect(0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 25, 0, 0, 0, 0, 0, 0, 0);
-                        sleep EVT_VAR(3);
-                        EVT_VAR(3) += EVT_VAR(4);
-                        EVT_VAR(4) += 0.5;
-                    }
-                }
-            }
-            PlaySoundAt(0x1A0, 0, 70, 40, 10);
-            PlayEffect(0x24, 0, 70, 40, 10, 3.0, 30, 0, 0, 0, 0, 0, 0, 0);
-            ShakeCam(0, 0, 20, 1.0);
-            PlaySoundAt(0x1A0, 0, 0, 30, 30);
-            PlayEffect(0x24, 0, 0, 30, 30, 4.0, 40, 0, 0, 0, 0, 0, 0, 0);
-            ShakeCam(0, 0, 20, 2.0);
-            await N(80242910);
-            PlaySoundAtCollider(20, 1169, 0);
-            FadeOutMusic(0, 1000);
-            DisablePlayerPhysics(TRUE);
-            sleep 30;
-            await N(80242B18);
-            EVT_STORY_PROGRESS = STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE;
-            GotoMap("flo_15", 1);
-            sleep 70;
-            return;
-        }
-    }
-0:
-    EVT_MAP_FLAG(3) = 0;
-});
+EvtSource N(80242E28) = {
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_LT(EVT_VAR(0), -210)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(PlaySound, 0x1E5)
+    EVT_EXEC_WAIT(N(802413F0))
+    EVT_SET(EVT_VAR(0), EVT_VAR(10))
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_SET(EVT_MAP_FLAG(1), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_MAP_FLAG(3), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_MAP_FLAG(3), 1)
+    EVT_IF_GT(EVT_VAR(0), 2)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 2)
+        EVT_GOTO(11)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_LABEL(11)
+        EVT_IF_EQ(EVT_SAVE_VAR(252), 0)
+            EVT_SET(EVT_SAVE_VAR(252), 1)
+            EVT_EXEC(N(80241ED4))
+            EVT_GOTO(0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 1)
+        EVT_IF_EQ(EVT_SAVE_VAR(253), 0)
+            EVT_SET(EVT_SAVE_VAR(253), 1)
+            EVT_EXEC(N(80242174))
+            EVT_GOTO(0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_IF_EQ(EVT_SAVE_VAR(252), 1)
+            EVT_SET(EVT_SAVE_VAR(252), 2)
+            EVT_EXEC(N(80242474))
+            EVT_GOTO(0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_VAR(252), 2)
+        EVT_IF_EQ(EVT_SAVE_VAR(253), 1)
+            EVT_SET(EVT_SAVE_VAR(253), 2)
+            EVT_EXEC(N(80242620))
+            EVT_GOTO(0)
+        EVT_END_IF
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_VAR(252), 2)
+        EVT_IF_EQ(EVT_SAVE_VAR(253), 2)
+            EVT_CALL(DisablePlayerInput, TRUE)
+            EVT_CALL(UseSettingsFrom, 0, 40, 0, 0)
+            EVT_CALL(SetPanTarget, 0, 40, 0, 0)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.5))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_SET(EVT_SAVE_VAR(253), 3)
+            EVT_EXEC_WAIT(N(802413F0))
+            EVT_EXEC_WAIT(N(802413F0))
+            EVT_EXEC_WAIT(N(802413F0))
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(GetModelCenter, 27)
+            EVT_CALL(PlayEffect, 0x1D, 0, EVT_VAR(0), 50, EVT_VAR(2), 100, 20, 0, 30, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x1D, 0, EVT_VAR(0), 30, EVT_VAR(2), 120, 20, 0, 30, 0, 0, 0, 0, 0)
+            EVT_CALL(PlayEffect, 0x1D, 0, EVT_VAR(0), 10, EVT_VAR(2), 100, 20, 0, 30, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_THREAD
+                EVT_SET(EVT_VAR(3), 6)
+                EVT_USE_BUF(EVT_PTR(N(intTable_80242DC8)))
+                EVT_LOOP(8)
+                    EVT_BUF_READ3(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_CALL(PlaySoundAt, 0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_CALL(PlayEffect, 0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 6, 0, 0, 0, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(2)
+                    EVT_ADD(EVT_VAR(1), 5)
+                    EVT_CALL(PlaySoundAt, 0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                    EVT_CALL(PlayEffect, 0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 2, 15, 0, 0, 0, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(EVT_VAR(3))
+                    EVT_ADD(EVT_VAR(3), 1)
+                EVT_END_LOOP
+                EVT_SETF(EVT_VAR(4), EVT_FIXED(2.0))
+                EVT_LOOP(2)
+                    EVT_USE_BUF(EVT_PTR(N(intTable_80242DC8)))
+                    EVT_LOOP(8)
+                        EVT_BUF_READ3(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                        EVT_CALL(PlaySoundAt, 0x190, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                        EVT_CALL(PlayEffect, 0x27, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 1, 25, 0, 0, 0, 0, 0, 0, 0)
+                        EVT_WAIT_FRAMES(EVT_VAR(3))
+                        EVT_ADD(EVT_VAR(3), EVT_VAR(4))
+                        EVT_ADDF(EVT_VAR(4), EVT_FIXED(0.5))
+                    EVT_END_LOOP
+                EVT_END_LOOP
+            EVT_END_THREAD
+            EVT_CALL(PlaySoundAt, 0x1A0, 0, 70, 40, 10)
+            EVT_CALL(PlayEffect, 0x24, 0, 70, 40, 10, EVT_FIXED(3.0), 30, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(ShakeCam, 0, 0, 20, EVT_FIXED(1.0))
+            EVT_CALL(PlaySoundAt, 0x1A0, 0, 0, 30, 30)
+            EVT_CALL(PlayEffect, 0x24, 0, 0, 30, 30, EVT_FIXED(4.0), 40, 0, 0, 0, 0, 0, 0, 0)
+            EVT_CALL(ShakeCam, 0, 0, 20, EVT_FIXED(2.0))
+            EVT_EXEC_WAIT(N(80242910))
+            EVT_CALL(PlaySoundAtCollider, 20, 1169, 0)
+            EVT_CALL(FadeOutMusic, 0, 1000)
+            EVT_CALL(DisablePlayerPhysics, TRUE)
+            EVT_WAIT_FRAMES(30)
+            EVT_EXEC_WAIT(N(80242B18))
+            EVT_SET(EVT_SAVE_VAR(0), 53)
+            EVT_CALL(GotoMap, EVT_PTR("flo_15"), 1)
+            EVT_WAIT_FRAMES(70)
+            EVT_RETURN
+        EVT_END_IF
+    EVT_END_IF
+    EVT_LABEL(0)
+    EVT_SET(EVT_MAP_FLAG(3), 0)
+    EVT_RETURN
+    EVT_END
+};
 
 Vec4f N(triggerCoord_8024367C) = { 5.0f, 0.0f, -10.0, 0.0f };
 
@@ -808,126 +835,128 @@ Vec4f N(triggerCoord_8024369C) = { 50.0f, 0.0f, -10.0, 0.0f };
 
 Vec4f N(triggerCoord_802436AC) = { 105.0f, 0.0f, -10.0, 0.0f };
 
-EvtSource N(802436BC) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        EnableModel(49, 0);
-        ModifyColliderFlags(0, 19, 0x7FFFFE00);
-        EnableModel(31, 0);
-        EnableModel(32, 0);
-        EnableModel(19, 0);
-        EnableModel(20, 0);
-        EnableModel(21, 0);
-        EnableModel(22, 0);
-        EnableModel(23, 0);
-        EnableModel(24, 0);
-        EnableModel(25, 0);
-        EnableModel(26, 0);
-        EnableModel(29, 0);
-        EnableModel(41, 0);
-        EnableModel(33, 0);
-        ModifyColliderFlags(0, 18, 0x7FFFFE00);
-        return;
-    }
-    spawn N(80240E90);
-    EnableModel(49, 0);
-    if (EVT_SAVE_VAR(252) >= 1) {
-        ModifyColliderFlags(0, 19, 0x7FFFFE00);
-        EnableModel(31, 0);
-        EnableModel(32, 0);
-    }
-    if (EVT_SAVE_VAR(253) >= 1) {
-        EnableModel(19, 0);
-        EnableModel(20, 0);
-    }
-    if (EVT_SAVE_VAR(252) >= 2) {
-        EnableModel(21, 0);
-    }
-    if (EVT_SAVE_VAR(253) >= 2) {
-        EnableModel(22, 0);
-        EnableModel(23, 0);
-        EnableModel(24, 0);
-        EnableModel(25, 0);
-        EnableModel(26, 0);
-    }
-    if (EVT_SAVE_VAR(253) >= 3) {
-        EnableModel(29, 0);
-        EnableModel(41, 0);
-        EnableModel(33, 0);
-        ModifyColliderFlags(0, 18, 0x7FFFFE00);
-        return;
-    }
-    EVT_VAR(0) = 0;
-    bind N(80242E28) TRIGGER_WALL_HAMMER 23;
-    bind N(80242E28) TRIGGER_POINT_BOMB N(triggerCoord_8024367C);
-    bind N(80242E28) TRIGGER_POINT_BOMB N(triggerCoord_8024368C);
-    EVT_VAR(0) = 1;
-    bind N(80242E28) TRIGGER_WALL_HAMMER 22;
-    bind N(80242E28) TRIGGER_POINT_BOMB N(triggerCoord_8024369C);
-    bind N(80242E28) TRIGGER_POINT_BOMB N(triggerCoord_802436AC);
-    EVT_VAR(0) = 3;
-    bind N(80242E28) TRIGGER_WALL_HAMMER 19;
-    EVT_VAR(0) = 4;
-    bind N(80242E28) TRIGGER_WALL_HAMMER 18;
-    EVT_VAR(0) = 0;
-    loop 16 {
-        EVT_VAR(1) = EVT_VAR(0);
-        EVT_VAR(1) += 10000;
-        EVT_VAR(0) += 1;
-        CloneModel(49, EVT_VAR(1));
-        EnableModel(EVT_VAR(1), 0);
-    }
-    spawn N(80241284);
-    EnableTexPanning(36, 1);
-    EnableTexPanning(37, 1);
-    EnableTexPanning(38, 1);
-    EnableTexPanning(39, 1);
-    EnableTexPanning(40, 1);
-    EnableTexPanning(41, 1);
-    spawn {
-        EVT_VAR(14) = 1.0;
-0:
-        if (EVT_SAVE_VAR(253) >= 3) {
-            EVT_VAR(14) *= 0.953125;
-        }
-        EVT_VAR(15) += (float) EVT_VAR(14);
-        if (EVT_VAR(15) == 1080) {
-            EVT_VAR(15) = (float) 0;
-        }
-        EVT_VAR(0) = EVT_VAR(15);
-        EVT_VAR(0) /= 9;
-        EVT_VAR(0) %= 4;
-        EVT_VAR(0) *= 16384;
-        EVT_VAR(1) = EVT_VAR(15);
-        EVT_VAR(1) /= 4;
-        EVT_VAR(1) %= 2;
-        EVT_VAR(1) *= 16384;
-        EVT_VAR(2) = EVT_VAR(15);
-        EVT_VAR(2) /= 5;
-        EVT_VAR(2) %= 2;
-        EVT_VAR(2) *= 16384;
-        EVT_VAR(3) = EVT_VAR(15);
-        EVT_VAR(3) /= 6;
-        EVT_VAR(3) %= 2;
-        EVT_VAR(3) *= 16384;
-        EVT_VAR(4) = EVT_VAR(15);
-        EVT_VAR(4) /= 2;
-        EVT_VAR(4) %= 2;
-        EVT_VAR(4) *= 32768;
-        EVT_VAR(5) = EVT_VAR(15);
-        EVT_VAR(5) /= 8;
-        EVT_VAR(5) %= 2;
-        EVT_VAR(5) *= 16384;
-        SetTexPanOffset(12, 0, EVT_VAR(0), 0);
-        SetTexPanOffset(13, 0, EVT_VAR(1), 0);
-        SetTexPanOffset(14, 0, EVT_VAR(2), 0);
-        SetTexPanOffset(15, 0, EVT_VAR(3), 0);
-        SetTexPanOffset(11, 0, EVT_VAR(4), 0);
-        SetTexPanOffset(10, 0, EVT_VAR(5), 0);
-        SetTexPanOffset(9, 0, EVT_VAR(5), 0);
-        sleep 1;
-        goto 0;
-    }
-});
+EvtSource N(802436BC) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(EnableModel, 49, 0)
+        EVT_CALL(ModifyColliderFlags, 0, 19, 0x7FFFFE00)
+        EVT_CALL(EnableModel, 31, 0)
+        EVT_CALL(EnableModel, 32, 0)
+        EVT_CALL(EnableModel, 19, 0)
+        EVT_CALL(EnableModel, 20, 0)
+        EVT_CALL(EnableModel, 21, 0)
+        EVT_CALL(EnableModel, 22, 0)
+        EVT_CALL(EnableModel, 23, 0)
+        EVT_CALL(EnableModel, 24, 0)
+        EVT_CALL(EnableModel, 25, 0)
+        EVT_CALL(EnableModel, 26, 0)
+        EVT_CALL(EnableModel, 29, 0)
+        EVT_CALL(EnableModel, 41, 0)
+        EVT_CALL(EnableModel, 33, 0)
+        EVT_CALL(ModifyColliderFlags, 0, 18, 0x7FFFFE00)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_EXEC(N(80240E90))
+    EVT_CALL(EnableModel, 49, 0)
+    EVT_IF_GE(EVT_SAVE_VAR(252), 1)
+        EVT_CALL(ModifyColliderFlags, 0, 19, 0x7FFFFE00)
+        EVT_CALL(EnableModel, 31, 0)
+        EVT_CALL(EnableModel, 32, 0)
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(253), 1)
+        EVT_CALL(EnableModel, 19, 0)
+        EVT_CALL(EnableModel, 20, 0)
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(252), 2)
+        EVT_CALL(EnableModel, 21, 0)
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(253), 2)
+        EVT_CALL(EnableModel, 22, 0)
+        EVT_CALL(EnableModel, 23, 0)
+        EVT_CALL(EnableModel, 24, 0)
+        EVT_CALL(EnableModel, 25, 0)
+        EVT_CALL(EnableModel, 26, 0)
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(253), 3)
+        EVT_CALL(EnableModel, 29, 0)
+        EVT_CALL(EnableModel, 41, 0)
+        EVT_CALL(EnableModel, 33, 0)
+        EVT_CALL(ModifyColliderFlags, 0, 18, 0x7FFFFE00)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_WALL_HAMMER, 23, 1, 0)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_8024367C)), 1, 0)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_8024368C)), 1, 0)
+    EVT_SET(EVT_VAR(0), 1)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_WALL_HAMMER, 22, 1, 0)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_8024369C)), 1, 0)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802436AC)), 1, 0)
+    EVT_SET(EVT_VAR(0), 3)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_WALL_HAMMER, 19, 1, 0)
+    EVT_SET(EVT_VAR(0), 4)
+    EVT_BIND_TRIGGER(N(80242E28), TRIGGER_WALL_HAMMER, 18, 1, 0)
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_LOOP(16)
+        EVT_SET(EVT_VAR(1), EVT_VAR(0))
+        EVT_ADD(EVT_VAR(1), 10000)
+        EVT_ADD(EVT_VAR(0), 1)
+        EVT_CALL(CloneModel, 49, EVT_VAR(1))
+        EVT_CALL(EnableModel, EVT_VAR(1), 0)
+    EVT_END_LOOP
+    EVT_EXEC(N(80241284))
+    EVT_CALL(EnableTexPanning, 36, 1)
+    EVT_CALL(EnableTexPanning, 37, 1)
+    EVT_CALL(EnableTexPanning, 38, 1)
+    EVT_CALL(EnableTexPanning, 39, 1)
+    EVT_CALL(EnableTexPanning, 40, 1)
+    EVT_CALL(EnableTexPanning, 41, 1)
+    EVT_THREAD
+        EVT_SETF(EVT_VAR(14), EVT_FIXED(1.0))
+        EVT_LABEL(0)
+        EVT_IF_GE(EVT_SAVE_VAR(253), 3)
+            EVT_MULF(EVT_VAR(14), EVT_FIXED(0.953125))
+        EVT_END_IF
+        EVT_ADDF(EVT_VAR(15), EVT_VAR(14))
+        EVT_IF_EQ(EVT_VAR(15), 1080)
+            EVT_SETF(EVT_VAR(15), 0)
+        EVT_END_IF
+        EVT_SET(EVT_VAR(0), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(0), 9)
+        EVT_MOD(EVT_VAR(0), 4)
+        EVT_MUL(EVT_VAR(0), 16384)
+        EVT_SET(EVT_VAR(1), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(1), 4)
+        EVT_MOD(EVT_VAR(1), 2)
+        EVT_MUL(EVT_VAR(1), 16384)
+        EVT_SET(EVT_VAR(2), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(2), 5)
+        EVT_MOD(EVT_VAR(2), 2)
+        EVT_MUL(EVT_VAR(2), 16384)
+        EVT_SET(EVT_VAR(3), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(3), 6)
+        EVT_MOD(EVT_VAR(3), 2)
+        EVT_MUL(EVT_VAR(3), 16384)
+        EVT_SET(EVT_VAR(4), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(4), 2)
+        EVT_MOD(EVT_VAR(4), 2)
+        EVT_MUL(EVT_VAR(4), 32768)
+        EVT_SET(EVT_VAR(5), EVT_VAR(15))
+        EVT_DIV(EVT_VAR(5), 8)
+        EVT_MOD(EVT_VAR(5), 2)
+        EVT_MUL(EVT_VAR(5), 16384)
+        EVT_CALL(SetTexPanOffset, 12, 0, EVT_VAR(0), 0)
+        EVT_CALL(SetTexPanOffset, 13, 0, EVT_VAR(1), 0)
+        EVT_CALL(SetTexPanOffset, 14, 0, EVT_VAR(2), 0)
+        EVT_CALL(SetTexPanOffset, 15, 0, EVT_VAR(3), 0)
+        EVT_CALL(SetTexPanOffset, 11, 0, EVT_VAR(4), 0)
+        EVT_CALL(SetTexPanOffset, 10, 0, EVT_VAR(5), 0)
+        EVT_CALL(SetTexPanOffset, 9, 0, EVT_VAR(5), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80243F10) = {
     .height = 32,
@@ -969,394 +998,416 @@ Vec3f N(vectorList_8024401C)[] = {
     { -280.0, 315.0, 30.0 },
 };
 
-EvtSource N(80244058) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePartnerAI(0);
-    SetPlayerPos(30, 0, 50);
-    InterpPlayerYaw(90, 0);
-    SetNpcPos(NPC_PARTNER, 65, 0, 50);
-    sleep 30;
-    AdjustCam(0, 8.0, 0, 300, 19.0, -8.5);
-    GetCurrentPartnerID(EVT_VAR(0));
-    BringPartnerOut(8);
-    if (EVT_VAR(0) != 8) {
-        SetNpcJumpscale(NPC_PARTNER, 0.0);
-        GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        EVT_VAR(1) += 20;
-        EVT_VAR(2) += 20;
-        EVT_VAR(3) += 20;
-        NpcJump0(NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30);
-    }
-    PlayerFaceNpc(-4, 0);
-    NpcFacePlayer(NPC_PARTNER, 0);
-    SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C9));
-    SetPlayerAnimation(ANIM_NOD_YES);
-    sleep 10;
-    SetPlayerAnimation(ANIM_STAND_STILL);
-    sleep 20;
-    EnablePartnerAI();
-    PutPartnerAway();
-    ResetCam(0, 4.0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80244058) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetPlayerPos, 30, 0, 50)
+    EVT_CALL(InterpPlayerYaw, 90, 0)
+    EVT_CALL(SetNpcPos, NPC_PARTNER, 65, 0, 50)
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(AdjustCam, 0, EVT_FIXED(8.0), 0, 300, EVT_FIXED(19.0), EVT_FIXED(-8.5))
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_CALL(BringPartnerOut, 8)
+    EVT_IF_NE(EVT_VAR(0), 8)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_ADD(EVT_VAR(1), 20)
+        EVT_ADD(EVT_VAR(2), 20)
+        EVT_ADD(EVT_VAR(3), 20)
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30)
+    EVT_END_IF
+    EVT_CALL(PlayerFaceNpc, -4, 0)
+    EVT_CALL(NpcFacePlayer, NPC_PARTNER, 0)
+    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C9))
+    EVT_CALL(SetPlayerAnimation, ANIM_NOD_YES)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(PutPartnerAway)
+    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244270) = SCRIPT({
-    spawn {
-        PlaySoundAtNpc(NPC_FLYING_MAGIKOOPA, 0x19E, 0);
-        SetNpcFlagBits(NPC_FLYING_MAGIKOOPA, ((NPC_FLAG_100)), TRUE);
-        InterpNpcYaw(NPC_FLYING_MAGIKOOPA, 270, 0);
-        LoadPath(60, N(vectorList_80243F68), 5, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_FLYING_MAGIKOOPA, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) != 1) {
-                break loop;
-            }
-        }
-    }
-    sleep 15;
-    spawn {
-        PlaySoundAtNpc(NPC_LAKITU0, 0x19F, 0);
-        SetNpcFlagBits(NPC_LAKITU0, ((NPC_FLAG_100)), TRUE);
-        InterpNpcYaw(NPC_LAKITU0, 270, 0);
-        LoadPath(60, N(vectorList_80243FA4), 5, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) != 1) {
-                break loop;
-            }
-        }
-    }
-    spawn {
-        SetNpcFlagBits(NPC_LAKITU1, ((NPC_FLAG_100)), TRUE);
-        InterpNpcYaw(NPC_LAKITU1, 270, 0);
-        LoadPath(70, N(vectorList_80243FE0), 5, 0);
-        loop {
-            GetNextPathPos();
-            SetNpcPos(NPC_LAKITU1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-            sleep 1;
-            if (EVT_VAR(0) != 1) {
-                break loop;
-            }
-        }
-    }
-    PlaySoundAtNpc(NPC_LAKITU2, 0x19F, 0);
-    SetNpcFlagBits(NPC_LAKITU2, ((NPC_FLAG_100)), TRUE);
-    InterpNpcYaw(NPC_LAKITU2, 270, 0);
-    LoadPath(80, N(vectorList_8024401C), 5, 0);
-    loop {
-        GetNextPathPos();
-        SetNpcPos(NPC_LAKITU2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) != 1) {
-            break loop;
-        }
-    }
-});
+EvtSource N(80244270) = {
+    EVT_THREAD
+        EVT_CALL(PlaySoundAtNpc, 4, 0x19E, 0)
+        EVT_CALL(SetNpcFlagBits, 4, ((NPC_FLAG_100)), TRUE)
+        EVT_CALL(InterpNpcYaw, 4, 270, 0)
+        EVT_CALL(LoadPath, 60, EVT_PTR(N(vectorList_80243F68)), 5, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 4, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_NE(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(15)
+    EVT_THREAD
+        EVT_CALL(PlaySoundAtNpc, 0, 0x19F, 0)
+        EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), TRUE)
+        EVT_CALL(InterpNpcYaw, 0, 270, 0)
+        EVT_CALL(LoadPath, 60, EVT_PTR(N(vectorList_80243FA4)), 5, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_NE(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), TRUE)
+        EVT_CALL(InterpNpcYaw, 1, 270, 0)
+        EVT_CALL(LoadPath, 70, EVT_PTR(N(vectorList_80243FE0)), 5, 0)
+        EVT_LOOP(0)
+            EVT_CALL(GetNextPathPos)
+            EVT_CALL(SetNpcPos, 1, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_NE(EVT_VAR(0), 1)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_CALL(PlaySoundAtNpc, 2, 0x19F, 0)
+    EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(InterpNpcYaw, 2, 270, 0)
+    EVT_CALL(LoadPath, 80, EVT_PTR(N(vectorList_8024401C)), 5, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetNpcPos, 2, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_NE(EVT_VAR(0), 1)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802445D4) = SCRIPT({
-    sleep 5;
-    IsPlayerWithin(40, 0, 200, EVT_VAR(0));
-    if (EVT_VAR(0) == 0) {
-        EVT_VAR(3) = 45;
-    } else {
-        EVT_VAR(3) = 25;
-    }
-    EVT_VAR(4) = EVT_VAR(3);
-    EVT_VAR(4) += -5;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(2) > -61) {
-        parallel {
-            SetNpcFlagBits(NPC_LAKITU0, ((NPC_FLAG_100)), TRUE);
-            NpcMoveTo(NPC_LAKITU0, EVT_VAR(0), 55, EVT_VAR(3));
-        }
-        parallel {
-            SetNpcFlagBits(NPC_LAKITU1, ((NPC_FLAG_100)), TRUE);
-            NpcMoveTo(NPC_LAKITU1, EVT_VAR(0), 55, EVT_VAR(3));
-        }
-        parallel {
-            SetNpcFlagBits(NPC_LAKITU2, ((NPC_FLAG_100)), TRUE);
-            NpcMoveTo(NPC_LAKITU2, EVT_VAR(0), 55, EVT_VAR(3));
-        }
-        sleep EVT_VAR(4);
-    }
-});
+EvtSource N(802445D4) = {
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(IsPlayerWithin, 40, 0, 200, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_SET(EVT_VAR(3), 45)
+    EVT_ELSE
+        EVT_SET(EVT_VAR(3), 25)
+    EVT_END_IF
+    EVT_SET(EVT_VAR(4), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(4), -5)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_GT(EVT_VAR(2), -61)
+        EVT_CHILD_THREAD
+            EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(NpcMoveTo, 0, EVT_VAR(0), 55, EVT_VAR(3))
+        EVT_END_CHILD_THREAD
+        EVT_CHILD_THREAD
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(NpcMoveTo, 1, EVT_VAR(0), 55, EVT_VAR(3))
+        EVT_END_CHILD_THREAD
+        EVT_CHILD_THREAD
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_100)), TRUE)
+            EVT_CALL(NpcMoveTo, 2, EVT_VAR(0), 55, EVT_VAR(3))
+        EVT_END_CHILD_THREAD
+        EVT_WAIT_FRAMES(EVT_VAR(4))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244774) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePartnerAI(0);
-    GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetNpcPos(NPC_PARTNER, 65, EVT_VAR(1), 80);
-    SetNpcYaw(NPC_PARTNER, 270);
-    AdjustCam(0, 8.0, 0, 450, 17.0, -6.0);
-    SpeakToPlayer(NPC_FLYING_MAGIKOOPA, NPC_ANIM_flying_magikoopa_Palette_02_Anim_9, NPC_ANIM_flying_magikoopa_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x00BB));
-    sleep 20;
-    spawn N(80244270);
-    sleep 80;
-    AdjustCam(0, 8.0, 0, 300, 19.0, -8.5);
-    GetCurrentPartnerID(EVT_VAR(0));
-    BringPartnerOut(8);
-    if (EVT_VAR(0) != 8) {
-        SetNpcJumpscale(NPC_PARTNER, 0.0);
-        GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        EVT_VAR(1) += 20;
-        EVT_VAR(2) += 20;
-        EVT_VAR(3) += 20;
-        NpcJump0(NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30);
-    }
-    NpcFacePlayer(NPC_PARTNER, 0);
-    DisablePartnerAI(0);
-    SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C1));
-    EnablePartnerAI();
-    sleep 20;
-    PutPartnerAway();
-    ResetCam(0, 4.0);
-    EVT_STORY_PROGRESS = STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS;
-    DisablePlayerInput(FALSE);
-    AwaitPlayerApproach(-250, 0, 50);
-    DisablePlayerInput(TRUE);
-    GetCurrentPartnerID(EVT_VAR(0));
-    BringPartnerOut(8);
-    if (EVT_VAR(0) != 8) {
-        SetNpcJumpscale(NPC_PARTNER, 0.0);
-        GetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        EVT_VAR(1) += 20;
-        EVT_VAR(2) += 20;
-        EVT_VAR(3) += 20;
-        NpcJump0(NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30);
-    }
-    PlayerFaceNpc(-4, 0);
-    NpcFacePlayer(NPC_PARTNER, 0);
-    DisablePartnerAI(0);
-    SpeakToPlayer(NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C2));
-    EnablePartnerAI();
-    PutPartnerAway();
-    ResetCam(0, 4.0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80244774) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetNpcPos, NPC_PARTNER, 65, EVT_VAR(1), 80)
+    EVT_CALL(SetNpcYaw, NPC_PARTNER, 270)
+    EVT_CALL(AdjustCam, 0, EVT_FIXED(8.0), 0, 450, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+    EVT_CALL(SpeakToPlayer, 4, NPC_ANIM_flying_magikoopa_Palette_02_Anim_9, NPC_ANIM_flying_magikoopa_Palette_02_Anim_1, 0, MESSAGE_ID(0x11, 0x00BB))
+    EVT_WAIT_FRAMES(20)
+    EVT_EXEC(N(80244270))
+    EVT_WAIT_FRAMES(80)
+    EVT_CALL(AdjustCam, 0, EVT_FIXED(8.0), 0, 300, EVT_FIXED(19.0), EVT_FIXED(-8.5))
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_CALL(BringPartnerOut, 8)
+    EVT_IF_NE(EVT_VAR(0), 8)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_ADD(EVT_VAR(1), 20)
+        EVT_ADD(EVT_VAR(2), 20)
+        EVT_ADD(EVT_VAR(3), 20)
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30)
+    EVT_END_IF
+    EVT_CALL(NpcFacePlayer, NPC_PARTNER, 0)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C1))
+    EVT_CALL(EnablePartnerAI)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(PutPartnerAway)
+    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_SET(EVT_SAVE_VAR(0), 52)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(AwaitPlayerApproach, -250, 0, 50)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_CALL(BringPartnerOut, 8)
+    EVT_IF_NE(EVT_VAR(0), 8)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_ADD(EVT_VAR(1), 20)
+        EVT_ADD(EVT_VAR(2), 20)
+        EVT_ADD(EVT_VAR(3), 20)
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), 30)
+    EVT_END_IF
+    EVT_CALL(PlayerFaceNpc, -4, 0)
+    EVT_CALL(NpcFacePlayer, NPC_PARTNER, 0)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SpeakToPlayer, NPC_PARTNER, NPC_ANIM_world_lakilester_Palette_00_Anim_9, NPC_ANIM_world_lakilester_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00C2))
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(PutPartnerAway)
+    EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80244B3C) = SCRIPT({
-    loop {
-        GetSelfVar(0, EVT_VAR(0));
-        if (EVT_VAR(0) != 0) {
-            break loop;
-        }
-        sleep 1;
-    }
-    DisablePlayerInput(TRUE);
-    sleep 10;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 1000);
-    SetCamPitch(0, 17.0, -6.0);
-    SetCamSpeed(0, 4.0);
-    PanToTarget(0, 0, 1);
-    DisablePlayerInput(FALSE);
-    StartBossBattle(3);
-});
+EvtSource N(idle_80244B3C) = {
+    EVT_LOOP(0)
+        EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+        EVT_IF_NE(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, 1000)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(StartBossBattle, 3)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_80244C84) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            GetSelfNpcID(EVT_VAR(0));
-            if (EVT_VAR(0) == 3) {
-                SetNpcPos(NPC_MAGIKOOPA, 0, -1000, 0);
-                SetNpcPos(NPC_FLYING_MAGIKOOPA, -55, 15, 35);
-                GetNpcYaw(3, EVT_VAR(0));
-                SetNpcYaw(NPC_FLYING_MAGIKOOPA, 90);
-                InterpPlayerYaw(180, 0);
-                SetPlayerPos(30, 0, 80);
-                SetNpcYaw(NPC_LAKITU0, 90);
-                SetNpcPos(NPC_LAKITU0, -20, 15, 30);
-                SetNpcYaw(NPC_LAKITU1, 270);
-                SetNpcPos(NPC_LAKITU1, 65, 15, 30);
-                SetNpcYaw(NPC_LAKITU2, 270);
-                SetNpcPos(NPC_LAKITU2, 120, 15, 30);
-                spawn N(80244774);
-            }
-        }
-        == 1 {}
-        == 2 {
-        }
-    }
-});
+EvtSource N(defeat_80244C84) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(GetSelfNpcID, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 3)
+                EVT_CALL(SetNpcPos, 3, 0, -1000, 0)
+                EVT_CALL(SetNpcPos, 4, -55, 15, 35)
+                EVT_CALL(GetNpcYaw, 3, EVT_VAR(0))
+                EVT_CALL(SetNpcYaw, 4, 90)
+                EVT_CALL(InterpPlayerYaw, 180, 0)
+                EVT_CALL(SetPlayerPos, 30, 0, 80)
+                EVT_CALL(SetNpcYaw, 0, 90)
+                EVT_CALL(SetNpcPos, 0, -20, 15, 30)
+                EVT_CALL(SetNpcYaw, 1, 270)
+                EVT_CALL(SetNpcPos, 1, 65, 15, 30)
+                EVT_CALL(SetNpcYaw, 2, 270)
+                EVT_CALL(SetNpcPos, 2, 120, 15, 30)
+                EVT_EXEC(N(80244774))
+            EVT_END_IF
+        EVT_CASE_EQ(1)
+        EVT_CASE_EQ(2)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244E2C) = SCRIPT({
-    match EVT_MAP_VAR(10) {
-        == 0 {
-            NpcFacePlayer(NPC_MAGIKOOPA, 1);
-        }
-        == 1 {
-            NpcFacePlayer(NPC_LAKITU0, 1);
-        }
-        == 2 {
-            NpcFacePlayer(NPC_LAKITU1, 1);
-        }
-        == 3 {
-            NpcFacePlayer(NPC_LAKITU2, 1);
-        }
-    }
-});
+EvtSource N(80244E2C) = {
+    EVT_SWITCH(EVT_MAP_VAR(10))
+        EVT_CASE_EQ(0)
+            EVT_CALL(NpcFacePlayer, 3, 1)
+        EVT_CASE_EQ(1)
+            EVT_CALL(NpcFacePlayer, 0, 1)
+        EVT_CASE_EQ(2)
+            EVT_CALL(NpcFacePlayer, 1, 1)
+        EVT_CASE_EQ(3)
+            EVT_CALL(NpcFacePlayer, 2, 1)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244ED0) = SCRIPT({
-    match EVT_MAP_VAR(10) {
-        == 0 {
-            SpeakToPlayer(NPC_MAGIKOOPA, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 16, MESSAGE_ID(0x11, 0x00B9));
-            InterpNpcYaw(NPC_MAGIKOOPA, 90, 0);
-        }
-        == 1 {
-            SpeakToPlayer(NPC_LAKITU0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF));
-            InterpNpcYaw(NPC_LAKITU0, 90, 0);
-        }
-        == 2 {
-            SpeakToPlayer(NPC_LAKITU1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF));
-            InterpNpcYaw(NPC_LAKITU1, 270, 0);
-        }
-        == 3 {
-            SpeakToPlayer(NPC_LAKITU2, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF));
-            InterpNpcYaw(NPC_LAKITU2, 270, 0);
-        }
-    }
-});
+EvtSource N(80244ED0) = {
+    EVT_SWITCH(EVT_MAP_VAR(10))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SpeakToPlayer, 3, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 16, MESSAGE_ID(0x11, 0x00B9))
+            EVT_CALL(InterpNpcYaw, 3, 90, 0)
+        EVT_CASE_EQ(1)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF))
+            EVT_CALL(InterpNpcYaw, 0, 90, 0)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF))
+            EVT_CALL(InterpNpcYaw, 1, 270, 0)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00BF))
+            EVT_CALL(InterpNpcYaw, 2, 270, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245004) = SCRIPT({
-    match EVT_MAP_VAR(10) {
-        == 0 {
-            SpeakToPlayer(NPC_MAGIKOOPA, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 16, MESSAGE_ID(0x11, 0x00BA));
-        }
-        == 1 {
-            SpeakToPlayer(NPC_LAKITU0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0));
-        }
-        == 2 {
-            SpeakToPlayer(NPC_LAKITU1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0));
-        }
-        == 3 {
-            SpeakToPlayer(NPC_LAKITU2, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0));
-        }
-    }
-    SetNpcVar(3, 0, 1);
-    sleep 5;
-    spawn N(802445D4);
-});
+EvtSource N(80245004) = {
+    EVT_SWITCH(EVT_MAP_VAR(10))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SpeakToPlayer, 3, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 16, MESSAGE_ID(0x11, 0x00BA))
+        EVT_CASE_EQ(1)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0))
+        EVT_CASE_EQ(2)
+            EVT_CALL(SpeakToPlayer, 1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0))
+        EVT_CASE_EQ(3)
+            EVT_CALL(SpeakToPlayer, 2, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 16, MESSAGE_ID(0x11, 0x00C0))
+    EVT_END_SWITCH
+    EVT_CALL(SetNpcVar, 3, 0, 1)
+    EVT_WAIT_FRAMES(5)
+    EVT_EXEC(N(802445D4))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245108) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    func_802D2C14(1);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-    AdjustCam(0, 8.0, 0, 300, 17.0, -6.0);
-    await N(80244E2C);
-    match EVT_AREA_VAR(7) {
-        == 0 {
-            await N(80244ED0);
-            EVT_AREA_VAR(7) += 1;
-            ResetCam(0, 4.0);
-        }
-        == 1 {
-            await N(80245004);
-        }
-    }
-    func_802D2C14(0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80245108) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 52)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(func_802D2C14, 1)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(AdjustCam, 0, EVT_FIXED(8.0), 0, 300, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+    EVT_EXEC_WAIT(N(80244E2C))
+    EVT_SWITCH(EVT_AREA_VAR(7))
+        EVT_CASE_EQ(0)
+            EVT_EXEC_WAIT(N(80244ED0))
+            EVT_ADD(EVT_AREA_VAR(7), 1)
+            EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+        EVT_CASE_EQ(1)
+            EVT_EXEC_WAIT(N(80245004))
+    EVT_END_SWITCH
+    EVT_CALL(func_802D2C14, 0)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245228) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 0;
-        await N(80245108);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(80245228) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 0)
+        EVT_EXEC_WAIT(N(80245108))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024527C) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 1;
-        await N(80245108);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(8024527C) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 1)
+        EVT_EXEC_WAIT(N(80245108))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802452D0) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 2;
-        await N(80245108);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(802452D0) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 2)
+        EVT_EXEC_WAIT(N(80245108))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245324) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 3;
-        await N(80245108);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(80245324) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 3)
+        EVT_EXEC_WAIT(N(80245108))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245378) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamSpeed(0, 8.0);
-    SetCamPitch(0, 17.0, -6.0);
-    SetCamDistance(0, 300);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    await N(80244E2C);
-    if (EVT_AREA_VAR(7) == 0) {
-        await N(80244ED0);
-        EVT_AREA_VAR(7) += 1;
-        ResetCam(0, 4.0);
-    } else {
-        await N(80245004);
-    }
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80245378) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 52)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(8.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+    EVT_CALL(SetCamDistance, 0, 300)
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_EXEC_WAIT(N(80244E2C))
+    EVT_IF_EQ(EVT_AREA_VAR(7), 0)
+        EVT_EXEC_WAIT(N(80244ED0))
+        EVT_ADD(EVT_AREA_VAR(7), 1)
+        EVT_CALL(ResetCam, 0, EVT_FIXED(4.0))
+    EVT_ELSE
+        EVT_EXEC_WAIT(N(80245004))
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802454D4) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 0;
-        GetNpcPos(NPC_MAGIKOOPA, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        await N(80245378);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(802454D4) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 0)
+        EVT_CALL(GetNpcPos, 3, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_EXEC_WAIT(N(80245378))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245544) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 1;
-        GetNpcPos(NPC_LAKITU0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        await N(80245378);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(80245544) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 1)
+        EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_EXEC_WAIT(N(80245378))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802455B4) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 2;
-        GetNpcPos(NPC_LAKITU1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        await N(80245378);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(802455B4) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 2)
+        EVT_CALL(GetNpcPos, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_EXEC_WAIT(N(80245378))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80245624) = SCRIPT({
-    if (EVT_MAP_VAR(10) == -1) {
-        EVT_MAP_VAR(10) = 3;
-        GetNpcPos(NPC_LAKITU2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        await N(80245378);
-        EVT_MAP_VAR(10) = -1;
-    }
-});
+EvtSource N(80245624) = {
+    EVT_IF_EQ(EVT_MAP_VAR(10), -1)
+        EVT_SET(EVT_MAP_VAR(10), 3)
+        EVT_CALL(GetNpcPos, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_EXEC_WAIT(N(80245378))
+        EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 Vec4f N(triggerCoord_80245694) = { 5.0f, 0.0f, -10.0, 0.0f };
 
@@ -1366,113 +1417,118 @@ Vec4f N(triggerCoord_802456B4) = { 50.0f, 0.0f, -10.0, 0.0f };
 
 Vec4f N(triggerCoord_802456C4) = { 105.0f, 0.0f, -10.0, 0.0f };
 
-EvtSource N(802456D4) = SCRIPT({
-    EVT_MAP_VAR(10) = -1;
-    bind N(80245228) TRIGGER_WALL_HAMMER 23;
-    bind N(80245228) TRIGGER_WALL_HAMMER 19;
-    bind N(802454D4) TRIGGER_POINT_BOMB N(triggerCoord_802456A4);
-    bind N(80245544) TRIGGER_POINT_BOMB N(triggerCoord_80245694);
-    bind N(802452D0) TRIGGER_WALL_HAMMER 22;
-    bind N(802455B4) TRIGGER_POINT_BOMB N(triggerCoord_802456B4);
-    bind N(80245324) TRIGGER_WALL_HAMMER 18;
-    bind N(80245624) TRIGGER_POINT_BOMB N(triggerCoord_802456C4);
-});
+EvtSource N(802456D4) = {
+    EVT_SET(EVT_MAP_VAR(10), -1)
+    EVT_BIND_TRIGGER(N(80245228), TRIGGER_WALL_HAMMER, 23, 1, 0)
+    EVT_BIND_TRIGGER(N(80245228), TRIGGER_WALL_HAMMER, 19, 1, 0)
+    EVT_BIND_TRIGGER(N(802454D4), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802456A4)), 1, 0)
+    EVT_BIND_TRIGGER(N(80245544), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80245694)), 1, 0)
+    EVT_BIND_TRIGGER(N(802452D0), TRIGGER_WALL_HAMMER, 22, 1, 0)
+    EVT_BIND_TRIGGER(N(802455B4), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802456B4)), 1, 0)
+    EVT_BIND_TRIGGER(N(80245324), TRIGGER_WALL_HAMMER, 18, 1, 0)
+    EVT_BIND_TRIGGER(N(80245624), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802456C4)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_802457D4) = SCRIPT({
-    match EVT_AREA_VAR(6) {
-        == 0 {
-            GetSelfNpcID(EVT_VAR(0));
-            if (EVT_VAR(0) == 3) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5,
-                              MESSAGE_ID(0x11, 0x00B6));
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11,
-                              0x00BC));
-            }
-            EVT_AREA_VAR(6) += 1;
-        }
-        == 1 {
-            GetSelfNpcID(EVT_VAR(0));
-            if (EVT_VAR(0) == 3) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5,
-                              MESSAGE_ID(0x11, 0x00B7));
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11,
-                              0x00BD));
-            }
-            EVT_AREA_VAR(6) += 1;
-        }
-        == 2 {
-            AdjustCam(0, 8.0, 0, 300, 19.0, -9.0);
-            GetSelfNpcID(EVT_VAR(0));
-            if (EVT_VAR(0) == 3) {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5,
-                              MESSAGE_ID(0x11, 0x00B8));
-                NpcFacePlayer(NPC_SELF, 0);
-                sleep 15;
-                EndSpeech(-1, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 0);
-            } else {
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11,
-                              0x00BE));
-                NpcFacePlayer(NPC_SELF, 0);
-                sleep 15;
-                EndSpeech(-1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0);
-            }
-            SetNpcVar(3, 0, 1);
-            sleep 5;
-            spawn N(802445D4);
-            BindNpcInteract(NPC_LAKITU0, 0);
-            BindNpcInteract(NPC_LAKITU1, 0);
-            BindNpcInteract(NPC_LAKITU2, 0);
-            BindNpcInteract(NPC_MAGIKOOPA, 0);
-        }
-    }
-});
+EvtSource N(interact_802457D4) = {
+    EVT_SWITCH(EVT_AREA_VAR(6))
+        EVT_CASE_EQ(0)
+            EVT_CALL(GetSelfNpcID, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 3)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5, MESSAGE_ID(0x11, 0x00B6))
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00BC))
+            EVT_END_IF
+            EVT_ADD(EVT_AREA_VAR(6), 1)
+        EVT_CASE_EQ(1)
+            EVT_CALL(GetSelfNpcID, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 3)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5, MESSAGE_ID(0x11, 0x00B7))
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00BD))
+            EVT_END_IF
+            EVT_ADD(EVT_AREA_VAR(6), 1)
+        EVT_CASE_EQ(2)
+            EVT_CALL(AdjustCam, 0, EVT_FIXED(8.0), 0, 300, EVT_FIXED(19.0), EVT_FIXED(-9.0))
+            EVT_CALL(GetSelfNpcID, EVT_VAR(0))
+            EVT_IF_EQ(EVT_VAR(0), 3)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 5, MESSAGE_ID(0x11, 0x00B8))
+                EVT_CALL(NpcFacePlayer, NPC_SELF, 0)
+                EVT_WAIT_FRAMES(15)
+                EVT_CALL(EndSpeech, -1, NPC_ANIM_magikoopa_Palette_02_Anim_2, NPC_ANIM_magikoopa_Palette_02_Anim_1, 0)
+            EVT_ELSE
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 5, MESSAGE_ID(0x11, 0x00BE))
+                EVT_CALL(NpcFacePlayer, NPC_SELF, 0)
+                EVT_WAIT_FRAMES(15)
+                EVT_CALL(EndSpeech, -1, NPC_ANIM_lakitu_Palette_00_Anim_16, NPC_ANIM_lakitu_Palette_00_Anim_1, 0)
+            EVT_END_IF
+            EVT_CALL(SetNpcVar, 3, 0, 1)
+            EVT_WAIT_FRAMES(5)
+            EVT_EXEC(N(802445D4))
+            EVT_CALL(BindNpcInteract, 0, 0)
+            EVT_CALL(BindNpcInteract, 1, 0)
+            EVT_CALL(BindNpcInteract, 2, 0)
+            EVT_CALL(BindNpcInteract, 3, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80245AA8) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        BindNpcIdle(NPC_SELF, N(idle_80244B3C));
-        BindNpcInteract(NPC_SELF, N(interact_802457D4));
-        BindNpcDefeat(NPC_SELF, N(defeat_80244C84));
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80245AA8) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80244B3C)))
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802457D4)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244C84)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80245B30) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        BindNpcDefeat(NPC_SELF, N(defeat_80244C84));
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80245B30) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244C84)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80245B90) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        BindNpcInteract(NPC_SELF, N(interact_802457D4));
-        BindNpcDefeat(NPC_SELF, N(defeat_80244C84));
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80245B90) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802457D4)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244C84)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80245C04) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        BindNpcInteract(NPC_SELF, N(interact_802457D4));
-        BindNpcDefeat(NPC_SELF, N(defeat_80244C84));
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80245C04) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802457D4)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244C84)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80245C78) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_PUFF_PUFF_GUARDS) {
-        BindNpcInteract(NPC_SELF, N(interact_802457D4));
-        BindNpcDefeat(NPC_SELF, N(defeat_80244C84));
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80245C78) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 52)
+        EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_802457D4)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80244C84)))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80245CEC)[] = {
     {

--- a/src/world/area_flo/flo_18/CDCC30.c
+++ b/src/world/area_flo/flo_18/CDCC30.c
@@ -2,6 +2,7 @@
 
 #include "world/common/foliage.inc.c"
 
-EvtSource N(80247024) = SCRIPT({
-
-});
+EvtSource N(80247024) = {
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_19/CE36F0.c
+++ b/src/world/area_flo/flo_19/CE36F0.c
@@ -18,22 +18,27 @@ MapConfig N(config) = {
 
 // Extraneous END_CASE_MULTI
 #ifdef NON_EQUIVALENT
-EvtSource N(802409C0) = SCRIPT({
-    GetEntryID(EVT_VAR(0));
-    match EVT_VAR(0) {
-        0, 1 {
-            SetMusicTrack(0, SONG_CLOUDY_CLIMB, 0, 8);
-        }
-        2, 7 {}
-        == 3 {
-            if (EVT_AREA_FLAG(44) != 0) {
-            } else {
-                FadeOutMusic(1, 3000);
-                FadeInMusic(0, 50, 0, 3000, 0, 127);
-            }
-        }
-    }
-});
+EvtSource N(802409C0) = {
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_OR_EQ(0)
+        EVT_CASE_OR_EQ(1)
+            EVT_CALL(SetMusicTrack, 0, SONG_CLOUDY_CLIMB, 0, 8)
+        EVT_END_CASE_GROUP
+        EVT_CASE_OR_EQ(2)
+        EVT_CASE_OR_EQ(7)
+        EVT_END_CASE_GROUP
+        EVT_CASE_EQ(3)
+            EVT_IF_NE(EVT_AREA_FLAG(44), 0)
+            EVT_ELSE
+                EVT_CALL(FadeOutMusic, 1, 3000)
+                EVT_CALL(FadeInMusic, 0, 50, 0, 3000, 0, 127)
+            EVT_END_IF
+        EVT_END_CASE_GROUP
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 #else
 EvtSource N(802409C0) = {
     EVT_CMD(EVT_OP_CALL, EVT_PTR(GetEntryID), EVT_VAR(0)),
@@ -62,601 +67,629 @@ static s32 N(pad_ABC) = {
     0x00000000,
 };
 
-EvtSource N(80240AC0) = SCRIPT({
-    MakeItemEntity(ITEM_S_JUMP_CHG, -200, 160, -213, 17, EVT_SAVE_FLAG(1391));
-});
+EvtSource N(80240AC0) = {
+    EVT_CALL(MakeItemEntity, ITEM_S_JUMP_CHG, -200, 160, -213, 17, EVT_SAVE_FLAG(1391))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_AF4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(updateTexturePan_80240B00) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(updateTexturePan_80240B00) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80240B9C) = EXIT_WALK_SCRIPT(60,  1, "flo_21",  0);
 
-EvtSource N(80240BF8) = SCRIPT({
-    bind N(exitWalk_80240B9C) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(80240BF8) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240B9C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_CLOUDY_CLIMB;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    EVT_SAVE_FLAG(1985) = 1;
-    await N(80240AC0);
-    ParentColliderToModel(12, 86);
-    HidePlayerShadow(TRUE);
-    spawn N(80242FD0);
-    spawn N(80241780);
-    ModifyColliderFlags(3, 5, 0x00000007);
-    EnableTexPanning(17, 1);
-    EnableTexPanning(18, 1);
-    spawn {
-        EVT_VAR(0) = 1;
-        EVT_VAR(1) = -120;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_80240B00);
-    }
-    spawn {
-        EVT_VAR(0) = 2;
-        EVT_VAR(1) = -90;
-        EVT_VAR(2) = 0;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 0;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_80240B00);
-    }
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) != 3) {
-        EVT_AREA_FLAG(44) = 0;
-    }
-    match EVT_VAR(0) {
-        == 0 {
-            spawn N(80240BF8);
-        }
-        == 1 {
-            ModifyColliderFlags(0, 1, 0x7FFFFE00);
-            EVT_VAR(0) = N(80240BF8);
-            spawn EnterWalk;
-        }
-        == 2 {
-            spawn N(80242A2C);
-            spawn N(80240BF8);
-        }
-        == 3 {
-            spawn N(80241CC4);
-            spawn N(80240BF8);
-        }
-    }
-    await N(802409C0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_8024030C_CE39FC)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 39)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_SET(EVT_SAVE_FLAG(1985), 1)
+    EVT_EXEC_WAIT(N(80240AC0))
+    EVT_CALL(ParentColliderToModel, 12, 86)
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_EXEC(N(80242FD0))
+    EVT_EXEC(N(80241780))
+    EVT_CALL(ModifyColliderFlags, 3, 5, 0x00000007)
+    EVT_CALL(EnableTexPanning, 17, 1)
+    EVT_CALL(EnableTexPanning, 18, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 1)
+        EVT_SET(EVT_VAR(1), -120)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_80240B00))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(1), -90)
+        EVT_SET(EVT_VAR(2), 0)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 0)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_80240B00))
+    EVT_END_THREAD
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 3)
+        EVT_SET(EVT_AREA_FLAG(44), 0)
+    EVT_END_IF
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_EXEC(N(80240BF8))
+        EVT_CASE_EQ(1)
+            EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+            EVT_SET(EVT_VAR(0), EVT_PTR(N(80240BF8)))
+            EVT_EXEC(EnterWalk)
+        EVT_CASE_EQ(2)
+            EVT_EXEC(N(80242A2C))
+            EVT_EXEC(N(80240BF8))
+        EVT_CASE_EQ(3)
+            EVT_EXEC(N(80241CC4))
+            EVT_EXEC(N(80240BF8))
+    EVT_END_SWITCH
+    EVT_EXEC_WAIT(N(802409C0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_8024030C_CE39FC))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1044)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80241050) = SCRIPT({
-    group 239;
-    EVT_VAR(15) = 0;
-0:
-    EVT_VAR(0) = -215.4375;
-    EVT_VAR(1) = 128.59375;
-    EVT_VAR(2) = -200.0;
-    EVT_VAR(1) += (float) EVT_MAP_VAR(12);
-    TranslateGroup(28, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) = -79.859375;
-    N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(1), 5.0, 136.765625, 300, 0, 0);
-    EVT_VAR(2) = -200.0;
-    EVT_VAR(1) += (float) EVT_MAP_VAR(13);
-    TranslateGroup(32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) = -364.265625;
-    N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(1), 5.0, 106.765625, 300, 0, 0);
-    EVT_VAR(2) = 10.0;
-    EVT_VAR(1) += (float) EVT_MAP_VAR(14);
-    TranslateGroup(36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) = 295.734375;
-    N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(1), 65.0, 86.984375, 200, 0, 0);
-    EVT_VAR(2) = -80.0;
-    EVT_VAR(1) += (float) EVT_MAP_VAR(15);
-    TranslateGroup(40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(2), 0.96875, 1.03125, 15, 0, 0);
-    N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(3), 1.03125, 0.96875, 15, 0, 0);
-    EVT_VAR(0) = (float) EVT_MAP_VAR(12);
-    EVT_VAR(1) = (float) EVT_MAP_VAR(12);
-    EVT_VAR(0) *= -0.01953125;
-    EVT_VAR(1) *= 0.0400390625;
-    EVT_VAR(0) += (float) EVT_VAR(2);
-    EVT_VAR(1) += (float) EVT_VAR(3);
-    ScaleGroup(28, EVT_VAR(0), EVT_VAR(1), 1);
-    EVT_VAR(0) = (float) EVT_MAP_VAR(13);
-    EVT_VAR(1) = (float) EVT_MAP_VAR(13);
-    EVT_VAR(0) *= -0.01953125;
-    EVT_VAR(1) *= 0.0400390625;
-    EVT_VAR(0) += (float) EVT_VAR(2);
-    EVT_VAR(1) += (float) EVT_VAR(3);
-    ScaleGroup(32, EVT_VAR(0), EVT_VAR(1), 1);
-    EVT_VAR(0) = (float) EVT_MAP_VAR(14);
-    EVT_VAR(1) = (float) EVT_MAP_VAR(14);
-    EVT_VAR(0) *= -0.01953125;
-    EVT_VAR(1) *= 0.0400390625;
-    EVT_VAR(0) += (float) EVT_VAR(2);
-    EVT_VAR(1) += (float) EVT_VAR(3);
-    ScaleGroup(36, EVT_VAR(0), EVT_VAR(1), 1);
-    EVT_VAR(0) = (float) EVT_MAP_VAR(15);
-    EVT_VAR(1) = (float) EVT_MAP_VAR(15);
-    EVT_VAR(0) *= -0.01953125;
-    EVT_VAR(1) *= 0.0400390625;
-    EVT_VAR(0) += (float) EVT_VAR(2);
-    EVT_VAR(1) += (float) EVT_VAR(3);
-    ScaleGroup(40, EVT_VAR(0), EVT_VAR(1), 1);
-    UpdateColliderTransform(8);
-    UpdateColliderTransform(9);
-    UpdateColliderTransform(7);
-    UpdateColliderTransform(10);
-    EVT_VAR(15) += 1;
-    if (EVT_VAR(15) >= 1200) {
-        EVT_VAR(15) = 0;
-    }
-    EVT_VAR(0) = (float) EVT_VAR(10);
-    EVT_VAR(1) = (float) EVT_VAR(11);
-    EVT_VAR(2) = (float) EVT_VAR(12);
-    EVT_VAR(3) = (float) EVT_VAR(13);
-    EVT_VAR(0) *= -0.046875;
-    EVT_VAR(1) *= -0.09375;
-    EVT_VAR(2) *= -0.09375;
-    EVT_VAR(3) *= -0.09375;
-    EVT_MAP_VAR(12) += (float) EVT_VAR(0);
-    EVT_MAP_VAR(13) += (float) EVT_VAR(1);
-    EVT_MAP_VAR(14) += (float) EVT_VAR(2);
-    EVT_MAP_VAR(15) += (float) EVT_VAR(3);
-    EVT_MAP_VAR(12) *= 0.84375;
-    EVT_MAP_VAR(13) *= 0.84375;
-    EVT_MAP_VAR(14) *= 0.84375;
-    EVT_MAP_VAR(15) *= 0.84375;
-    EVT_VAR(10) += (float) EVT_MAP_VAR(12);
-    EVT_VAR(11) += (float) EVT_MAP_VAR(13);
-    EVT_VAR(12) += (float) EVT_MAP_VAR(14);
-    EVT_VAR(13) += (float) EVT_MAP_VAR(15);
-    sleep 1;
-    goto 0;
-});
+EvtSource N(80241050) = {
+    EVT_SET_GROUP(239)
+    EVT_SET(EVT_VAR(15), 0)
+    EVT_LABEL(0)
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(-215.4375))
+    EVT_SETF(EVT_VAR(1), EVT_FIXED(128.59375))
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(-200.0))
+    EVT_ADDF(EVT_VAR(1), EVT_MAP_VAR(12))
+    EVT_CALL(TranslateGroup, 28, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(-79.86))
+    EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(1), EVT_FIXED(5.0), EVT_FIXED(136.765625), 300, 0, 0)
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(-200.0))
+    EVT_ADDF(EVT_VAR(1), EVT_MAP_VAR(13))
+    EVT_CALL(TranslateGroup, 32, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(-364.265625))
+    EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(1), EVT_FIXED(5.0), EVT_FIXED(106.765625), 300, 0, 0)
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(10.0))
+    EVT_ADDF(EVT_VAR(1), EVT_MAP_VAR(14))
+    EVT_CALL(TranslateGroup, 36, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(295.734375))
+    EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(1), EVT_FIXED(65.0), EVT_FIXED(86.984375), 200, 0, 0)
+    EVT_SETF(EVT_VAR(2), EVT_FIXED(-80.0))
+    EVT_ADDF(EVT_VAR(1), EVT_MAP_VAR(15))
+    EVT_CALL(TranslateGroup, 40, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(2), EVT_FIXED(0.96875), EVT_FIXED(1.03125), 15, 0, 0)
+    EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(3), EVT_FIXED(1.03125), EVT_FIXED(0.96875), 15, 0, 0)
+    EVT_SETF(EVT_VAR(0), EVT_MAP_VAR(12))
+    EVT_SETF(EVT_VAR(1), EVT_MAP_VAR(12))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-0.02))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(0.04))
+    EVT_ADDF(EVT_VAR(0), EVT_VAR(2))
+    EVT_ADDF(EVT_VAR(1), EVT_VAR(3))
+    EVT_CALL(ScaleGroup, 28, EVT_VAR(0), EVT_VAR(1), 1)
+    EVT_SETF(EVT_VAR(0), EVT_MAP_VAR(13))
+    EVT_SETF(EVT_VAR(1), EVT_MAP_VAR(13))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-0.02))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(0.04))
+    EVT_ADDF(EVT_VAR(0), EVT_VAR(2))
+    EVT_ADDF(EVT_VAR(1), EVT_VAR(3))
+    EVT_CALL(ScaleGroup, 32, EVT_VAR(0), EVT_VAR(1), 1)
+    EVT_SETF(EVT_VAR(0), EVT_MAP_VAR(14))
+    EVT_SETF(EVT_VAR(1), EVT_MAP_VAR(14))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-0.02))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(0.04))
+    EVT_ADDF(EVT_VAR(0), EVT_VAR(2))
+    EVT_ADDF(EVT_VAR(1), EVT_VAR(3))
+    EVT_CALL(ScaleGroup, 36, EVT_VAR(0), EVT_VAR(1), 1)
+    EVT_SETF(EVT_VAR(0), EVT_MAP_VAR(15))
+    EVT_SETF(EVT_VAR(1), EVT_MAP_VAR(15))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-0.02))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(0.04))
+    EVT_ADDF(EVT_VAR(0), EVT_VAR(2))
+    EVT_ADDF(EVT_VAR(1), EVT_VAR(3))
+    EVT_CALL(ScaleGroup, 40, EVT_VAR(0), EVT_VAR(1), 1)
+    EVT_CALL(UpdateColliderTransform, 8)
+    EVT_CALL(UpdateColliderTransform, 9)
+    EVT_CALL(UpdateColliderTransform, 7)
+    EVT_CALL(UpdateColliderTransform, 10)
+    EVT_ADD(EVT_VAR(15), 1)
+    EVT_IF_GE(EVT_VAR(15), 1200)
+        EVT_SET(EVT_VAR(15), 0)
+    EVT_END_IF
+    EVT_SETF(EVT_VAR(0), EVT_VAR(10))
+    EVT_SETF(EVT_VAR(1), EVT_VAR(11))
+    EVT_SETF(EVT_VAR(2), EVT_VAR(12))
+    EVT_SETF(EVT_VAR(3), EVT_VAR(13))
+    EVT_MULF(EVT_VAR(0), EVT_FIXED(-0.046875))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(-0.09375))
+    EVT_MULF(EVT_VAR(2), EVT_FIXED(-0.09375))
+    EVT_MULF(EVT_VAR(3), EVT_FIXED(-0.09375))
+    EVT_ADDF(EVT_MAP_VAR(12), EVT_VAR(0))
+    EVT_ADDF(EVT_MAP_VAR(13), EVT_VAR(1))
+    EVT_ADDF(EVT_MAP_VAR(14), EVT_VAR(2))
+    EVT_ADDF(EVT_MAP_VAR(15), EVT_VAR(3))
+    EVT_MULF(EVT_MAP_VAR(12), EVT_FIXED(0.84375))
+    EVT_MULF(EVT_MAP_VAR(13), EVT_FIXED(0.84375))
+    EVT_MULF(EVT_MAP_VAR(14), EVT_FIXED(0.84375))
+    EVT_MULF(EVT_MAP_VAR(15), EVT_FIXED(0.84375))
+    EVT_ADDF(EVT_VAR(10), EVT_MAP_VAR(12))
+    EVT_ADDF(EVT_VAR(11), EVT_MAP_VAR(13))
+    EVT_ADDF(EVT_VAR(12), EVT_MAP_VAR(14))
+    EVT_ADDF(EVT_VAR(13), EVT_MAP_VAR(15))
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241650) = SCRIPT({
-    spawn {
-        EVT_MAP_VAR(12) += -1.5;
-        sleep 1;
-        EVT_MAP_VAR(12) += -1.5;
-    }
-});
+EvtSource N(80241650) = {
+    EVT_THREAD
+        EVT_ADDF(EVT_MAP_VAR(12), EVT_FIXED(-1.5))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADDF(EVT_MAP_VAR(12), EVT_FIXED(-1.5))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(8024169C) = SCRIPT({
-    spawn {
-        EVT_MAP_VAR(13) += -1.5;
-        sleep 1;
-        EVT_MAP_VAR(13) += -1.5;
-    }
-});
+EvtSource N(8024169C) = {
+    EVT_THREAD
+        EVT_ADDF(EVT_MAP_VAR(13), EVT_FIXED(-1.5))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADDF(EVT_MAP_VAR(13), EVT_FIXED(-1.5))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802416E8) = SCRIPT({
-    spawn {
-        EVT_MAP_VAR(14) += -1.5;
-        sleep 1;
-        EVT_MAP_VAR(14) += -1.5;
-    }
-});
+EvtSource N(802416E8) = {
+    EVT_THREAD
+        EVT_ADDF(EVT_MAP_VAR(14), EVT_FIXED(-1.5))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADDF(EVT_MAP_VAR(14), EVT_FIXED(-1.5))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241734) = SCRIPT({
-    spawn {
-        EVT_MAP_VAR(15) += -1.5;
-        sleep 1;
-        EVT_MAP_VAR(15) += -1.5;
-    }
-});
+EvtSource N(80241734) = {
+    EVT_THREAD
+        EVT_ADDF(EVT_MAP_VAR(15), EVT_FIXED(-1.5))
+        EVT_WAIT_FRAMES(1)
+        EVT_ADDF(EVT_MAP_VAR(15), EVT_FIXED(-1.5))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241780) = SCRIPT({
-    ParentColliderToModel(8, 28);
-    ParentColliderToModel(9, 32);
-    ParentColliderToModel(7, 36);
-    ParentColliderToModel(10, 40);
-    SetModelFlags(28, 256, 1);
-    SetModelFlags(32, 256, 1);
-    SetModelFlags(36, 256, 1);
-    SetModelFlags(40, 256, 1);
-    spawn N(80241050);
-    bind N(80241650) TRIGGER_FLOOR_TOUCH 8;
-    bind N(8024169C) TRIGGER_FLOOR_TOUCH 9;
-    bind N(802416E8) TRIGGER_FLOOR_TOUCH 7;
-    bind N(80241734) TRIGGER_FLOOR_TOUCH 10;
-    spawn {
-        EVT_VAR(15) = 0;
-0:
-        N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(0), 0.96875, 1.03125, 15, 0, 0);
-        N(func_80240340_CE3A30)(EVT_VAR(15), EVT_VAR(1), 1.03125, 0.96875, 15, 0, 0);
-        ScaleModel(70, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(60, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(64, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(68, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(66, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(58, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(62, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(72, EVT_VAR(0), EVT_VAR(1), 1);
-        EVT_VAR(15) += 1;
-        if (EVT_VAR(15) >= 30) {
-            EVT_VAR(15) = 0;
-        }
-        sleep 1;
-        goto 0;
-    }
-});
+EvtSource N(80241780) = {
+    EVT_CALL(ParentColliderToModel, 8, 28)
+    EVT_CALL(ParentColliderToModel, 9, 32)
+    EVT_CALL(ParentColliderToModel, 7, 36)
+    EVT_CALL(ParentColliderToModel, 10, 40)
+    EVT_CALL(SetModelFlags, 28, 256, 1)
+    EVT_CALL(SetModelFlags, 32, 256, 1)
+    EVT_CALL(SetModelFlags, 36, 256, 1)
+    EVT_CALL(SetModelFlags, 40, 256, 1)
+    EVT_EXEC(N(80241050))
+    EVT_BIND_TRIGGER(N(80241650), TRIGGER_FLOOR_TOUCH, 8, 1, 0)
+    EVT_BIND_TRIGGER(N(8024169C), TRIGGER_FLOOR_TOUCH, 9, 1, 0)
+    EVT_BIND_TRIGGER(N(802416E8), TRIGGER_FLOOR_TOUCH, 7, 1, 0)
+    EVT_BIND_TRIGGER(N(80241734), TRIGGER_FLOOR_TOUCH, 10, 1, 0)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(15), 0)
+        EVT_LABEL(0)
+        EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(0), EVT_FIXED(0.96875), EVT_FIXED(1.03125), 15, 0, 0)
+        EVT_CALL(N(func_80240340_CE3A30), EVT_VAR(15), EVT_VAR(1), EVT_FIXED(1.03125), EVT_FIXED(0.96875), 15, 0, 0)
+        EVT_CALL(ScaleModel, 70, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 60, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 64, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 68, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 66, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 58, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 62, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 72, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_ADD(EVT_VAR(15), 1)
+        EVT_IF_GE(EVT_VAR(15), 30)
+            EVT_SET(EVT_VAR(15), 0)
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1A68)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80241A70) = SCRIPT({
-    EVT_VAR(0) = 0;
-10:
-    N(func_80240784_CE3E74)();
-    EVT_VAR(0) += 25;
-    sleep 1;
-    if (EVT_VAR(0) < 255) {
-        goto 10;
-    }
-    EVT_VAR(0) = 255;
-    N(func_80240784_CE3E74)();
-    sleep 1;
-});
+EvtSource N(80241A70) = {
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_LABEL(10)
+    EVT_CALL(N(func_80240784_CE3E74))
+    EVT_ADD(EVT_VAR(0), 25)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_LT(EVT_VAR(0), 255)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_SET(EVT_VAR(0), 255)
+    EVT_CALL(N(func_80240784_CE3E74))
+    EVT_WAIT_FRAMES(1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241B10) = SCRIPT({
-    EVT_VAR(0) = 255;
-10:
-    N(func_80240784_CE3E74)();
-    EVT_VAR(0) -= 25;
-    sleep 1;
-    if (EVT_VAR(0) > 0) {
-        goto 10;
-    }
-    EVT_VAR(0) = 0;
-    N(func_80240784_CE3E74)();
-    sleep 1;
-});
+EvtSource N(80241B10) = {
+    EVT_SET(EVT_VAR(0), 255)
+    EVT_LABEL(10)
+    EVT_CALL(N(func_80240784_CE3E74))
+    EVT_SUB(EVT_VAR(0), 25)
+    EVT_WAIT_FRAMES(1)
+    EVT_IF_GT(EVT_VAR(0), 0)
+        EVT_GOTO(10)
+    EVT_END_IF
+    EVT_SET(EVT_VAR(0), 0)
+    EVT_CALL(N(func_80240784_CE3E74))
+    EVT_WAIT_FRAMES(1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241BB0) = SCRIPT({
-    TranslateGroup(79, 0, EVT_VAR(0), 0);
-    TranslateGroup(92, 0, EVT_VAR(0), 0);
-    EVT_VAR(1) = (float) EVT_VAR(0);
-    EVT_VAR(1) *= -12.0;
-    RotateGroup(79, EVT_VAR(1), 0, 1, 0);
-    RotateGroup(92, EVT_VAR(1), 0, 1, 0);
-});
+EvtSource N(80241BB0) = {
+    EVT_CALL(TranslateGroup, 79, 0, EVT_VAR(0), 0)
+    EVT_CALL(TranslateGroup, 92, 0, EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), EVT_VAR(0))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(-12.0))
+    EVT_CALL(RotateGroup, 79, EVT_VAR(1), 0, 1, 0)
+    EVT_CALL(RotateGroup, 92, EVT_VAR(1), 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241C58) = SCRIPT({
-    TranslateGroup(84, 0, EVT_VAR(0), 0);
-    EVT_VAR(1) = (float) EVT_VAR(0);
-    EVT_VAR(1) *= -12.0;
-    RotateGroup(84, EVT_VAR(1), 0, 1, 0);
-});
+EvtSource N(80241C58) = {
+    EVT_CALL(TranslateGroup, 84, 0, EVT_VAR(0), 0)
+    EVT_SETF(EVT_VAR(1), EVT_VAR(0))
+    EVT_MULF(EVT_VAR(1), EVT_FIXED(-12.0))
+    EVT_CALL(RotateGroup, 84, EVT_VAR(1), 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241CC4) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    SetPlayerActionState(10);
-    DisablePartnerAI(0);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_100)), TRUE);
-    ModifyColliderFlags(0, 13, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    SetCamType(0, 1, 0);
-    UseSettingsFrom(0, 0, 0, 0);
-    SetPanTarget(0, 0, 0, 0);
-    SetCamDistance(0, 350);
-    SetCamPitch(0, 17.0, 11.0);
-    SetCamPosA(0, 0, 0);
-    SetCamPosB(0, 0, 0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    EnableGroup(2, 0);
-    EnableGroup(13, 0);
-    EnableGroup(24, 0);
-    EnableGroup(41, 0);
-    EnableGroup(48, 0);
-    EnableGroup(57, 0);
-    EnableGroup(74, 0);
-    EVT_VAR(9) = (int) 45.0;
-    EVT_VAR(10) = (int) 28.0;
-    EVT_VAR(11) = (int) 5.0;
-    EVT_VAR(12) = (int) 60.0;
-    EVT_VAR(13) = (int) 28.0;
-    EVT_VAR(14) = (int) 10.0;
-    spawn {
-        sleep 5;
-        SetNpcAnimation(NPC_PARTNER, 0x106);
-        SetPlayerAnimation(ANIM_WALKING);
-        match EVT_AREA_FLAG(16) {
-            == 0 {
-                InterpPlayerYaw(90, 0);
-                InterpNpcYaw(NPC_PARTNER, 90, 0);
-            }
-            == 1 {
-                InterpPlayerYaw(270, 0);
-                InterpNpcYaw(NPC_PARTNER, 270, 0);
-            }
-        }
-    }
-    TranslateModel(86, 1.3134765625, 3.0, -0.56640625);
-    UpdateColliderTransform(12);
-    spawn {
-        EVT_AREA_FLAG(45) = 0;
-        SetPlayerAnimation(ANIM_WALKING);
-        sleep 200;
-        await N(80241A70);
-        EVT_AREA_FLAG(45) = 1;
-        sleep 10;
-        EnableGroup(2, 1);
-        EnableGroup(13, 1);
-        EnableGroup(24, 1);
-        EnableGroup(41, 1);
-        EnableGroup(48, 1);
-        EnableGroup(57, 1);
-        EnableGroup(74, 1);
-        SetCamDistance(0, 450);
-        SetCamPitch(0, 17.0, -6.0);
-        SetCamPosA(0, 0, 0);
-        SetCamPosB(0, 0, 0);
-        SetCamSpeed(0, 90.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        await N(80241B10);
-        sleep 20;
-        EVT_AREA_FLAG(45) = 0;
-    }
-    EVT_VAR(15) = 0;
-    loop 344 {
-        EVT_VAR(15) += 1;
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(0), -210, 0, 344, 0, 0);
-        EVT_VAR(1) = (float) EVT_VAR(0);
-        EVT_VAR(1) *= -3.0;
-        TranslateModel(86, 1.3134765625, EVT_VAR(0), -0.56640625);
-        RotateModel(86, EVT_VAR(1), 0, 1, 0);
-        UpdateColliderTransform(12);
-        EVT_VAR(2) = (float) EVT_VAR(0);
-        EVT_VAR(2) *= -3.0;
-        EVT_VAR(3) = (float) EVT_VAR(0);
-        N(func_80240540_CE3C30)();
-        N(func_80240660_CE3D50)();
-11:
-        sleep 1;
-        if (EVT_AREA_FLAG(45) == 1) {
-            goto 11;
-        }
-    }
-    ModifyColliderFlags(1, 13, 0x7FFFFE00);
-    ModifyColliderFlags(1, 5, 0x7FFFFE00);
-    EnablePartnerAI();
-    ClearPartnerMoveHistory(-4);
-    SetPlayerJumpscale(1.0);
-    PlayerJump(100, 0, 60, 20);
-    SetPlayerActionState(10);
-    InterpPlayerYaw(90, 0);
-    sleep 5;
-    EVT_AREA_FLAG(44) = 0;
-    StopSound(412);
-    await N(802409C0);
-    ResetCam(0, 1.0);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80241CC4) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(SetPlayerActionState, 10)
+    EVT_CALL(DisablePartnerAI, 0)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_CALL(SetCamType, 0, 1, 0)
+    EVT_CALL(UseSettingsFrom, 0, 0, 0, 0)
+    EVT_CALL(SetPanTarget, 0, 0, 0, 0)
+    EVT_CALL(SetCamDistance, 0, 350)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(11.0))
+    EVT_CALL(SetCamPosA, 0, 0, 0)
+    EVT_CALL(SetCamPosB, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(EnableGroup, 2, 0)
+    EVT_CALL(EnableGroup, 13, 0)
+    EVT_CALL(EnableGroup, 24, 0)
+    EVT_CALL(EnableGroup, 41, 0)
+    EVT_CALL(EnableGroup, 48, 0)
+    EVT_CALL(EnableGroup, 57, 0)
+    EVT_CALL(EnableGroup, 74, 0)
+    EVT_SET(EVT_VAR(9), EVT_FIXED(45.0))
+    EVT_SET(EVT_VAR(10), EVT_FIXED(28.0))
+    EVT_SET(EVT_VAR(11), EVT_FIXED(5.0))
+    EVT_SET(EVT_VAR(12), EVT_FIXED(60.0))
+    EVT_SET(EVT_VAR(13), EVT_FIXED(28.0))
+    EVT_SET(EVT_VAR(14), EVT_FIXED(10.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+        EVT_CALL(SetPlayerAnimation, ANIM_WALKING)
+        EVT_SWITCH(EVT_AREA_FLAG(16))
+            EVT_CASE_EQ(0)
+                EVT_CALL(InterpPlayerYaw, 90, 0)
+                EVT_CALL(InterpNpcYaw, NPC_PARTNER, 90, 0)
+            EVT_CASE_EQ(1)
+                EVT_CALL(InterpPlayerYaw, 270, 0)
+                EVT_CALL(InterpNpcYaw, NPC_PARTNER, 270, 0)
+        EVT_END_SWITCH
+    EVT_END_THREAD
+    EVT_CALL(TranslateModel, 86, EVT_FIXED(1.3134765625), EVT_FIXED(3.0), EVT_FIXED(-0.56640625))
+    EVT_CALL(UpdateColliderTransform, 12)
+    EVT_THREAD
+        EVT_SET(EVT_AREA_FLAG(45), 0)
+        EVT_CALL(SetPlayerAnimation, ANIM_WALKING)
+        EVT_WAIT_FRAMES(200)
+        EVT_EXEC_WAIT(N(80241A70))
+        EVT_SET(EVT_AREA_FLAG(45), 1)
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(EnableGroup, 2, 1)
+        EVT_CALL(EnableGroup, 13, 1)
+        EVT_CALL(EnableGroup, 24, 1)
+        EVT_CALL(EnableGroup, 41, 1)
+        EVT_CALL(EnableGroup, 48, 1)
+        EVT_CALL(EnableGroup, 57, 1)
+        EVT_CALL(EnableGroup, 74, 1)
+        EVT_CALL(SetCamDistance, 0, 450)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+        EVT_CALL(SetCamPosA, 0, 0, 0)
+        EVT_CALL(SetCamPosB, 0, 0, 0)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_EXEC_WAIT(N(80241B10))
+        EVT_WAIT_FRAMES(20)
+        EVT_SET(EVT_AREA_FLAG(45), 0)
+    EVT_END_THREAD
+    EVT_SET(EVT_VAR(15), 0)
+    EVT_LOOP(344)
+        EVT_ADD(EVT_VAR(15), 1)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(0), -210, 0, 344, 0, 0)
+        EVT_SETF(EVT_VAR(1), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(1), EVT_FIXED(-3.0))
+        EVT_CALL(TranslateModel, 86, EVT_FIXED(1.3134765625), EVT_VAR(0), EVT_FIXED(-0.56640625))
+        EVT_CALL(RotateModel, 86, EVT_VAR(1), 0, 1, 0)
+        EVT_CALL(UpdateColliderTransform, 12)
+        EVT_SETF(EVT_VAR(2), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(2), EVT_FIXED(-3.0))
+        EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+        EVT_CALL(N(func_80240540_CE3C30))
+        EVT_CALL(N(func_80240660_CE3D50))
+        EVT_LABEL(11)
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_AREA_FLAG(45), 1)
+            EVT_GOTO(11)
+        EVT_END_IF
+    EVT_END_LOOP
+    EVT_CALL(ModifyColliderFlags, 1, 13, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 1, 5, 0x7FFFFE00)
+    EVT_CALL(EnablePartnerAI)
+    EVT_CALL(ClearPartnerMoveHistory, -4)
+    EVT_CALL(SetPlayerJumpscale, EVT_FIXED(1.0))
+    EVT_CALL(PlayerJump, 100, 0, 60, 20)
+    EVT_CALL(SetPlayerActionState, 10)
+    EVT_CALL(InterpPlayerYaw, 90, 0)
+    EVT_WAIT_FRAMES(5)
+    EVT_SET(EVT_AREA_FLAG(44), 0)
+    EVT_CALL(StopSound, 412)
+    EVT_EXEC_WAIT(N(802409C0))
+    EVT_CALL(ResetCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802423F8) = SCRIPT({
-    if (EVT_AREA_FLAG(44) == 0) {
-        DisablePlayerInput(TRUE);
-        func_802D2B6C();
-        sleep 15;
-        DisablePartnerAI(0);
-        EVT_AREA_FLAG(44) = 1;
-        ModifyColliderFlags(0, 13, 0x7FFFFE00);
-        ModifyColliderFlags(0, 5, 0x7FFFFE00);
-        EVT_VAR(9) = (int) 45.0;
-        EVT_VAR(10) = (int) 28.0;
-        EVT_VAR(11) = (int) 5.0;
-        EVT_VAR(12) = (int) 60.0;
-        EVT_VAR(13) = (int) 28.0;
-        EVT_VAR(14) = (int) 10.0;
-        PlayerMoveTo(EVT_VAR(9), EVT_VAR(11), 8);
-        SetNpcJumpscale(NPC_PARTNER, 0.0);
-        NpcJump0(NPC_PARTNER, EVT_VAR(12), EVT_VAR(13), EVT_VAR(14), 5);
-        PlaySound(0x19D);
-        SetMusicTrack(0, SONG_MAGIC_BEANSTALK, 1, 8);
-        SetNpcAnimation(NPC_PARTNER, 0x106);
-        SetPlayerAnimation(ANIM_WALKING);
-        N(func_802404D0_CE3BC0)(EVT_VAR(3), EVT_VAR(4));
-        match EVT_VAR(4) {
-            < 90 {
-                EVT_AREA_FLAG(16) = 0;
-                InterpPlayerYaw(90, 0);
-                InterpNpcYaw(NPC_PARTNER, 90, 0);
-            }
-            >= 270 {
-                EVT_AREA_FLAG(16) = 1;
-                InterpPlayerYaw(270, 0);
-                InterpNpcYaw(NPC_PARTNER, 270, 0);
-            }
-        }
-        TranslateModel(86, 1.3134765625, 3.0, -0.56640625);
-        UpdateColliderTransform(12);
-        EVT_MAP_VAR(10) = 0;
-        spawn {
-            EVT_AREA_FLAG(45) = 0;
-            sleep 120;
-            EVT_AREA_FLAG(45) = 1;
-            sleep 20;
-            await N(80241A70);
-            sleep 10;
-            EnableGroup(2, 0);
-            EnableGroup(13, 0);
-            EnableGroup(24, 0);
-            EnableGroup(41, 0);
-            EnableGroup(48, 0);
-            EnableGroup(57, 0);
-            EnableGroup(74, 0);
-            SetCamType(0, 1, 0);
-            UseSettingsFrom(0, 0, 0, 0);
-            SetPanTarget(0, 0, 0, 0);
-            SetCamDistance(0, 350);
-            SetCamPitch(0, 17.0, 7.0);
-            SetCamSpeed(0, 90.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            EVT_AREA_FLAG(45) = 0;
-            await N(80241B10);
-        }
-        spawn {
-            EVT_VAR(15) = 0;
-            loop 344 {
-                EVT_VAR(15) += 1;
-                N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(0), 0, -210, 344, 0, 0);
-                EVT_VAR(1) = (float) EVT_VAR(0);
-                EVT_VAR(1) *= -3.0;
-                TranslateModel(86, 1.3134765625, EVT_VAR(0), -0.56640625);
-                RotateModel(86, EVT_VAR(1), 0, 1, 0);
-                UpdateColliderTransform(12);
-                EVT_VAR(2) = (float) EVT_VAR(0);
-                EVT_VAR(2) *= -3.0;
-                EVT_VAR(3) = (float) EVT_VAR(0);
-                N(func_80240540_CE3C30)();
-                N(func_80240660_CE3D50)();
-                if (EVT_VAR(15) == 300) {
-                    EVT_MAP_VAR(10) = 1;
-                }
-11:
-                sleep 1;
-                if (EVT_AREA_FLAG(45) == 1) {
-                    goto 11;
-                }
-            }
-        }
-10:
-        if (EVT_MAP_VAR(10) == 0) {
-            sleep 1;
-            goto 10;
-        }
-        GotoMap("flo_00", 8);
-        sleep 100;
-    }
-});
+EvtSource N(802423F8) = {
+    EVT_IF_EQ(EVT_AREA_FLAG(44), 0)
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_CALL(func_802D2B6C)
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(DisablePartnerAI, 0)
+        EVT_SET(EVT_AREA_FLAG(44), 1)
+        EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+        EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+        EVT_SET(EVT_VAR(9), EVT_FIXED(45.0))
+        EVT_SET(EVT_VAR(10), EVT_FIXED(28.0))
+        EVT_SET(EVT_VAR(11), EVT_FIXED(5.0))
+        EVT_SET(EVT_VAR(12), EVT_FIXED(60.0))
+        EVT_SET(EVT_VAR(13), EVT_FIXED(28.0))
+        EVT_SET(EVT_VAR(14), EVT_FIXED(10.0))
+        EVT_CALL(PlayerMoveTo, EVT_VAR(9), EVT_VAR(11), 8)
+        EVT_CALL(SetNpcJumpscale, NPC_PARTNER, EVT_FIXED(0.0))
+        EVT_CALL(NpcJump0, NPC_PARTNER, EVT_VAR(12), EVT_VAR(13), EVT_VAR(14), 5)
+        EVT_CALL(PlaySound, 0x19D)
+        EVT_CALL(SetMusicTrack, 0, SONG_MAGIC_BEANSTALK, 1, 8)
+        EVT_CALL(SetNpcAnimation, NPC_PARTNER, 0x106)
+        EVT_CALL(SetPlayerAnimation, ANIM_WALKING)
+        EVT_CALL(N(func_802404D0_CE3BC0), EVT_VAR(3), EVT_VAR(4))
+        EVT_SWITCH(EVT_VAR(4))
+            EVT_CASE_LT(90)
+                EVT_SET(EVT_AREA_FLAG(16), 0)
+                EVT_CALL(InterpPlayerYaw, 90, 0)
+                EVT_CALL(InterpNpcYaw, NPC_PARTNER, 90, 0)
+            EVT_CASE_GE(270)
+                EVT_SET(EVT_AREA_FLAG(16), 1)
+                EVT_CALL(InterpPlayerYaw, 270, 0)
+                EVT_CALL(InterpNpcYaw, NPC_PARTNER, 270, 0)
+        EVT_END_SWITCH
+        EVT_CALL(TranslateModel, 86, EVT_FIXED(1.3134765625), EVT_FIXED(3.0), EVT_FIXED(-0.56640625))
+        EVT_CALL(UpdateColliderTransform, 12)
+        EVT_SET(EVT_MAP_VAR(10), 0)
+        EVT_THREAD
+            EVT_SET(EVT_AREA_FLAG(45), 0)
+            EVT_WAIT_FRAMES(120)
+            EVT_SET(EVT_AREA_FLAG(45), 1)
+            EVT_WAIT_FRAMES(20)
+            EVT_EXEC_WAIT(N(80241A70))
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(EnableGroup, 2, 0)
+            EVT_CALL(EnableGroup, 13, 0)
+            EVT_CALL(EnableGroup, 24, 0)
+            EVT_CALL(EnableGroup, 41, 0)
+            EVT_CALL(EnableGroup, 48, 0)
+            EVT_CALL(EnableGroup, 57, 0)
+            EVT_CALL(EnableGroup, 74, 0)
+            EVT_CALL(SetCamType, 0, 1, 0)
+            EVT_CALL(UseSettingsFrom, 0, 0, 0, 0)
+            EVT_CALL(SetPanTarget, 0, 0, 0, 0)
+            EVT_CALL(SetCamDistance, 0, 350)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(7.0))
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_SET(EVT_AREA_FLAG(45), 0)
+            EVT_EXEC_WAIT(N(80241B10))
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_SET(EVT_VAR(15), 0)
+            EVT_LOOP(344)
+                EVT_ADD(EVT_VAR(15), 1)
+                EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(0), 0, -210, 344, 0, 0)
+                EVT_SETF(EVT_VAR(1), EVT_VAR(0))
+                EVT_MULF(EVT_VAR(1), EVT_FIXED(-3.0))
+                EVT_CALL(TranslateModel, 86, EVT_FIXED(1.3134765625), EVT_VAR(0), EVT_FIXED(-0.56640625))
+                EVT_CALL(RotateModel, 86, EVT_VAR(1), 0, 1, 0)
+                EVT_CALL(UpdateColliderTransform, 12)
+                EVT_SETF(EVT_VAR(2), EVT_VAR(0))
+                EVT_MULF(EVT_VAR(2), EVT_FIXED(-3.0))
+                EVT_SETF(EVT_VAR(3), EVT_VAR(0))
+                EVT_CALL(N(func_80240540_CE3C30))
+                EVT_CALL(N(func_80240660_CE3D50))
+                EVT_IF_EQ(EVT_VAR(15), 300)
+                    EVT_SET(EVT_MAP_VAR(10), 1)
+                EVT_END_IF
+                EVT_LABEL(11)
+                EVT_WAIT_FRAMES(1)
+                EVT_IF_EQ(EVT_AREA_FLAG(45), 1)
+                    EVT_GOTO(11)
+                EVT_END_IF
+            EVT_END_LOOP
+        EVT_END_THREAD
+        EVT_LABEL(10)
+        EVT_IF_EQ(EVT_MAP_VAR(10), 0)
+            EVT_WAIT_FRAMES(1)
+            EVT_GOTO(10)
+        EVT_END_IF
+        EVT_CALL(GotoMap, EVT_PTR("flo_00"), 8)
+        EVT_WAIT_FRAMES(100)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242A2C) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    SetPlayerActionState(10);
-    SetNpcFlagBits(NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE);
-    EnableModel(86, 0);
-    EnableGroup(2, 0);
-    EnableGroup(13, 0);
-    EnableGroup(24, 0);
-    EnableGroup(41, 0);
-    EnableGroup(48, 0);
-    EnableGroup(57, 0);
-    EnableGroup(74, 0);
-    SetCamType(0, 1, 0);
-    UseSettingsFrom(0, 0, 0, 0);
-    SetPanTarget(0, 0, 0, 0);
-    SetCamDistance(0, 800);
-    SetCamPitch(0, -20.0, 8.5);
-    SetCamPosA(0, 0, 0);
-    SetCamPosB(0, 0, 0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    EVT_VAR(15) = 100;
-    EVT_MAP_VAR(11) = EVT_VAR(15);
-    EVT_AREA_FLAG(40) = 0;
-    loop 400 {
-        if (EVT_AREA_FLAG(40) == 0) {
-            if (EVT_MAP_VAR(11) > 400) {
-                EnableGroup(85, 0);
-                EnableGroup(92, 0);
-                EnableGroup(2, 1);
-                EnableGroup(13, 1);
-                EnableGroup(24, 1);
-                EnableGroup(41, 1);
-                EnableGroup(48, 1);
-                EnableGroup(57, 1);
-                EnableGroup(74, 1);
-                SetCamDistance(0, 1000);
-                SetCamPitch(0, 45.0, -3.0);
-                SetCamPosA(0, 0, 0);
-                SetCamPosB(0, 0, 0);
-                SetCamSpeed(0, 90.0);
-                PanToTarget(0, 0, 1);
-                EVT_VAR(15) = 150;
-                spawn {
-                    sleep 5;
-                    EnableGroup(85, 1);
-                    EnableGroup(92, 1);
-                    EnableModel(86, 0);
-                    sleep 48;
-                    PlayEffect(0xA, 0, 22, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-                    sleep 10;
-                    PlayEffect(0xA, 0, 22, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-                }
-                EVT_AREA_FLAG(40) = 1;
-            }
-        }
-        EVT_VAR(15) += 1;
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(0), -350, 0, 400, 0, 0);
-        EVT_MAP_VAR(11) = (float) EVT_VAR(15);
-        EVT_MAP_VAR(11) *= 1.6005859375;
-        EVT_VAR(2) = (float) EVT_VAR(0);
-        EVT_VAR(2) *= 1.0;
-        EVT_VAR(0) = (float) EVT_VAR(2);
-        spawn N(80241BB0);
-        EVT_VAR(2) = (float) EVT_VAR(0);
-        EVT_VAR(2) *= 1.0;
-        EVT_VAR(0) = (float) EVT_VAR(2);
-        spawn N(80241C58);
-        sleep 1;
-    }
-    sleep 15;
-    EVT_STORY_PROGRESS = STORY_CH6_GREW_MAGIC_BEANSTALK;
-    GotoMap("flo_00", 7);
-});
+EvtSource N(80242A2C) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(SetPlayerActionState, 10)
+    EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), FALSE)
+    EVT_CALL(EnableModel, 86, 0)
+    EVT_CALL(EnableGroup, 2, 0)
+    EVT_CALL(EnableGroup, 13, 0)
+    EVT_CALL(EnableGroup, 24, 0)
+    EVT_CALL(EnableGroup, 41, 0)
+    EVT_CALL(EnableGroup, 48, 0)
+    EVT_CALL(EnableGroup, 57, 0)
+    EVT_CALL(EnableGroup, 74, 0)
+    EVT_CALL(SetCamType, 0, 1, 0)
+    EVT_CALL(UseSettingsFrom, 0, 0, 0, 0)
+    EVT_CALL(SetPanTarget, 0, 0, 0, 0)
+    EVT_CALL(SetCamDistance, 0, 800)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(-20.0), EVT_FIXED(8.5))
+    EVT_CALL(SetCamPosA, 0, 0, 0)
+    EVT_CALL(SetCamPosB, 0, 0, 0)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_SET(EVT_VAR(15), 100)
+    EVT_SET(EVT_MAP_VAR(11), EVT_VAR(15))
+    EVT_SET(EVT_AREA_FLAG(40), 0)
+    EVT_LOOP(400)
+        EVT_IF_EQ(EVT_AREA_FLAG(40), 0)
+            EVT_IF_GT(EVT_MAP_VAR(11), 400)
+                EVT_CALL(EnableGroup, 85, 0)
+                EVT_CALL(EnableGroup, 92, 0)
+                EVT_CALL(EnableGroup, 2, 1)
+                EVT_CALL(EnableGroup, 13, 1)
+                EVT_CALL(EnableGroup, 24, 1)
+                EVT_CALL(EnableGroup, 41, 1)
+                EVT_CALL(EnableGroup, 48, 1)
+                EVT_CALL(EnableGroup, 57, 1)
+                EVT_CALL(EnableGroup, 74, 1)
+                EVT_CALL(SetCamDistance, 0, 1000)
+                EVT_CALL(SetCamPitch, 0, EVT_FIXED(45.0), EVT_FIXED(-3.0))
+                EVT_CALL(SetCamPosA, 0, 0, 0)
+                EVT_CALL(SetCamPosB, 0, 0, 0)
+                EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+                EVT_CALL(PanToTarget, 0, 0, 1)
+                EVT_SET(EVT_VAR(15), 150)
+                EVT_THREAD
+                    EVT_WAIT_FRAMES(5)
+                    EVT_CALL(EnableGroup, 85, 1)
+                    EVT_CALL(EnableGroup, 92, 1)
+                    EVT_CALL(EnableModel, 86, 0)
+                    EVT_WAIT_FRAMES(48)
+                    EVT_CALL(PlayEffect, 0xA, 0, 22, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+                    EVT_WAIT_FRAMES(10)
+                    EVT_CALL(PlayEffect, 0xA, 0, 22, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+                EVT_END_THREAD
+                EVT_SET(EVT_AREA_FLAG(40), 1)
+            EVT_END_IF
+        EVT_END_IF
+        EVT_ADD(EVT_VAR(15), 1)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(0), -350, 0, 400, 0, 0)
+        EVT_SETF(EVT_MAP_VAR(11), EVT_VAR(15))
+        EVT_MULF(EVT_MAP_VAR(11), EVT_FIXED(1.6))
+        EVT_SETF(EVT_VAR(2), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(2), EVT_FIXED(1.0))
+        EVT_SETF(EVT_VAR(0), EVT_VAR(2))
+        EVT_EXEC(N(80241BB0))
+        EVT_SETF(EVT_VAR(2), EVT_VAR(0))
+        EVT_MULF(EVT_VAR(2), EVT_FIXED(1.0))
+        EVT_SETF(EVT_VAR(0), EVT_VAR(2))
+        EVT_EXEC(N(80241C58))
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(15)
+    EVT_SET(EVT_SAVE_VAR(0), 55)
+    EVT_CALL(GotoMap, EVT_PTR("flo_00"), 7)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242FD0) = SCRIPT({
-    bind N(802423F8) TRIGGER_FLOOR_TOUCH 12;
-});
+EvtSource N(80242FD0) = {
+    EVT_BIND_TRIGGER(N(802423F8), TRIGGER_FLOOR_TOUCH, 12, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/UnkTexturePanFunc.inc.c"
 

--- a/src/world/area_flo/flo_21/CE6700.c
+++ b/src/world/area_flo/flo_21/CE6700.c
@@ -37,139 +37,147 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_21_tattle },
 };
 
-EvtSource N(80240D40) = SCRIPT({
-    if (EVT_STORY_PROGRESS == STORY_CH6_DEFEATED_HUFF_N_PUFF) {
-        FadeOutMusic(0, 500);
-    } else {
-        SetMusicTrack(0, SONG_CLOUDY_CLIMB, 0, 8);
-    }
-});
+EvtSource N(80240D40) = {
+    EVT_IF_EQ(EVT_SAVE_VAR(0), 56)
+        EVT_CALL(FadeOutMusic, 0, 500)
+    EVT_ELSE
+        EVT_CALL(SetMusicTrack, 0, SONG_CLOUDY_CLIMB, 0, 8)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/StarSpiritEffectFunc.inc.c"
 
-EvtSource N(80240DA0) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(80240DA0) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240E3C) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        == STORY_CH6_GREW_MAGIC_BEANSTALK {
-            EVT_VAR(0) = 0;
-            if (EVT_MAP_VAR(10) == 0) {
-                return;
-            }
-            EVT_STORY_PROGRESS = STORY_CH6_DEFEATED_HUFF_N_PUFF;
-        }
-        == STORY_CH6_DEFEATED_HUFF_N_PUFF {
-            EVT_VAR(0) = 1;
-        } else {
-            return;
-        }
-    }
-    if (EVT_VAR(0) == 0) {
-        DisablePlayerInput(TRUE);
-        UseSettingsFrom(0, 650, 205, 0);
-        SetCamSpeed(0, 0.6005859375);
-        SetPanTarget(0, 650, 150, 0);
-        GetCamDistance(0, EVT_VAR(1));
-        EVT_VAR(1) -= 100;
-        SetCamDistance(0, EVT_VAR(1));
-        if (-5.5 != 10000) {
-            GetCamPitch(0, EVT_VAR(2), EVT_VAR(3));
-            SetCamPitch(0, EVT_VAR(2), -5.5);
-        }
-        PanToTarget(0, 0, 1);
-        N(StarSpiritEffectFunc2)(5, 180, 650, 170, 0, 650, 205, 0, 150, 120);
-        spawn {
-            N(StarSpiritEffectFunc3)();
-        }
-        spawn {
-            sleep 1;
-            PlaySound(0x80000067);
-            N(StarSpiritEffectFunc1)();
-            StopSound(0x80000067);
-            PlaySoundAt(0xB2, 0, 650, 205, 0);
-        }
-        spawn {
-            sleep 45;
-            SetPlayerAnimation(0x1002A);
-        }
-        spawn {
-            sleep 180;
-            sleep 115;
-            PlaySoundAt(0x137, 0, 650, 205, 0);
-        }
-        N(StarSpiritEffectFunc4)(1);
-        spawn {
-            sleep 80;
-            SetPlayerAnimation(ANIM_10002);
-        }
-        EVT_VAR(1) += 100;
-        SetCamDistance(0, EVT_VAR(1));
-        SetPanTarget(0, 650, 120, 0);
-        N(StarSpiritEffectFunc4)(2);
-        GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        UseSettingsFrom(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        SetCamSpeed(0, 1.0);
-        SetPanTarget(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        WaitForCam(0, 1.0);
-        PanToTarget(0, 0, 0);
-        DisablePlayerInput(FALSE);
-    } else {
-        N(StarSpiritEffectFunc5)(5, 650, 150, 0, 120);
-        spawn {
-            N(StarSpiritEffectFunc6)();
-        }
-        sleep 1;
-    }
-    N(StarSpiritEffectFunc4)(3);
-    PlaySoundAtPlayer(312, 0);
-    DisablePlayerInput(TRUE);
-    EVT_STORY_PROGRESS = STORY_CH6_STAR_SPIRIT_RESCUED;
-    GotoMapSpecial("kmr_23", 5, 14);
-    sleep 100;
-});
+EvtSource N(80240E3C) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_EQ(55)
+            EVT_SET(EVT_VAR(0), 0)
+            EVT_IF_EQ(EVT_MAP_VAR(10), 0)
+                EVT_RETURN
+            EVT_END_IF
+            EVT_SET(EVT_SAVE_VAR(0), 56)
+        EVT_CASE_EQ(56)
+            EVT_SET(EVT_VAR(0), 1)
+        EVT_CASE_DEFAULT
+            EVT_RETURN
+    EVT_END_SWITCH
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_CALL(UseSettingsFrom, 0, 650, 205, 0)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(0.6))
+        EVT_CALL(SetPanTarget, 0, 650, 150, 0)
+        EVT_CALL(GetCamDistance, 0, EVT_VAR(1))
+        EVT_SUB(EVT_VAR(1), 100)
+        EVT_CALL(SetCamDistance, 0, EVT_VAR(1))
+        EVT_IF_NE(EVT_FIXED(-5.5), 10000)
+            EVT_CALL(GetCamPitch, 0, EVT_VAR(2), EVT_VAR(3))
+            EVT_CALL(SetCamPitch, 0, EVT_VAR(2), EVT_FIXED(-5.5))
+        EVT_END_IF
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(N(StarSpiritEffectFunc2), 5, 180, 650, 170, 0, 650, 205, 0, 150, 120)
+        EVT_THREAD
+            EVT_CALL(N(StarSpiritEffectFunc3))
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_WAIT_FRAMES(1)
+            EVT_CALL(PlaySound, 0x80000067)
+            EVT_CALL(N(StarSpiritEffectFunc1))
+            EVT_CALL(StopSound, 0x80000067)
+            EVT_CALL(PlaySoundAt, 0xB2, 0, 650, 205, 0)
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_WAIT_FRAMES(45)
+            EVT_CALL(SetPlayerAnimation, 65578)
+        EVT_END_THREAD
+        EVT_THREAD
+            EVT_WAIT_FRAMES(180)
+            EVT_WAIT_FRAMES(115)
+            EVT_CALL(PlaySoundAt, 0x137, 0, 650, 205, 0)
+        EVT_END_THREAD
+        EVT_CALL(N(StarSpiritEffectFunc4), 1)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(80)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+        EVT_END_THREAD
+        EVT_ADD(EVT_VAR(1), 100)
+        EVT_CALL(SetCamDistance, 0, EVT_VAR(1))
+        EVT_CALL(SetPanTarget, 0, 650, 120, 0)
+        EVT_CALL(N(StarSpiritEffectFunc4), 2)
+        EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.0))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(PanToTarget, 0, 0, 0)
+        EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_ELSE
+        EVT_CALL(N(StarSpiritEffectFunc5), 5, 650, 150, 0, 120)
+        EVT_THREAD
+            EVT_CALL(N(StarSpiritEffectFunc6))
+        EVT_END_THREAD
+        EVT_WAIT_FRAMES(1)
+    EVT_END_IF
+    EVT_CALL(N(StarSpiritEffectFunc4), 3)
+    EVT_CALL(PlaySoundAtPlayer, 312, 0)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_SAVE_VAR(0), 57)
+    EVT_CALL(GotoMapSpecial, EVT_PTR("kmr_23"), 5, 14)
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_802412F4) = EXIT_WALK_SCRIPT(60,  0, "flo_19",  1);
 
-EvtSource N(80241350) = SCRIPT({
-    bind N(exitWalk_802412F4) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(80241350) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802412F4), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_CLOUDY_CLIMB;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80245AEC));
-    spawn N(80241B98);
-    HidePlayerShadow(TRUE);
-    spawn N(80241600);
-    ModifyColliderFlags(3, 5, 0x00000007);
-    ModifyColliderFlags(3, 7, 0x00000007);
-    GetEntryID(EVT_VAR(0));
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    EVT_VAR(0) = N(80241350);
-    spawn EnterWalk;
-    await N(80240D40);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240B00_CE7200)();
-    }
-    spawn N(80240E3C);
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 39)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80245AEC)))
+    EVT_EXEC(N(80241B98))
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_EXEC(N(80241600))
+    EVT_CALL(ModifyColliderFlags, 3, 5, 0x00000007)
+    EVT_CALL(ModifyColliderFlags, 3, 7, 0x00000007)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80241350)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80240D40))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240B00_CE7200))
+    EVT_END_IF
+    EVT_EXEC(N(80240E3C))
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(D_802414FC_CE7BFC)[] = {
     0,
@@ -183,48 +191,60 @@ s32 N(D_802414FC_CE7BFC)[] = {
     EVT_FIXED(0.900390625), EVT_FIXED(0.900390625), EVT_FIXED(0.900390625),
 };
 
-EvtSource N(80241560) = SCRIPT({
-    EVT_MAP_VAR(0) += -1.5;
-});
+EvtSource N(80241560) = {
+    EVT_ADDF(EVT_MAP_VAR(0), EVT_FIXED(-1.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241580) = SCRIPT({
-    EVT_MAP_VAR(1) += -1.5;
-});
+EvtSource N(80241580) = {
+    EVT_ADDF(EVT_MAP_VAR(1), EVT_FIXED(-1.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802415A0) = SCRIPT({
-    EVT_MAP_VAR(2) += -1.5;
-});
+EvtSource N(802415A0) = {
+    EVT_ADDF(EVT_MAP_VAR(2), EVT_FIXED(-1.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802415C0) = SCRIPT({
-    EVT_MAP_VAR(3) += -1.5;
-});
+EvtSource N(802415C0) = {
+    EVT_ADDF(EVT_MAP_VAR(3), EVT_FIXED(-1.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802415E0) = SCRIPT({
-    EVT_MAP_VAR(4) += -1.5;
-});
+EvtSource N(802415E0) = {
+    EVT_ADDF(EVT_MAP_VAR(4), EVT_FIXED(-1.5))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241600) = SCRIPT({
-    spawn {
-        EVT_VAR(15) = 0;
-0:
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(0), 0.96875, 1.03125, 15, 0, 0);
-        N(UnkFloatFunc)(EVT_VAR(15), EVT_VAR(1), 1.03125, 0.96875, 15, 0, 0);
-        ScaleModel(88, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(90, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(92, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(94, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(96, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(98, EVT_VAR(1), EVT_VAR(0), 1);
-        ScaleModel(100, EVT_VAR(0), EVT_VAR(1), 1);
-        ScaleModel(102, EVT_VAR(0), EVT_VAR(1), 1);
-        EVT_VAR(15) += 1;
-        if (EVT_VAR(15) >= 30) {
-            EVT_VAR(15) = 0;
-        }
-        sleep 1;
-        goto 0;
-    }
-});
+EvtSource N(80241600) = {
+    EVT_THREAD
+        EVT_SET(EVT_VAR(15), 0)
+        EVT_LABEL(0)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(0), EVT_FIXED(0.96875), EVT_FIXED(1.03125), 15, 0, 0)
+        EVT_CALL(N(UnkFloatFunc), EVT_VAR(15), EVT_VAR(1), EVT_FIXED(1.03125), EVT_FIXED(0.96875), 15, 0, 0)
+        EVT_CALL(ScaleModel, 88, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 90, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 92, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 94, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 96, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 98, EVT_VAR(1), EVT_VAR(0), 1)
+        EVT_CALL(ScaleModel, 100, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(ScaleModel, 102, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_ADD(EVT_VAR(15), 1)
+        EVT_IF_GE(EVT_VAR(15), 30)
+            EVT_SET(EVT_VAR(15), 0)
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_17BC) = {
     0x00000000,
@@ -267,186 +287,192 @@ Vec3f N(vectorList_8024189C)[] = {
     { 550.0, 104.0, 0.0 },
 };
 
-EvtSource N(802418C0) = SCRIPT({
-0:
-    PlaySound(0x20B6);
-    ShakeCam(0, 0, 15, 1.0);
-    sleep 15;
-    goto 0;
-});
+EvtSource N(802418C0) = {
+    EVT_LABEL(0)
+    EVT_CALL(PlaySound, 0x20B6)
+    EVT_CALL(ShakeCam, 0, 0, 15, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(15)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241920) = SCRIPT({
-    PlaySoundAtNpc(NPC_HUFF_N_PUFF0, 0x3C0, 0);
-    PlayEffect(0x25, 3, 650, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep 15;
-    SetNpcJumpscale(NPC_HUFF_N_PUFF1, 0.0);
-    NpcJump0(NPC_HUFF_N_PUFF1, 650, 50, 0, 5);
-    SetNpcPos(NPC_HUFF_N_PUFF0, 650, 50, 5);
-    SetNpcPos(NPC_HUFF_N_PUFF1, 650, 50, 0);
-    SetNpcPos(NPC_HUFF_N_PUFF2, 650, 50, 0);
-    SetNpcJumpscale(NPC_HUFF_N_PUFF0, 0.0);
-    SetNpcJumpscale(NPC_HUFF_N_PUFF1, 0.0);
-    SetNpcJumpscale(NPC_HUFF_N_PUFF2, 0.0);
-    spawn {
-        NpcJump0(NPC_HUFF_N_PUFF0, 650, 150, 5, 10);
-    }
-    spawn {
-        NpcJump0(NPC_HUFF_N_PUFF1, 650, 150, 0, 10);
-    }
-    spawn {
-        NpcJump0(NPC_HUFF_N_PUFF2, 650, 150, 0, 10);
-    }
-    spawn {
-        SetPlayerAnimation(ANIM_80017);
-        LoadPath(30, N(vectorList_8024189C), 3, 0);
-0:
-        GetNextPathPos();
-        SetPlayerPos(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-        sleep 1;
-        if (EVT_VAR(0) == 1) {
-            goto 0;
-        }
-    }
-    SetPlayerAnimation(ANIM_1002B);
-});
+EvtSource N(80241920) = {
+    EVT_CALL(PlaySoundAtNpc, 0, 0x3C0, 0)
+    EVT_CALL(PlayEffect, 0x25, 3, 650, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(15)
+    EVT_CALL(SetNpcJumpscale, 1, EVT_FIXED(0.0))
+    EVT_CALL(NpcJump0, 1, 650, 50, 0, 5)
+    EVT_CALL(SetNpcPos, 0, 650, 50, 5)
+    EVT_CALL(SetNpcPos, 1, 650, 50, 0)
+    EVT_CALL(SetNpcPos, 2, 650, 50, 0)
+    EVT_CALL(SetNpcJumpscale, 0, EVT_FIXED(0.0))
+    EVT_CALL(SetNpcJumpscale, 1, EVT_FIXED(0.0))
+    EVT_CALL(SetNpcJumpscale, 2, EVT_FIXED(0.0))
+    EVT_THREAD
+        EVT_CALL(NpcJump0, 0, 650, 150, 5, 10)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(NpcJump0, 1, 650, 150, 0, 10)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(NpcJump0, 2, 650, 150, 0, 10)
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_CALL(SetPlayerAnimation, ANIM_80017)
+        EVT_CALL(LoadPath, 30, EVT_PTR(N(vectorList_8024189C)), 3, 0)
+        EVT_LABEL(0)
+        EVT_CALL(GetNextPathPos)
+        EVT_CALL(SetPlayerPos, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(0), 1)
+            EVT_GOTO(0)
+        EVT_END_IF
+    EVT_END_THREAD
+    EVT_CALL(SetPlayerAnimation, ANIM_1002B)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241B98) = SCRIPT({
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DEFEATED_HUFF_N_PUFF) {
-        return;
-    }
-    AwaitPlayerApproach(650, 0, 30);
-    DisablePlayerInput(TRUE);
-    SetMusicTrack(0, SONG_HUFF_N_PUFF_THEME, 0, 8);
-    EVT_VAR(9) = spawn N(802418C0);
-    GetCurrentPartner(EVT_VAR(0));
-    if (EVT_VAR(0) != 0) {
-        func_802D2B6C();
-        sleep 20;
-    }
-    DisablePlayerPhysics(TRUE);
-    InterpPlayerYaw(90, 1);
-    sleep 5;
-    SetPlayerAnimation(ANIM_1002B);
-    SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((NPC_FLAG_100)), TRUE);
-    GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-    UseSettingsFrom(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-    SetPanTarget(0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    MakeLerp(EVT_VAR(2), 600, 20, 0);
-    EVT_VAR(2) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(3);
-    EVT_VAR(5) += 15;
-    loop {
-        UpdateLerp();
-        EVT_VAR(3) += 3;
-        SetPlayerPos(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4));
-        if (EVT_VAR(3) > EVT_VAR(5)) {
-            EVT_VAR(3) = EVT_VAR(2);
-        }
-        sleep 1;
-        if (EVT_VAR(1) == 0) {
-            break loop;
-        }
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(2), EVT_VAR(4));
-    }
-    func_802D2C14(1);
-    SetPlayerPos(EVT_VAR(0), EVT_VAR(2), EVT_VAR(4));
-    SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((NPC_FLAG_100)), FALSE);
-    DisablePlayerPhysics(FALSE);
-    sleep 10;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += 25;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 300.0);
-    SetCamPitch(0, 17.0, -9.0);
-    SetCamSpeed(0, 4.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    sleep 10;
-    ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00CA), 630, 120, 0);
-    SetCamDistance(0, 600.0);
-    SetCamPitch(0, 30.0, -9.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    sleep 10;
-    ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00CB), 630, 120, 0);
-    SetCamDistance(0, 300.0);
-    SetCamPitch(0, 17.0, -9.0);
-    PanToTarget(0, 0, 1);
-    func_802D2C14(0);
-    sleep 10;
-    GetCurrentPartnerID(EVT_VAR(0));
-    if (EVT_VAR(0) != 8) {
-        ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00CC), 630, 120, 0);
-    } else {
-        ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00CD), 630, 120, 0);
-    }
-    parallel {
-        sleep 15;
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        EVT_VAR(0) += 25;
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamPitch(0, 17.0, -6.0);
-        EVT_VAR(3) = 40;
-        loop 5 {
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 400.0);
-            SetCamSpeed(0, EVT_VAR(3));
-            WaitForCam(0, 1.0);
-            EVT_VAR(3) -= 10;
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamDistance(0, 600.0);
-            SetCamSpeed(0, EVT_VAR(3));
-            WaitForCam(0, 1.0);
-            EVT_VAR(3) += 7;
-        }
-    }
-    await N(80241920);
-    kill EVT_VAR(9);
-    sleep 30;
-    SetNpcVar(0, 0, 1);
-    DisablePlayerInput(FALSE);
-    sleep 15;
-});
+EvtSource N(80241B98) = {
+    EVT_IF_GE(EVT_SAVE_VAR(0), 56)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(AwaitPlayerApproach, 650, 0, 30)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(SetMusicTrack, 0, SONG_HUFF_N_PUFF_THEME, 0, 8)
+    EVT_EXEC_GET_TID(N(802418C0), EVT_VAR(9))
+    EVT_CALL(GetCurrentPartner, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 0)
+        EVT_CALL(func_802D2B6C)
+        EVT_WAIT_FRAMES(20)
+    EVT_END_IF
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(InterpPlayerYaw, 90, 1)
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(SetPlayerAnimation, ANIM_1002B)
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), TRUE)
+    EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(MakeLerp, EVT_VAR(2), 600, 20, 0)
+    EVT_SET(EVT_VAR(2), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(3))
+    EVT_ADD(EVT_VAR(5), 15)
+    EVT_LOOP(0)
+        EVT_CALL(UpdateLerp)
+        EVT_ADD(EVT_VAR(3), 3)
+        EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4))
+        EVT_IF_GT(EVT_VAR(3), EVT_VAR(5))
+            EVT_SET(EVT_VAR(3), EVT_VAR(2))
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+        EVT_IF_EQ(EVT_VAR(1), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(2), EVT_VAR(4))
+    EVT_END_LOOP
+    EVT_CALL(func_802D2C14, 1)
+    EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(2), EVT_VAR(4))
+    EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_100)), FALSE)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), 25)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(300.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00CA), 630, 120, 0)
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(600.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(30.0), EVT_FIXED(-9.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00CB), 630, 120, 0)
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(300.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-9.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(func_802D2C14, 0)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetCurrentPartnerID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 8)
+        EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00CC), 630, 120, 0)
+    EVT_ELSE
+        EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00CD), 630, 120, 0)
+    EVT_END_IF
+    EVT_CHILD_THREAD
+        EVT_WAIT_FRAMES(15)
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), 25)
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-6.0))
+        EVT_SET(EVT_VAR(3), 40)
+        EVT_LOOP(5)
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, EVT_FIXED(400.0))
+            EVT_CALL(SetCamSpeed, 0, EVT_VAR(3))
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_SUB(EVT_VAR(3), 10)
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamDistance, 0, EVT_FIXED(600.0))
+            EVT_CALL(SetCamSpeed, 0, EVT_VAR(3))
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_ADD(EVT_VAR(3), 7)
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_EXEC_WAIT(N(80241920))
+    EVT_KILL_THREAD(EVT_VAR(9))
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SetNpcVar, 0, 0, 1)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_WAIT_FRAMES(15)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242290) = SCRIPT({
-    EVT_VAR(0) = 0.9501953125;
-    EVT_VAR(1) = 1.1005859375;
-0:
-    match EVT_MAP_VAR(13) {
-        == 0 {
-            EVT_VAR(3) = 10;
-            EVT_VAR(2) = 2;
-        }
-        == 1 {
-            EVT_VAR(3) = 5;
-            EVT_VAR(2) = 1;
-        } else {
-            return;
-        }
-    }
-    EVT_VAR(4) = EVT_VAR(3);
-    loop EVT_VAR(4) {
-        SetNpcScale(NPC_HUFF_N_PUFF0, EVT_VAR(0), EVT_VAR(1), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF1, EVT_VAR(0), EVT_VAR(1), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF2, EVT_VAR(0), EVT_VAR(1), 1);
-        EVT_VAR(0) += 0.015625;
-        EVT_VAR(1) -= 0.0107421875;
-        sleep EVT_VAR(2);
-    }
-    EVT_VAR(4) = EVT_VAR(3);
-    loop EVT_VAR(4) {
-        SetNpcScale(NPC_HUFF_N_PUFF0, EVT_VAR(0), EVT_VAR(1), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF1, EVT_VAR(0), EVT_VAR(1), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF2, EVT_VAR(0), EVT_VAR(1), 1);
-        EVT_VAR(0) -= 0.015625;
-        EVT_VAR(1) += 0.0107421875;
-        sleep EVT_VAR(2);
-    }
-    goto 0;
-});
+EvtSource N(80242290) = {
+    EVT_SETF(EVT_VAR(0), EVT_FIXED(0.95))
+    EVT_SETF(EVT_VAR(1), EVT_FIXED(1.1))
+    EVT_LABEL(0)
+    EVT_SWITCH(EVT_MAP_VAR(13))
+        EVT_CASE_EQ(0)
+            EVT_SET(EVT_VAR(3), 10)
+            EVT_SET(EVT_VAR(2), 2)
+        EVT_CASE_EQ(1)
+            EVT_SET(EVT_VAR(3), 5)
+            EVT_SET(EVT_VAR(2), 1)
+        EVT_CASE_DEFAULT
+            EVT_RETURN
+    EVT_END_SWITCH
+    EVT_SET(EVT_VAR(4), EVT_VAR(3))
+    EVT_LOOP(EVT_VAR(4))
+        EVT_CALL(SetNpcScale, 0, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(SetNpcScale, 1, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(SetNpcScale, 2, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_ADDF(EVT_VAR(0), EVT_FIXED(0.015625))
+        EVT_SUBF(EVT_VAR(1), EVT_FIXED(0.01))
+        EVT_WAIT_FRAMES(EVT_VAR(2))
+    EVT_END_LOOP
+    EVT_SET(EVT_VAR(4), EVT_VAR(3))
+    EVT_LOOP(EVT_VAR(4))
+        EVT_CALL(SetNpcScale, 0, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(SetNpcScale, 1, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_CALL(SetNpcScale, 2, EVT_VAR(0), EVT_VAR(1), 1)
+        EVT_SUBF(EVT_VAR(0), EVT_FIXED(0.015625))
+        EVT_ADDF(EVT_VAR(1), EVT_FIXED(0.01))
+        EVT_WAIT_FRAMES(EVT_VAR(2))
+    EVT_END_LOOP
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(intTable_8024249C)[] = {
     0x0000027B, 0x000000A5, 0x000001C2, 0x00000078, 0x00000280, 0x000000AA, 0x00000208, 0x0000010E,
@@ -479,295 +505,315 @@ s32 N(intTable_8024262C)[] = {
     0x0000000A, 0x00000006, 0x00000006, 0x0000000A,
 };
 
-EvtSource N(8024263C) = SCRIPT({
-    EVT_VAR(0) = (float) 10;
-    EVT_VAR(1) = (float) 1;
-    parallel {
-        loop 8 {
-            SetNpcFlagBits(NPC_HUFF_N_PUFF0, ((0x00000002)), FALSE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((0x00000002)), FALSE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF2, ((0x00000002)), FALSE);
-            sleep EVT_VAR(0);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF0, ((0x00000002)), TRUE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((0x00000002)), TRUE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF2, ((0x00000002)), TRUE);
-            sleep EVT_VAR(1);
-            EVT_VAR(0) -= (float) 0;
-            EVT_VAR(1) += (float) 0;
-        }
-        loop {
-            SetNpcFlagBits(NPC_HUFF_N_PUFF0, ((0x00000002)), FALSE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((0x00000002)), FALSE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF2, ((0x00000002)), FALSE);
-            sleep EVT_VAR(0);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF0, ((0x00000002)), TRUE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF1, ((0x00000002)), TRUE);
-            SetNpcFlagBits(NPC_HUFF_N_PUFF2, ((0x00000002)), TRUE);
-            sleep EVT_VAR(1);
-        }
-    }
-    parallel {
-        loop {
-            MakeLerp(0, 255, 10, 4);
-            loop {
-                UpdateLerp();
-                func_802CFD30(NPC_HUFF_N_PUFF0, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0);
-                func_802CFD30(NPC_HUFF_N_PUFF1, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0);
-                func_802CFD30(NPC_HUFF_N_PUFF2, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0);
-                sleep 1;
-                if (EVT_VAR(1) == 0) {
-                    break loop;
-                }
-            }
-        }
-    }
-    sleep 100;
-});
+EvtSource N(8024263C) = {
+    EVT_SETF(EVT_VAR(0), 10)
+    EVT_SETF(EVT_VAR(1), 1)
+    EVT_CHILD_THREAD
+        EVT_LOOP(8)
+            EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), FALSE)
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_2)), FALSE)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_2)), FALSE)
+            EVT_WAIT_FRAMES(EVT_VAR(0))
+            EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), TRUE)
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_2)), TRUE)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_2)), TRUE)
+            EVT_WAIT_FRAMES(EVT_VAR(1))
+            EVT_SUBF(EVT_VAR(0), 0)
+            EVT_ADDF(EVT_VAR(1), 0)
+        EVT_END_LOOP
+        EVT_LOOP(0)
+            EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), FALSE)
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_2)), FALSE)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_2)), FALSE)
+            EVT_WAIT_FRAMES(EVT_VAR(0))
+            EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), TRUE)
+            EVT_CALL(SetNpcFlagBits, 1, ((NPC_FLAG_2)), TRUE)
+            EVT_CALL(SetNpcFlagBits, 2, ((NPC_FLAG_2)), TRUE)
+            EVT_WAIT_FRAMES(EVT_VAR(1))
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_CHILD_THREAD
+        EVT_LOOP(0)
+            EVT_CALL(MakeLerp, 0, 255, 10, 4)
+            EVT_LOOP(0)
+                EVT_CALL(UpdateLerp)
+                EVT_CALL(func_802CFD30, 0, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0)
+                EVT_CALL(func_802CFD30, 1, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0)
+                EVT_CALL(func_802CFD30, 2, 9, EVT_VAR(0), EVT_VAR(0), EVT_VAR(0), 0)
+                EVT_WAIT_FRAMES(1)
+                EVT_IF_EQ(EVT_VAR(1), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+            EVT_END_LOOP
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_WAIT_FRAMES(100)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242918) = SCRIPT({
-    EVT_MAP_VAR(11) = 1.0;
-    EVT_MAP_VAR(12) = 1.0;
-    parallel {
-        buf_use N(intTable_8024258C);
-        loop 6 {
-            PlaySoundAtNpc(NPC_HUFF_N_PUFF0, 0x20B6, 0);
-            buf_read EVT_VAR(6) EVT_VAR(7) EVT_VAR(8);
-            MakeLerp(EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 11);
-            loop {
-                UpdateLerp();
-                EVT_VAR(0) /= (float) 10;
-                EVT_MAP_VAR(11) = (float) EVT_VAR(0);
-                sleep 1;
-                if (EVT_VAR(1) == 0) {
-                    break loop;
-                }
-            }
-            sleep 1;
-        }
-        loop {
-            buf_use N(intTable_802425D4);
-            loop 2 {
-                PlaySoundAtNpc(NPC_HUFF_N_PUFF0, 0x20B6, 0);
-                buf_read EVT_VAR(6) EVT_VAR(7);
-                MakeLerp(EVT_VAR(6), EVT_VAR(7), 4, 11);
-                loop {
-                    UpdateLerp();
-                    EVT_VAR(0) /= (float) 10;
-                    EVT_MAP_VAR(11) = (float) EVT_VAR(0);
-                    sleep 1;
-                    if (EVT_VAR(1) == 0) {
-                        break loop;
-                    }
-                }
-            }
-        }
-    }
-    parallel {
-        buf_use N(intTable_802425E4);
-        loop 6 {
-            buf_read EVT_VAR(6) EVT_VAR(7) EVT_VAR(8);
-            MakeLerp(EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 11);
-            loop {
-                UpdateLerp();
-                EVT_VAR(0) /= (float) 10;
-                EVT_MAP_VAR(12) = (float) EVT_VAR(0);
-                sleep 1;
-                if (EVT_VAR(1) == 0) {
-                    break loop;
-                }
-            }
-            sleep 1;
-        }
-        loop {
-            buf_use N(intTable_8024262C);
-            loop 2 {
-                buf_read EVT_VAR(6) EVT_VAR(7);
-                MakeLerp(EVT_VAR(6), EVT_VAR(7), 4, 11);
-                loop {
-                    UpdateLerp();
-                    EVT_VAR(0) /= (float) 10;
-                    EVT_MAP_VAR(12) = (float) EVT_VAR(0);
-                    sleep 1;
-                    if (EVT_VAR(1) == 0) {
-                        break loop;
-                    }
-                }
-            }
-        }
-    }
-    loop 100 {
-        SetNpcScale(NPC_HUFF_N_PUFF0, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF1, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1);
-        SetNpcScale(NPC_HUFF_N_PUFF2, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1);
-        sleep 1;
-    }
-});
+EvtSource N(80242918) = {
+    EVT_SETF(EVT_MAP_VAR(11), EVT_FIXED(1.0))
+    EVT_SETF(EVT_MAP_VAR(12), EVT_FIXED(1.0))
+    EVT_CHILD_THREAD
+        EVT_USE_BUF(EVT_PTR(N(intTable_8024258C)))
+        EVT_LOOP(6)
+            EVT_CALL(PlaySoundAtNpc, 0, 0x20B6, 0)
+            EVT_BUF_READ3(EVT_VAR(6), EVT_VAR(7), EVT_VAR(8))
+            EVT_CALL(MakeLerp, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 11)
+            EVT_LOOP(0)
+                EVT_CALL(UpdateLerp)
+                EVT_DIVF(EVT_VAR(0), 10)
+                EVT_SETF(EVT_MAP_VAR(11), EVT_VAR(0))
+                EVT_WAIT_FRAMES(1)
+                EVT_IF_EQ(EVT_VAR(1), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+            EVT_END_LOOP
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_LOOP(0)
+            EVT_USE_BUF(EVT_PTR(N(intTable_802425D4)))
+            EVT_LOOP(2)
+                EVT_CALL(PlaySoundAtNpc, 0, 0x20B6, 0)
+                EVT_BUF_READ2(EVT_VAR(6), EVT_VAR(7))
+                EVT_CALL(MakeLerp, EVT_VAR(6), EVT_VAR(7), 4, 11)
+                EVT_LOOP(0)
+                    EVT_CALL(UpdateLerp)
+                    EVT_DIVF(EVT_VAR(0), 10)
+                    EVT_SETF(EVT_MAP_VAR(11), EVT_VAR(0))
+                    EVT_WAIT_FRAMES(1)
+                    EVT_IF_EQ(EVT_VAR(1), 0)
+                        EVT_BREAK_LOOP
+                    EVT_END_IF
+                EVT_END_LOOP
+            EVT_END_LOOP
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_CHILD_THREAD
+        EVT_USE_BUF(EVT_PTR(N(intTable_802425E4)))
+        EVT_LOOP(6)
+            EVT_BUF_READ3(EVT_VAR(6), EVT_VAR(7), EVT_VAR(8))
+            EVT_CALL(MakeLerp, EVT_VAR(6), EVT_VAR(7), EVT_VAR(8), 11)
+            EVT_LOOP(0)
+                EVT_CALL(UpdateLerp)
+                EVT_DIVF(EVT_VAR(0), 10)
+                EVT_SETF(EVT_MAP_VAR(12), EVT_VAR(0))
+                EVT_WAIT_FRAMES(1)
+                EVT_IF_EQ(EVT_VAR(1), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+            EVT_END_LOOP
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_LOOP(0)
+            EVT_USE_BUF(EVT_PTR(N(intTable_8024262C)))
+            EVT_LOOP(2)
+                EVT_BUF_READ2(EVT_VAR(6), EVT_VAR(7))
+                EVT_CALL(MakeLerp, EVT_VAR(6), EVT_VAR(7), 4, 11)
+                EVT_LOOP(0)
+                    EVT_CALL(UpdateLerp)
+                    EVT_DIVF(EVT_VAR(0), 10)
+                    EVT_SETF(EVT_MAP_VAR(12), EVT_VAR(0))
+                    EVT_WAIT_FRAMES(1)
+                    EVT_IF_EQ(EVT_VAR(1), 0)
+                        EVT_BREAK_LOOP
+                    EVT_END_IF
+                EVT_END_LOOP
+            EVT_END_LOOP
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_LOOP(100)
+        EVT_CALL(SetNpcScale, 0, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1)
+        EVT_CALL(SetNpcScale, 1, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1)
+        EVT_CALL(SetNpcScale, 2, EVT_MAP_VAR(11), EVT_MAP_VAR(12), 1)
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242D34) = SCRIPT({
-    parallel {
-        EVT_VAR(1) = 0;
-        loop {
-            EVT_VAR(0) = 3;
-            loop 15 {
-                SetNpcRotation(EVT_VAR(0), 0, EVT_VAR(1), 0);
-                EVT_VAR(0) += 1;
-            }
-            EVT_VAR(1) += 60;
-            if (EVT_VAR(1) > 360) {
-                EVT_VAR(1) += -360;
-            }
-            sleep 1;
-        }
-    }
-    buf_use N(intTable_8024249C);
-    EVT_VAR(8) = 3;
-    loop 14 {
-        buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3) EVT_VAR(4);
-        spawn {
-            RandInt(5, EVT_VAR(5));
-            sleep EVT_VAR(5);
-            SetNpcPos(EVT_VAR(8), EVT_VAR(1), EVT_VAR(2), -30);
-            RandInt(2, EVT_VAR(5));
-            EVT_VAR(5) += 8;
-            PlaySoundAtNpc(EVT_VAR(8), 0x3D5, 0);
-            NpcJump0(EVT_VAR(8), EVT_VAR(3), EVT_VAR(4), -15, EVT_VAR(5));
-            SetNpcPos(EVT_VAR(8), 0, -1000, 0);
-        }
-        EVT_VAR(8) += 1;
-    }
-    SetNpcPos(NPC_HUFF_N_PUFF0, 0, -1000, 0);
-    SetNpcPos(NPC_HUFF_N_PUFF1, 0, -1000, 0);
-    SetNpcPos(NPC_HUFF_N_PUFF2, 0, -1000, 0);
-    buf_read EVT_VAR(1) EVT_VAR(2) EVT_VAR(3) EVT_VAR(4);
-    sleep 5;
-    SetNpcPos(EVT_VAR(8), EVT_VAR(1), EVT_VAR(2), -30);
-    PlaySoundAtNpc(EVT_VAR(8), 0x3D6, 0);
-    NpcJump0(EVT_VAR(8), EVT_VAR(3), EVT_VAR(4), -15, 10);
-    SetNpcPos(EVT_VAR(8), 0, -1000, 0);
-});
+EvtSource N(80242D34) = {
+    EVT_CHILD_THREAD
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_LOOP(0)
+            EVT_SET(EVT_VAR(0), 3)
+            EVT_LOOP(15)
+                EVT_CALL(SetNpcRotation, EVT_VAR(0), 0, EVT_VAR(1), 0)
+                EVT_ADD(EVT_VAR(0), 1)
+            EVT_END_LOOP
+            EVT_ADD(EVT_VAR(1), 60)
+            EVT_IF_GT(EVT_VAR(1), 360)
+                EVT_ADD(EVT_VAR(1), -360)
+            EVT_END_IF
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+    EVT_END_CHILD_THREAD
+    EVT_USE_BUF(EVT_PTR(N(intTable_8024249C)))
+    EVT_SET(EVT_VAR(8), 3)
+    EVT_LOOP(14)
+        EVT_BUF_READ4(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_THREAD
+            EVT_CALL(RandInt, 5, EVT_VAR(5))
+            EVT_WAIT_FRAMES(EVT_VAR(5))
+            EVT_CALL(SetNpcPos, EVT_VAR(8), EVT_VAR(1), EVT_VAR(2), -30)
+            EVT_CALL(RandInt, 2, EVT_VAR(5))
+            EVT_ADD(EVT_VAR(5), 8)
+            EVT_CALL(PlaySoundAtNpc, EVT_VAR(8), 0x3D5, 0)
+            EVT_CALL(NpcJump0, EVT_VAR(8), EVT_VAR(3), EVT_VAR(4), -15, EVT_VAR(5))
+            EVT_CALL(SetNpcPos, EVT_VAR(8), 0, -1000, 0)
+        EVT_END_THREAD
+        EVT_ADD(EVT_VAR(8), 1)
+    EVT_END_LOOP
+    EVT_CALL(SetNpcPos, 0, 0, -1000, 0)
+    EVT_CALL(SetNpcPos, 1, 0, -1000, 0)
+    EVT_CALL(SetNpcPos, 2, 0, -1000, 0)
+    EVT_BUF_READ4(EVT_VAR(1), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(SetNpcPos, EVT_VAR(8), EVT_VAR(1), EVT_VAR(2), -30)
+    EVT_CALL(PlaySoundAtNpc, EVT_VAR(8), 0x3D6, 0)
+    EVT_CALL(NpcJump0, EVT_VAR(8), EVT_VAR(3), EVT_VAR(4), -15, 10)
+    EVT_CALL(SetNpcPos, EVT_VAR(8), 0, -1000, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80243010) = SCRIPT({
-    SetNpcAnimation(NPC_HUFF_N_PUFF1, NPC_ANIM_huff_n_puff_Palette_00_Anim_4);
-    SetNpcAnimation(NPC_HUFF_N_PUFF0, NPC_ANIM_huff_n_puff_Palette_00_Anim_5);
-    SetNpcAnimation(NPC_HUFF_N_PUFF2, NPC_ANIM_huff_n_puff_Palette_00_Anim_6);
-    GetNpcPos(NPC_HUFF_N_PUFF0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(0) += -15;
-    EVT_VAR(2) += 40;
-    SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamDistance(0, 350.0);
-    SetCamPitch(0, 17.0, -5.5);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    SpeakToPlayer(NPC_HUFF_N_PUFF0, NPC_ANIM_huff_n_puff_Palette_00_Anim_30, NPC_ANIM_huff_n_puff_Palette_00_Anim_5, 256, -30, 30, MESSAGE_ID(0x11, 0x00CE));
-    FadeOutMusic(0, 1500);
-    EVT_MAP_VAR(13) = 2;
-    GetNpcPos(NPC_HUFF_N_PUFF0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    spawn {
-        EVT_VAR(3) = EVT_VAR(0);
-        EVT_VAR(4) = EVT_VAR(0);
-        EVT_VAR(3) += -35;
-        EVT_VAR(4) += 35;
-        loop 3 {
-            PlayEffect(0x19, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 12;
-            PlayEffect(0x19, 0, EVT_VAR(3), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            EVT_VAR(3) += 7;
-            sleep 8;
-            PlayEffect(0x19, 0, EVT_VAR(4), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-            EVT_VAR(4) += -7;
-            sleep 14;
-        }
-        PlayEffect(0x19, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        ShakeCam(0, 0, 30, 1.5);
-    }
-    spawn {
-        sleep 30;
-        loop 10 {
-            PlayEffect(0x3A, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 40, 65, 12, 15, 0, 0, 0, 0, 0);
-            sleep 7;
-        }
-    }
-    spawn N(8024263C);
-    await N(80242918);
-    await N(80242D34);
-    sleep 10;
-});
+EvtSource N(80243010) = {
+    EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_huff_n_puff_Palette_00_Anim_4)
+    EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_huff_n_puff_Palette_00_Anim_5)
+    EVT_CALL(SetNpcAnimation, 2, NPC_ANIM_huff_n_puff_Palette_00_Anim_6)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(0), -15)
+    EVT_ADD(EVT_VAR(2), 40)
+    EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(350.0))
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(17.0), EVT_FIXED(-5.5))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_huff_n_puff_Palette_00_Anim_30, NPC_ANIM_huff_n_puff_Palette_00_Anim_5, 256, -30, 30, MESSAGE_ID(0x11, 0x00CE))
+    EVT_CALL(FadeOutMusic, 0, 1500)
+    EVT_SET(EVT_MAP_VAR(13), 2)
+    EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_THREAD
+        EVT_SET(EVT_VAR(3), EVT_VAR(0))
+        EVT_SET(EVT_VAR(4), EVT_VAR(0))
+        EVT_ADD(EVT_VAR(3), -35)
+        EVT_ADD(EVT_VAR(4), 35)
+        EVT_LOOP(3)
+            EVT_CALL(PlayEffect, 0x19, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(12)
+            EVT_CALL(PlayEffect, 0x19, 0, EVT_VAR(3), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_ADD(EVT_VAR(3), 7)
+            EVT_WAIT_FRAMES(8)
+            EVT_CALL(PlayEffect, 0x19, 0, EVT_VAR(4), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_ADD(EVT_VAR(4), -7)
+            EVT_WAIT_FRAMES(14)
+        EVT_END_LOOP
+        EVT_CALL(PlayEffect, 0x19, 2, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        EVT_CALL(ShakeCam, 0, 0, 30, EVT_FIXED(1.5))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_WAIT_FRAMES(30)
+        EVT_LOOP(10)
+            EVT_CALL(PlayEffect, 0x3A, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 40, 65, 12, 15, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(7)
+        EVT_END_LOOP
+    EVT_END_THREAD
+    EVT_EXEC(N(8024263C))
+    EVT_EXEC_WAIT(N(80242918))
+    EVT_EXEC_WAIT(N(80242D34))
+    EVT_WAIT_FRAMES(10)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80243428) = SCRIPT({
-0:
-    SetSelfVar(0, 0);
-    loop {
-        GetSelfVar(0, EVT_VAR(0));
-        if (EVT_VAR(0) != 0) {
-            break loop;
-        }
-        sleep 1;
-    }
-    EVT_MAP_VAR(13) = 1;
-    StartBossBattle(14);
-    goto 0;
-});
+EvtSource N(idle_80243428) = {
+    EVT_LABEL(0)
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_LOOP(0)
+        EVT_CALL(GetSelfVar, 0, EVT_VAR(0))
+        EVT_IF_NE(EVT_VAR(0), 0)
+            EVT_BREAK_LOOP
+        EVT_END_IF
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_SET(EVT_MAP_VAR(13), 1)
+    EVT_CALL(StartBossBattle, 14)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802434D8) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            SetEncounterStatusFlags(1, 1);
-            SetNpcYaw(NPC_PARTNER, 90);
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(3));
-            GetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            EVT_VAR(3) += -20;
-            SetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(3));
-            await N(80243010);
-            sleep 50;
-            EVT_MAP_VAR(10) = 1;
-            spawn N(80240E3C);
-        }
-    }
-});
+EvtSource N(defeat_802434D8) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_CALL(SetEncounterStatusFlags, 1, 1)
+            EVT_CALL(SetNpcYaw, NPC_PARTNER, 90)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(3))
+            EVT_CALL(GetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_ADD(EVT_VAR(3), -20)
+            EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(3))
+            EVT_EXEC_WAIT(N(80243010))
+            EVT_WAIT_FRAMES(50)
+            EVT_SET(EVT_MAP_VAR(10), 1)
+            EVT_EXEC(N(80240E3C))
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802435D4) = SCRIPT({
+EvtSource N(defeat_802435D4) = {
+    EVT_RETURN
+    EVT_END
+};
 
-});
+EvtSource N(init_802435E4) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 56)
+        EVT_CALL(SetEnemyFlagBits, -1, 4194304, 1)
+        EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80243428)))
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802434D8)))
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_2)
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802435E4) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_HUFF_N_PUFF) {
-        SetEnemyFlagBits(-1, 4194304, 1);
-        BindNpcIdle(NPC_SELF, N(idle_80243428));
-        BindNpcDefeat(NPC_SELF, N(defeat_802434D8));
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_2);
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_80243684) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 56)
+        EVT_CALL(SetEnemyFlagBits, -1, 4194304, 1)
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802435D4)))
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_1)
+        EVT_EXEC(N(80242290))
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80243684) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_HUFF_N_PUFF) {
-        SetEnemyFlagBits(-1, 4194304, 1);
-        BindNpcDefeat(NPC_SELF, N(defeat_802435D4));
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_1);
-        spawn N(80242290);
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
+EvtSource N(init_8024371C) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 56)
+        EVT_CALL(SetEnemyFlagBits, -1, 4194304, 1)
+        EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802435D4)))
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_19)
+    EVT_ELSE
+        EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_8024371C) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DEFEATED_HUFF_N_PUFF) {
-        SetEnemyFlagBits(-1, 4194304, 1);
-        BindNpcDefeat(NPC_SELF, N(defeat_802435D4));
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_huff_n_puff_Palette_00_Anim_19);
-    } else {
-        SetNpcPos(NPC_SELF, 0, -1000, 0);
-    }
-});
-
-EvtSource N(init_802437A8) = SCRIPT({
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_tuff_puff_Palette_00_Anim_B);
-    SetNpcJumpscale(NPC_SELF, 0);
-});
+EvtSource N(init_802437A8) = {
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_tuff_puff_Palette_00_Anim_B)
+    EVT_CALL(SetNpcJumpscale, NPC_SELF, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 s32 N(extraAnimationList_802437E0)[] = {
     NPC_ANIM_huff_n_puff_Palette_00_Anim_0,

--- a/src/world/area_flo/flo_22/CEC240.c
+++ b/src/world/area_flo/flo_22/CEC240.c
@@ -20,42 +20,47 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_22_tattle },
 };
 
-EvtSource N(802402E0) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(802402E0) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_80240350) = EXIT_WALK_SCRIPT(60,  0, "flo_03",  1);
 
-EvtSource N(802403AC) = SCRIPT({
-    bind N(exitWalk_80240350) TRIGGER_FLOOR_ABOVE 0;
-});
+EvtSource N(802403AC) = {
+    EVT_BIND_TRIGGER(N(exitWalk_80240350), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80240DE4));
-    spawn N(80241F6C);
-    spawn N(80241528);
-    GetEntryID(EVT_VAR(0));
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    EVT_VAR(0) = N(802403AC);
-    spawn EnterWalk;
-    spawn N(80240E24);
-    await N(802402E0);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CEC240)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80240DE4)))
+    EVT_EXEC(N(80241F6C))
+    EVT_EXEC(N(80241528))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(802403AC)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC(N(80240E24))
+    EVT_EXEC_WAIT(N(802402E0))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CEC240))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_518)[] = {
     0x00000000, 0x00000000,
@@ -67,101 +72,104 @@ NpcSettings N(npcSettings_80240520) = {
     .level = 99,
 };
 
-EvtSource N(idle_8024054C) = SCRIPT({
-    EVT_MAP_VAR(10) = 0;
-    loop {
-        match EVT_MAP_VAR(10) {
-            == 0 {}
-            == 1 {
-                SetPlayerAnimation(0x1002E);
-                EVT_MAP_VAR(10) = 0;
-                StartBattle();
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_8024054C) = {
+    EVT_SET(EVT_MAP_VAR(10), 0)
+    EVT_LOOP(0)
+        EVT_SWITCH(EVT_MAP_VAR(10))
+            EVT_CASE_EQ(0)
+            EVT_CASE_EQ(1)
+                EVT_CALL(SetPlayerAnimation, 65582)
+                EVT_SET(EVT_MAP_VAR(10), 0)
+                EVT_CALL(StartBattle)
+        EVT_END_SWITCH
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_802405E4) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            spawn {
-                sleep 25;
-                SetNpcPos(NPC_SELF, 0, -1000, 0);
-                SetNpcFlagBits(NPC_SELF, ((0x00000002)), FALSE);
-            }
-            DoNpcDefeat();
-        }
-        == 1 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-        == 2 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_bzzap_Palette_00_Anim_1);
-            SetNpcPos(NPC_SELF, 30, 60, 0);
-            sleep 10;
-            SetNpcJumpscale(NPC_SELF, 0);
-            NpcJump0(NPC_SELF, 30, 0, 0, 15);
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(defeat_802405E4) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_THREAD
+                EVT_WAIT_FRAMES(25)
+                EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+                EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_2)), FALSE)
+            EVT_END_THREAD
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_bzzap_Palette_00_Anim_1)
+            EVT_CALL(SetNpcPos, NPC_SELF, 30, 60, 0)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SetNpcJumpscale, NPC_SELF, 0)
+            EVT_CALL(NpcJump0, NPC_SELF, 30, 0, 0, 15)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80240740) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(idle_8024054C));
-    BindNpcDefeat(NPC_SELF, N(defeat_802405E4));
-});
+EvtSource N(init_80240740) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_8024054C)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_802405E4)))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(idle_80240778) = SCRIPT({
-    EVT_MAP_VAR(11) = 0;
-    loop {
-        match EVT_MAP_VAR(11) {
-            == 0 {}
-            == 1 {
-                SetPlayerAnimation(0x1002E);
-                EVT_MAP_VAR(11) = 0;
-                StartBattle();
-            }
-        }
-        sleep 1;
-    }
-});
+EvtSource N(idle_80240778) = {
+    EVT_SET(EVT_MAP_VAR(11), 0)
+    EVT_LOOP(0)
+        EVT_SWITCH(EVT_MAP_VAR(11))
+            EVT_CASE_EQ(0)
+            EVT_CASE_EQ(1)
+                EVT_CALL(SetPlayerAnimation, 65582)
+                EVT_SET(EVT_MAP_VAR(11), 0)
+                EVT_CALL(StartBattle)
+        EVT_END_SWITCH
+        EVT_WAIT_FRAMES(1)
+    EVT_END_LOOP
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(defeat_80240810) = SCRIPT({
-    GetBattleOutcome(EVT_VAR(0));
-    match EVT_VAR(0) {
-        == 0 {
-            spawn {
-                sleep 25;
-                SetNpcPos(NPC_SELF, 0, -1000, 0);
-                SetNpcFlagBits(NPC_SELF, ((0x00000002)), FALSE);
-            }
-            DoNpcDefeat();
-        }
-        == 1 {
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-        == 3 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_dayzee_Palette_00_Anim_1);
-            sleep 10;
-            SetNpcJumpscale(NPC_SELF, 2.0);
-            NpcJump0(NPC_SELF, 30, 0, 0, 15);
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-        == 2 {
-            SetNpcAnimation(NPC_SELF, NPC_ANIM_dayzee_Palette_00_Anim_1);
-            sleep 10;
-            SetNpcJumpscale(NPC_SELF, 2.0);
-            NpcJump0(NPC_SELF, 30, 0, 0, 15);
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(defeat_80240810) = {
+    EVT_CALL(GetBattleOutcome, EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+            EVT_THREAD
+                EVT_WAIT_FRAMES(25)
+                EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+                EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_2)), FALSE)
+            EVT_END_THREAD
+            EVT_CALL(DoNpcDefeat)
+        EVT_CASE_EQ(1)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_CASE_EQ(3)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_dayzee_Palette_00_Anim_1)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(2.0))
+            EVT_CALL(NpcJump0, NPC_SELF, 30, 0, 0, 15)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+        EVT_CASE_EQ(2)
+            EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_dayzee_Palette_00_Anim_1)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SetNpcJumpscale, NPC_SELF, EVT_FIXED(2.0))
+            EVT_CALL(NpcJump0, NPC_SELF, 30, 0, 0, 15)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802409CC) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(idle_80240778));
-    BindNpcDefeat(NPC_SELF, N(defeat_80240810));
-});
+EvtSource N(init_802409CC) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(idle_80240778)))
+    EVT_CALL(BindNpcDefeat, NPC_SELF, EVT_PTR(N(defeat_80240810)))
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80240A04) = {
     .id = NPC_BZZAP,
@@ -248,120 +256,126 @@ s32 N(itemList_80240E10)[] = {
     ITEM_NONE,
 };
 
-EvtSource N(80240E24) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    sleep 20;
-    ShowMessageAtScreenPos(MESSAGE_ID(0x11, 0x00DB), 300, 120);
-    sleep 10;
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80240E24) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_WAIT_FRAMES(20)
+    EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x11, 0x00DB), 300, 120)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240E84) = SCRIPT({
-    SetPlayerAnimation(0x6000E);
-    spawn {
-        GetPlayerPos(EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-        EVT_VAR(6) = 35;
-        EVT_VAR(5) = 5;
-        MakeItemEntity(EVT_VAR(8), EVT_VAR(2), EVT_VAR(6), 0, 1, 0);
-        EVT_VAR(7) = EVT_VAR(0);
-        MakeLerp(EVT_VAR(2), 35, 20, 5);
-        loop {
-            UpdateLerp();
-            SetItemPos(EVT_VAR(7), EVT_VAR(0), EVT_VAR(6), 0);
-            EVT_VAR(6) += EVT_VAR(5);
-            EVT_VAR(5) += -1;
-            sleep 1;
-            if (EVT_VAR(1) == 0) {
-                break loop;
-            }
-        }
-        RemoveItemEntity(EVT_VAR(7));
-    }
-    sleep 10;
-    PlaySoundAt(0x302, 0, 35, 0, 0);
-    sleep 5;
-    SetPlayerAnimation(ANIM_10002);
-    sleep 10;
-});
+EvtSource N(80240E84) = {
+    EVT_CALL(SetPlayerAnimation, 393230)
+    EVT_THREAD
+        EVT_CALL(GetPlayerPos, EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+        EVT_SET(EVT_VAR(6), 35)
+        EVT_SET(EVT_VAR(5), 5)
+        EVT_CALL(MakeItemEntity, EVT_VAR(8), EVT_VAR(2), EVT_VAR(6), 0, 1, 0)
+        EVT_SET(EVT_VAR(7), EVT_VAR(0))
+        EVT_CALL(MakeLerp, EVT_VAR(2), 35, 20, 5)
+        EVT_LOOP(0)
+            EVT_CALL(UpdateLerp)
+            EVT_CALL(SetItemPos, EVT_VAR(7), EVT_VAR(0), EVT_VAR(6), 0)
+            EVT_ADD(EVT_VAR(6), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(5), -1)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_BREAK_LOOP
+            EVT_END_IF
+        EVT_END_LOOP
+        EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(PlaySoundAt, 0x302, 0, 35, 0, 0)
+    EVT_WAIT_FRAMES(5)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_WAIT_FRAMES(10)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241028) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    DisablePlayerInput(FALSE);
-    ShowConsumableChoicePopup();
-    CloseChoicePopup();
-    DisablePlayerInput(TRUE);
-    EVT_VAR(8) = EVT_VAR(0);
-    match EVT_VAR(8) {
-        <= -1 {}
-        <= 0 {
-            ShowMessageAtScreenPos(MESSAGE_ID(0x1D, 0x015C), 160, 40);
-        }
-        == 158 {
-            await N(80240E84);
-            RemoveItemAt(EVT_VAR(1));
-            if (EVT_SAVE_FLAG(1395) == 0) {
-                ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00DD), 35, 35, 0);
-                EVT_SAVE_FLAG(1395) = 1;
-                MakeItemEntity(ITEM_FLOWER_SAVER_B, -35, 0, 0, 0, EVT_SAVE_FLAG(1392));
-                EVT_VAR(7) = EVT_VAR(0);
-                SetNpcFlagBits(NPC_BZZAP, ((0x00000002)), TRUE);
-                SetNpcFlagBits(NPC_BZZAP, ((NPC_FLAG_HAS_SHADOW)), FALSE);
-                SetNpcPos(NPC_BZZAP, 35, 0, 0);
-                SetNpcJumpscale(NPC_BZZAP, 1.0);
-                spawn {
-                    NpcJump0(NPC_BZZAP, -53, 0, 0, 25);
-                    NpcJump0(NPC_BZZAP, -73, 0, 0, 15);
-                    NpcJump0(NPC_BZZAP, -83, 0, 0, 8);
-                }
-                loop 53 {
-                    GetNpcPos(NPC_BZZAP, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                    SetItemPos(EVT_VAR(7), EVT_VAR(1), EVT_VAR(2), EVT_VAR(3));
-                    sleep 1;
-                }
-                SetNpcPos(NPC_BZZAP, 0, -1000, 0);
-                SetNpcFlagBits(NPC_BZZAP, ((0x00000002)), FALSE);
-                SetNpcFlagBits(NPC_BZZAP, ((NPC_FLAG_HAS_SHADOW)), TRUE);
-            } else {
-                ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00DE), 35, 35, 0);
-            }
-        } else {
-            await N(80240E84);
-            RemoveItemAt(EVT_VAR(1));
-            ShowMessageAtWorldPos(MESSAGE_ID(0x11, 0x00DC), 35, 35, 0);
-            RandInt(1, EVT_VAR(1));
-            if (EVT_VAR(1) == 0) {
-                SetNpcJumpscale(NPC_BZZAP, 0.0);
-                NpcFacePlayer(NPC_BZZAP, 0);
-                sleep 1;
-                SetNpcPos(NPC_BZZAP, 30, 0, 0);
-                SetNpcAnimation(NPC_BZZAP, NPC_ANIM_bzzap_Palette_00_Anim_1);
-                NpcJump0(NPC_BZZAP, 30, 60, 0, 20);
-                sleep 10;
-                SetNpcAnimation(NPC_BZZAP, NPC_ANIM_bzzap_Palette_00_Anim_4);
-                GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                EVT_VAR(1) += 20;
-                NpcJump0(NPC_BZZAP, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 5);
-                EVT_MAP_VAR(10) = 1;
-            } else {
-                SetNpcPos(NPC_DAYZEE, 30, 0, 0);
-                SetNpcAnimation(NPC_DAYZEE, NPC_ANIM_dayzee_Palette_00_Anim_E);
-                GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-                EVT_VAR(1) += 20;
-                SetNpcJumpscale(NPC_DAYZEE, 2.0);
-                NpcJump0(NPC_DAYZEE, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 20);
-                EVT_MAP_VAR(11) = 1;
-            }
-        }
-    }
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80241028) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_CALL(CloseChoicePopup)
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_SET(EVT_VAR(8), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(8))
+        EVT_CASE_LE(-1)
+        EVT_CASE_LE(0)
+            EVT_CALL(ShowMessageAtScreenPos, MESSAGE_ID(0x1D, 0x015C), 160, 40)
+        EVT_CASE_EQ(158)
+            EVT_EXEC_WAIT(N(80240E84))
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_IF_EQ(EVT_SAVE_FLAG(1395), 0)
+                EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00DD), 35, 35, 0)
+                EVT_SET(EVT_SAVE_FLAG(1395), 1)
+                EVT_CALL(MakeItemEntity, ITEM_FLOWER_SAVER_B, -35, 0, 0, 0, EVT_SAVE_FLAG(1392))
+                EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), TRUE)
+                EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_HAS_SHADOW)), FALSE)
+                EVT_CALL(SetNpcPos, 0, 35, 0, 0)
+                EVT_CALL(SetNpcJumpscale, 0, EVT_FIXED(1.0))
+                EVT_THREAD
+                    EVT_CALL(NpcJump0, 0, -53, 0, 0, 25)
+                    EVT_CALL(NpcJump0, 0, -73, 0, 0, 15)
+                    EVT_CALL(NpcJump0, 0, -83, 0, 0, 8)
+                EVT_END_THREAD
+                EVT_LOOP(53)
+                    EVT_CALL(GetNpcPos, 0, EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_CALL(SetItemPos, EVT_VAR(7), EVT_VAR(1), EVT_VAR(2), EVT_VAR(3))
+                    EVT_WAIT_FRAMES(1)
+                EVT_END_LOOP
+                EVT_CALL(SetNpcPos, 0, 0, -1000, 0)
+                EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_2)), FALSE)
+                EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_HAS_SHADOW)), TRUE)
+            EVT_ELSE
+                EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00DE), 35, 35, 0)
+            EVT_END_IF
+        EVT_CASE_DEFAULT
+            EVT_EXEC_WAIT(N(80240E84))
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(ShowMessageAtWorldPos, MESSAGE_ID(0x11, 0x00DC), 35, 35, 0)
+            EVT_CALL(RandInt, 1, EVT_VAR(1))
+            EVT_IF_EQ(EVT_VAR(1), 0)
+                EVT_CALL(SetNpcJumpscale, 0, EVT_FIXED(0.0))
+                EVT_CALL(NpcFacePlayer, 0, 0)
+                EVT_WAIT_FRAMES(1)
+                EVT_CALL(SetNpcPos, 0, 30, 0, 0)
+                EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_bzzap_Palette_00_Anim_1)
+                EVT_CALL(NpcJump0, 0, 30, 60, 0, 20)
+                EVT_WAIT_FRAMES(10)
+                EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_bzzap_Palette_00_Anim_4)
+                EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_ADD(EVT_VAR(1), 20)
+                EVT_CALL(NpcJump0, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 5)
+                EVT_SET(EVT_MAP_VAR(10), 1)
+            EVT_ELSE
+                EVT_CALL(SetNpcPos, 1, 30, 0, 0)
+                EVT_CALL(SetNpcAnimation, 1, NPC_ANIM_dayzee_Palette_00_Anim_E)
+                EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+                EVT_ADD(EVT_VAR(1), 20)
+                EVT_CALL(SetNpcJumpscale, 1, EVT_FIXED(2.0))
+                EVT_CALL(NpcJump0, 1, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 20)
+                EVT_SET(EVT_MAP_VAR(11), 1)
+            EVT_END_IF
+    EVT_END_SWITCH
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241528) = SCRIPT({
-    bind_padlock N(80241028) TRIGGER_WALL_PRESS_A 9 N(itemList_80240E10);
-    if (EVT_SAVE_FLAG(1395) == 1) {
-        MakeItemEntity(ITEM_FLOWER_SAVER_B, -83, 0, 0, 0, EVT_SAVE_FLAG(1392));
-    }
-});
+EvtSource N(80241528) = {
+    EVT_BIND_PADLOCK(N(80241028), TRIGGER_WALL_PRESS_A, 9, EVT_PTR(N(itemList_80240E10)), 0, 1)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1395), 1)
+        EVT_CALL(MakeItemEntity, ITEM_FLOWER_SAVER_B, -83, 0, 0, 0, EVT_SAVE_FLAG(1392))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_1594)[] = {
     0x00000000, 0x00000000, 0x00000000,

--- a/src/world/area_flo/flo_22/CEC290.c
+++ b/src/world/area_flo/flo_22/CEC290.c
@@ -24,11 +24,13 @@ ShakeTreeConfig N(tree2) = {
 
 Vec4f N(triggerCoord_80241F5C) = { 150.0f, 0.0f, 135.0f, 0.0f };
 
-EvtSource N(80241F6C) = SCRIPT({
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 14;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80241F28);
-    EVT_VAR(0) = N(tree2);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 16;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80241F5C);
-});
+EvtSource N(80241F6C) = {
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 14, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80241F28)), 1, 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree2)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 16, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80241F5C)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_flo/flo_23/CEE2A0.c
+++ b/src/world/area_flo/flo_23/CEE2A0.c
@@ -28,88 +28,95 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_23_tattle },
 };
 
-EvtSource N(80240D30) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80240D30) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240DA0) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80240DA0) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024104C) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  2);
 
 EvtSource N(exitWalk_802410A8) = EXIT_WALK_SCRIPT(60,  1, "flo_11",  0);
 
-EvtSource N(80241104) = SCRIPT({
-    bind N(exitWalk_802410A8) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_8024104C) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80241104) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802410A8), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024104C), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80242568));
-    await N(makeEntities);
-    EVT_VAR(0) = -290;
-    EVT_VAR(1) = -190;
-    EVT_VAR(2) = 480;
-    EVT_VAR(3) = -90;
-    EVT_VAR(4) = 0;
-    spawn N(80240DA0);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80241104);
-    spawn EnterWalk;
-    await N(80240D30);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CEE260)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80242568)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_SET(EVT_VAR(0), -290)
+    EVT_SET(EVT_VAR(1), -190)
+    EVT_SET(EVT_VAR(2), 480)
+    EVT_SET(EVT_VAR(3), -90)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240DA0))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80241104)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80240D30))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CEE260))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_12D8)[] = {
     0x00000000, 0x00000000,
@@ -129,34 +136,37 @@ s32 N(D_80241310_CEF570) = {
     0x00000000,
 };
 
-EvtSource N(80241314) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowConsumableChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_802402C0_CEE520)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80241314) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_802402C0_CEE520), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80241448) = SCRIPT({
-    N(func_802402F8_CEE558)(EVT_VAR(0));
-    bind_padlock N(80241314) 0x10 0 0x802426E0; // TODO: fix raw ptr
-    N(func_8024026C_CEE4CC)(EVT_VAR(0));
-});
+EvtSource N(80241448) = {
+    EVT_CALL(N(func_802402F8_CEE558), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80241314), 0x10, 0, EVT_PTR(N(D_802426E0)), 0, 1)
+    EVT_CALL(N(func_8024026C_CEE4CC), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcAISettings N(npcAISettings_80241498) = {
     .moveSpeed = 1.5f,
@@ -171,13 +181,15 @@ NpcAISettings N(npcAISettings_80241498) = {
     .unk_2C = 3,
 };
 
-EvtSource N(npcAI_802414C8) = SCRIPT({
-    SetSelfVar(2, 3);
-    SetSelfVar(3, 18);
-    SetSelfVar(5, 3);
-    SetSelfVar(7, 4);
-    N(func_80240728_CEE988)(N(npcAISettings_80241498));
-});
+EvtSource N(npcAI_802414C8) = {
+    EVT_CALL(SetSelfVar, 2, 3)
+    EVT_CALL(SetSelfVar, 3, 18)
+    EVT_CALL(SetSelfVar, 5, 3)
+    EVT_CALL(SetSelfVar, 7, 4)
+    EVT_CALL(N(func_80240728_CEE988), EVT_PTR(N(npcAISettings_80241498)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80241538) = {
     .height = 21,
@@ -188,159 +200,155 @@ NpcSettings N(npcSettings_80241538) = {
     .level = 19,
 };
 
-EvtSource N(interact_80241564) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    if (EVT_SAVE_FLAG(1365) == 0) {
-        GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamDistance(0, 350);
-        SetCamPitch(0, 18.5, -7.5);
-        SetCamSpeed(0, 4.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0,
-                      MESSAGE_ID(0x11, 0x0049));
-        SetPlayerAnimation(ANIM_THINKING);
-        N(func_80240C9C_CEEEFC)();
-        EVT_VAR(0) = N(D_80242850);
-        EVT_VAR(1) = 2;
-        await N(80241448);
-        match EVT_VAR(0) {
-            <= 0 {
-                SetPlayerAnimation(ANIM_STAND_STILL);
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004A));
-            } else {
-                EVT_VAR(8) = EVT_VAR(0);
-                N(func_80240C2C_CEEE8C)(EVT_VAR(0));
-                MakeItemEntity(EVT_VAR(8), 385, 20, -34, 1, 0);
-                EVT_VAR(7) = EVT_VAR(0);
-                PlaySoundAtNpc(NPC_SELF, SOUND_2095, 0);
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_3);
-                sleep 20;
-                RemoveItemEntity(EVT_VAR(7));
-                match EVT_VAR(8) {
-                    == 158 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004D));
-                        PlaySoundAtNpc(NPC_SELF, 0x21C, 0);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0);
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_7);
-                        PlaySoundAtCollider(13, 457, 0);
-                        ModifyColliderFlags(0, 13, 0x7FFFFE00);
-                        MakeLerp(0, 100, 30, 1);
-                        loop {
-                            UpdateLerp();
-                            EVT_VAR(8) = (float) EVT_VAR(0);
-                            EVT_VAR(9) = (float) EVT_VAR(0);
-                            EVT_VAR(8) *= 0.5;
-                            EVT_VAR(9) *= 1.2001953125;
-                            RotateModel(59, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(60, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(61, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(55, EVT_VAR(9), 0, 1, 0);
-                            RotateModel(56, EVT_VAR(9), 0, 1, 0);
-                            RotateModel(57, EVT_VAR(9), 0, 1, 0);
-                            sleep 1;
-                            if (EVT_VAR(1) != 1) {
-                                break loop;
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_5);
-                        EVT_SAVE_FLAG(1365) = 1;
-                    }
-                    == 159 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004C));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1);
-                    }
-                    == 160 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004C));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1);
-                    } else {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0,
-                                      MESSAGE_ID(0x11, 0x004B));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_6);
-                        PlaySoundAtNpc(NPC_SELF, 0x2096, 0);
-                        MakeItemEntity(EVT_VAR(8), 375, 20, 0, 1, 0);
-                        EVT_VAR(7) = EVT_VAR(0);
-                        sleep 5;
-                        GetAngleToPlayer(-1, EVT_VAR(0));
-                        if (EVT_VAR(0) < 180) {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = -0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 0.900390625;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += 380.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -30.0;
-                                N(func_80240B68_CEEDC8)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) != 1) {
-                                    break loop;
-                                }
-                            }
-                        } else {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = 0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 1.0;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += 390.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -30.0;
-                                N(func_80240B68_CEEDC8)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) != 1) {
-                                    break loop;
-                                }
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1);
-                        RemoveItemEntity(EVT_VAR(7));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0);
-                    }
-                }
-            }
-        }
-        spawn {
-            ResetCam(0, 6.0);
-        }
-        sleep 10;
-    } else {
-        if (EVT_STORY_PROGRESS < STORY_CH6_STAR_SPIRIT_RESCUED) {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x004E));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x004F));
-        }
-    }
-    DisablePlayerInput(FALSE);
-    unbind;
-});
+EvtSource N(interact_80241564) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1365), 0)
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamDistance, 0, 350)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.5), EVT_FIXED(-7.5))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x0049))
+        EVT_CALL(SetPlayerAnimation, ANIM_THINKING)
+        EVT_CALL(N(func_80240C9C_CEEEFC))
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(D_80242850)))
+        EVT_SET(EVT_VAR(1), 2)
+        EVT_EXEC_WAIT(N(80241448))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_LE(0)
+                EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004A))
+            EVT_CASE_DEFAULT
+                EVT_SET(EVT_VAR(8), EVT_VAR(0))
+                EVT_CALL(N(func_80240C2C_CEEE8C), EVT_VAR(0))
+                EVT_CALL(MakeItemEntity, EVT_VAR(8), 385, 20, -34, 1, 0)
+                EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2095, 0)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_3)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                EVT_SWITCH(EVT_VAR(8))
+                    EVT_CASE_EQ(158)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004D))
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x21C, 0)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0)
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_7)
+                        EVT_CALL(PlaySoundAtCollider, 13, 457, 0)
+                        EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+                        EVT_CALL(MakeLerp, 0, 100, 30, 1)
+                        EVT_LOOP(0)
+                            EVT_CALL(UpdateLerp)
+                            EVT_SETF(EVT_VAR(8), EVT_VAR(0))
+                            EVT_SETF(EVT_VAR(9), EVT_VAR(0))
+                            EVT_MULF(EVT_VAR(8), EVT_FIXED(0.5))
+                            EVT_MULF(EVT_VAR(9), EVT_FIXED(1.2))
+                            EVT_CALL(RotateModel, 59, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 60, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 61, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 55, EVT_VAR(9), 0, 1, 0)
+                            EVT_CALL(RotateModel, 56, EVT_VAR(9), 0, 1, 0)
+                            EVT_CALL(RotateModel, 57, EVT_VAR(9), 0, 1, 0)
+                            EVT_WAIT_FRAMES(1)
+                            EVT_IF_NE(EVT_VAR(1), 1)
+                                EVT_BREAK_LOOP
+                            EVT_END_IF
+                        EVT_END_LOOP
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_5)
+                        EVT_SET(EVT_SAVE_FLAG(1365), 1)
+                    EVT_CASE_EQ(159)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004C))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1)
+                    EVT_CASE_EQ(160)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004C))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1)
+                    EVT_CASE_DEFAULT
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_4, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0, MESSAGE_ID(0x11, 0x004B))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_6)
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x2096, 0)
+                        EVT_CALL(MakeItemEntity, EVT_VAR(8), 375, 20, 0, 1, 0)
+                        EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(GetAngleToPlayer, -1, EVT_VAR(0))
+                        EVT_IF_LT(EVT_VAR(0), 180)
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(-0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(0.9))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(380.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-30.0))
+                                EVT_CALL(N(func_80240B68_CEEDC8), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_NE(EVT_VAR(1), 1)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_ELSE
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(1.0))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(390.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-30.0))
+                                EVT_CALL(N(func_80240B68_CEEDC8), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_NE(EVT_VAR(1), 1)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_END_IF
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1)
+                        EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_1)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_00_Anim_2, NPC_ANIM_gate_flower_Palette_00_Anim_1, 0)
+                EVT_END_SWITCH
+        EVT_END_SWITCH
+        EVT_THREAD
+            EVT_CALL(ResetCam, 0, EVT_FIXED(6.0))
+        EVT_END_THREAD
+        EVT_WAIT_FRAMES(10)
+    EVT_ELSE
+        EVT_IF_LT(EVT_SAVE_VAR(0), 57)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0, MESSAGE_ID(0x11, 0x004E))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_9, NPC_ANIM_gate_flower_Palette_00_Anim_8, 0, MESSAGE_ID(0x11, 0x004F))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80241E70) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_80241564));
-    if (EVT_SAVE_FLAG(1365) == 1) {
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_5);
-        ModifyColliderFlags(0, 13, 0x7FFFFE00);
-        RotateModel(59, 50, 0, -1, 0);
-        RotateModel(60, 50, 0, -1, 0);
-        RotateModel(61, 50, 0, -1, 0);
-        RotateModel(55, 120, 0, 1, 0);
-        RotateModel(56, 120, 0, 1, 0);
-        RotateModel(57, 120, 0, 1, 0);
-    }
-});
+EvtSource N(init_80241E70) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80241564)))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1365), 1)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_00_Anim_5)
+        EVT_CALL(ModifyColliderFlags, 0, 13, 0x7FFFFE00)
+        EVT_CALL(RotateModel, 59, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 60, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 61, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 55, 120, 0, 1, 0)
+        EVT_CALL(RotateModel, 56, 120, 0, 1, 0)
+        EVT_CALL(RotateModel, 57, 120, 0, 1, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80241F98) = {
     .id = NPC_GATE_FLOWER,
@@ -446,14 +454,16 @@ static s32 N(pad_2598)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA0C4, 100, 60, 5, 0, MAKE_ENTITY_END);
-    MakeEntity(0x802EA588, 100, 145, 0, 0, ITEM_SHOOTING_STAR, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1409));
-    MakeEntity(0x802EA588, 25, 60, 0, 0, ITEM_COIN, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1408));
-    MakeEntity(0x802EAA54, -50, 0, 0, 90, ITEM_LETTER07, MAKE_ENTITY_END);
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, EVT_PTR(D_802EA0C4), 100, 60, 5, 0, MAKE_ENTITY_END)
+    EVT_CALL(MakeEntity, 0x802EA588, 100, 145, 0, 0, 131, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1409))
+    EVT_CALL(MakeEntity, 0x802EA588, 25, 60, 0, 0, 343, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1408))
+    EVT_CALL(MakeEntity, 0x802EAA54, -50, 0, 0, 90, 60, MAKE_ENTITY_END)
+    EVT_RETURN
+    EVT_END
+};
 
 #include "world/common/GetNpcCollisionHeight.inc.c"
 

--- a/src/world/area_flo/flo_23/flo_23.h
+++ b/src/world/area_flo/flo_23/flo_23.h
@@ -6,6 +6,8 @@
 
 #define NAMESPACE flo_23
 
+extern s32 D_802EA0C4;
+
 ApiStatus N(AddPlayerHandsOffset)(Evt* script, s32 isInitialCall);
 ApiStatus N(func_80240000_CEE260)(Evt* script, s32 isInitialCall);
 ApiStatus N(func_8024026C_CEE4CC)(Evt* script, s32 isInitialCall);

--- a/src/world/area_flo/flo_24/CF0980.c
+++ b/src/world/area_flo/flo_24/CF0980.c
@@ -15,111 +15,119 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_24_tattle },
 };
 
-EvtSource N(80240600) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-    } else {
-        SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-    }
-    if (EVT_STORY_PROGRESS >= STORY_CH6_FILLED_SPRING_WITH_WATER) {
-        PlaySound(0x80000022);
-    }
-});
+EvtSource N(80240600) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+    EVT_ELSE
+        EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_IF
+    EVT_IF_GE(EVT_SAVE_VAR(0), 49)
+        EVT_CALL(PlaySound, 0x80000022)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80240690) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80240690) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024093C) = EXIT_WALK_SCRIPT(60,  0, "flo_08",  1);
 
 EvtSource N(exitWalk_80240998) = EXIT_WALK_SCRIPT(60,  1, "flo_10",  0);
 
-EvtSource N(802409F4) = SCRIPT({
-    bind N(exitWalk_8024093C) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_80240998) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(802409F4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_8024093C), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80240998), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    await N(makeEntities);
-    MakeTransformGroup(93);
-    MakeTransformGroup(100);
-    spawn N(80241728);
-    spawn N(80241ABC);
-    ModifyColliderFlags(3, 29, 0x00000004);
-    ModifyColliderFlags(3, 27, 0x00000004);
-    ModifyColliderFlags(3, 28, 0x00000004);
-    ModifyColliderFlags(0, 29, 0x00080000);
-    ModifyColliderFlags(0, 27, 0x00080000);
-    ModifyColliderFlags(0, 28, 0x00080000);
-    ModifyColliderFlags(3, 23, 0x00000001);
-    EVT_VAR(0) = -480;
-    EVT_VAR(1) = -350;
-    EVT_VAR(2) = -65;
-    EVT_VAR(3) = -260;
-    EVT_VAR(4) = 0;
-    spawn N(80240690);
-    EVT_VAR(0) = 100;
-    EVT_VAR(1) = -350;
-    EVT_VAR(2) = 480;
-    EVT_VAR(3) = -260;
-    EVT_VAR(4) = 0;
-    spawn N(80240690);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) == 2) {
-        spawn N(8024183C);
-        spawn N(802409F4);
-    } else {
-        EVT_VAR(0) = N(802409F4);
-        spawn EnterWalk;
-    }
-    await N(80240600);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CF0940)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_CALL(MakeTransformGroup, 93)
+    EVT_CALL(MakeTransformGroup, 100)
+    EVT_EXEC(N(80241728))
+    EVT_EXEC(N(80241ABC))
+    EVT_CALL(ModifyColliderFlags, 3, 29, 0x00000004)
+    EVT_CALL(ModifyColliderFlags, 3, 27, 0x00000004)
+    EVT_CALL(ModifyColliderFlags, 3, 28, 0x00000004)
+    EVT_CALL(ModifyColliderFlags, 0, 29, 0x00080000)
+    EVT_CALL(ModifyColliderFlags, 0, 27, 0x00080000)
+    EVT_CALL(ModifyColliderFlags, 0, 28, 0x00080000)
+    EVT_CALL(ModifyColliderFlags, 3, 23, 0x00000001)
+    EVT_SET(EVT_VAR(0), -480)
+    EVT_SET(EVT_VAR(1), -350)
+    EVT_SET(EVT_VAR(2), -65)
+    EVT_SET(EVT_VAR(3), -260)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240690))
+    EVT_SET(EVT_VAR(0), 100)
+    EVT_SET(EVT_VAR(1), -350)
+    EVT_SET(EVT_VAR(2), 480)
+    EVT_SET(EVT_VAR(3), -260)
+    EVT_SET(EVT_VAR(4), 0)
+    EVT_EXEC(N(80240690))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_EQ(EVT_VAR(0), 2)
+        EVT_EXEC(N(8024183C))
+        EVT_EXEC(N(802409F4))
+    EVT_ELSE
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(802409F4)))
+        EVT_EXEC(EnterWalk)
+    EVT_END_IF
+    EVT_EXEC_WAIT(N(80240600))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CF0940))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_D38)[] = {
     0x00000000, 0x00000000,
@@ -163,72 +171,76 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_80241718) = { 1.0f, 0.0f, -192.0f, 0.0f };
 
-EvtSource N(80241728) = SCRIPT({
-    EVT_AREA_FLAG(31) = 0;
-    EVT_AREA_FLAG(32) = 0;
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 13;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_80241718);
-});
+EvtSource N(80241728) = {
+    EVT_SET(EVT_AREA_FLAG(31), 0)
+    EVT_SET(EVT_AREA_FLAG(32), 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 13, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_80241718)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(updateTexturePan_802417A0) = SCRIPT({
-    group 0;
-    if (EVT_VAR(5) == 1) {
-        if (EVT_VAR(6) == 1) {
-            if (EVT_VAR(7) == 1) {
-                if (EVT_VAR(8) == 1) {
-                    N(UnkTexturePanFunc)();
-                    return;
-                }
-            }
-        }
-    }
-    N(UnkTexturePanFunc2)();
-});
+EvtSource N(updateTexturePan_802417A0) = {
+    EVT_SET_GROUP(0)
+    EVT_IF_EQ(EVT_VAR(5), 1)
+        EVT_IF_EQ(EVT_VAR(6), 1)
+            EVT_IF_EQ(EVT_VAR(7), 1)
+                EVT_IF_EQ(EVT_VAR(8), 1)
+                    EVT_CALL(N(UnkTexturePanFunc))
+                    EVT_RETURN
+                EVT_END_IF
+            EVT_END_IF
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(N(UnkTexturePanFunc2))
+    EVT_RETURN
+    EVT_END
+};
 
 extern const char N(flo_10_name_hack)[];
 
 // BUG: missing END_SPAWN_THREADs
 #ifdef NON_EQUIVALENT
-EvtSource N(8024183C) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    TranslateGroup(100, 0, 45, 0);
-    UseSettingsFrom(0, 170, 0, 160);
-    SetPanTarget(0, 170, -90, 160);
-    SetCamDistance(0, 800);
-    SetCamPitch(0, 18.5, -7.5);
-    SetCamPosA(0, -300.0, 200.0);
-    SetCamPosB(0, 300.0, -150.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    PlaySound(0x80000050);
-    spawn {
-        MakeLerp(80, 90, 10, 0);
-    0:
-        UpdateLerp();
-        RotateModel(101, EVT_VAR(0), 1, 0, 0);
-        RotateModel(103, EVT_VAR(0), 1, 0, 0);
-        if (EVT_VAR(1) == 1) {
-            sleep 1;
-            goto 0;
-        }
-        spawn {
-            MakeLerp(45, 100, 150, 0);
-            loop {
-                UpdateLerp();
-                TranslateGroup(100, 0, EVT_VAR(0), 0);
-                sleep 1;
-                if (EVT_VAR(1) == 0) {
-                    break loop;
-                }
-            }
-            sleep 30;
-            EVT_STORY_PROGRESS = STORY_CH6_FILLED_SPRING_WITH_WATER;
-            GotoMap("flo_10", 2);
-            sleep 100;
-        }
-    }
-});
+EvtSource N(8024183C) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(TranslateGroup, 100, 0, 45, 0)
+    EVT_CALL(UseSettingsFrom, 0, 170, 0, 160)
+    EVT_CALL(SetPanTarget, 0, 170, -90, 160)
+    EVT_CALL(SetCamDistance, 0, 800)
+    EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.5), EVT_FIXED(-7.5))
+    EVT_CALL(SetCamPosA, 0, EVT_FIXED(-300.0), EVT_FIXED(200.0))
+    EVT_CALL(SetCamPosB, 0, EVT_FIXED(300.0), EVT_FIXED(-150.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(PlaySound, 0x80000050)
+    EVT_THREAD
+        EVT_CALL(MakeLerp, 80, 90, 10, 0)
+        EVT_LABEL(0)
+        EVT_CALL(UpdateLerp)
+        EVT_CALL(RotateModel, 101, EVT_VAR(0), 1, 0, 0)
+        EVT_CALL(RotateModel, 103, EVT_VAR(0), 1, 0, 0)
+        EVT_IF_EQ(EVT_VAR(1), 1)
+            EVT_WAIT_FRAMES(1)
+            EVT_GOTO(0)
+        EVT_END_IF
+        EVT_THREAD
+            EVT_CALL(MakeLerp, 45, 100, 150, 0)
+            EVT_LOOP(0)
+                EVT_CALL(UpdateLerp)
+                EVT_CALL(TranslateGroup, 100, 0, EVT_VAR(0), 0)
+                EVT_WAIT_FRAMES(1)
+                EVT_IF_EQ(EVT_VAR(1), 0)
+                    EVT_BREAK_LOOP
+                EVT_END_IF
+            EVT_END_LOOP
+            EVT_WAIT_FRAMES(30)
+            EVT_SET(EVT_SAVE_VAR(0), 49)
+            EVT_CALL(GotoMap, EVT_PTR(UNK_STR_80242280), 2)
+            EVT_WAIT_FRAMES(100)
+            EVT_RETURN
+            EVT_END
+};
 #else
 EvtSource N(8024183C) = {
     EVT_CMD(EVT_OP_CALL, EVT_PTR(DisablePlayerInput), 1),
@@ -271,135 +283,139 @@ EvtSource N(8024183C) = {
         };
 #endif
 
-EvtSource N(80241ABC) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH6_FILLED_SPRING_WITH_WATER) {
-        EnableGroup(94, 0);
-        ModifyColliderFlags(0, 30, 0x7FFFFE00);
-    } else {
-        EnableGroup(65, 0);
-    }
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) != 2) {
-        EnableGroup(105, 0);
-    }
-    EnableTexPanning(89, 1);
-    EnableTexPanning(97, 1);
-    EnableTexPanning(90, 1);
-    EnableTexPanning(98, 1);
-    EnableTexPanning(91, 1);
-    EnableTexPanning(92, 1);
-    EnableTexPanning(101, 1);
-    EnableTexPanning(103, 1);
-    EnableTexPanning(99, 1);
-    spawn {
-        EVT_VAR(0) = 1;
-        EVT_VAR(1) = 140;
-        EVT_VAR(2) = -80;
-        EVT_VAR(3) = -70;
-        EVT_VAR(4) = 100;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 1;
-        EVT_VAR(8) = 1;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-    spawn {
-        EVT_VAR(0) = 2;
-        EVT_VAR(1) = -70;
-        EVT_VAR(2) = 100;
-        EVT_VAR(3) = 100;
-        EVT_VAR(4) = -40;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 1;
-        EVT_VAR(8) = 1;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-    spawn {
-        EVT_VAR(0) = 3;
-        EVT_VAR(1) = 0;
-        EVT_VAR(2) = -800;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-    spawn {
-        EVT_VAR(0) = 4;
-        EVT_VAR(1) = 0;
-        EVT_VAR(2) = -800;
-        EVT_VAR(3) = -200;
-        EVT_VAR(4) = 100;
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 1;
-        EVT_VAR(8) = 1;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-    spawn {
-        EVT_VAR(0) = 5;
-        EVT_VAR(1) = 0;
-        EVT_VAR(2) = -2500;
-        EVT_VAR(3) = 0;
-        EVT_VAR(4) = 0;
-        EVT_VAR(5) = 0;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 0;
-        EVT_VAR(8) = 0;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-    spawn {
-        EVT_VAR(0) = 6;
-        EVT_VAR(1) = 0;
-        EVT_VAR(2) = -2500;
-        EVT_VAR(3) = -200;
-        EVT_VAR(4) = 100;
-        EVT_VAR(5) = 1;
-        EVT_VAR(6) = 1;
-        EVT_VAR(7) = 1;
-        EVT_VAR(8) = 1;
-        EVT_VAR(9) = 0;
-        EVT_VAR(10) = 0;
-        EVT_VAR(11) = 0;
-        EVT_VAR(12) = 0;
-        spawn N(updateTexturePan_802417A0);
-    }
-});
+EvtSource N(80241ABC) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), 49)
+        EVT_CALL(EnableGroup, 94, 0)
+        EVT_CALL(ModifyColliderFlags, 0, 30, 0x7FFFFE00)
+    EVT_ELSE
+        EVT_CALL(EnableGroup, 65, 0)
+    EVT_END_IF
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 2)
+        EVT_CALL(EnableGroup, 105, 0)
+    EVT_END_IF
+    EVT_CALL(EnableTexPanning, 89, 1)
+    EVT_CALL(EnableTexPanning, 97, 1)
+    EVT_CALL(EnableTexPanning, 90, 1)
+    EVT_CALL(EnableTexPanning, 98, 1)
+    EVT_CALL(EnableTexPanning, 91, 1)
+    EVT_CALL(EnableTexPanning, 92, 1)
+    EVT_CALL(EnableTexPanning, 101, 1)
+    EVT_CALL(EnableTexPanning, 103, 1)
+    EVT_CALL(EnableTexPanning, 99, 1)
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 1)
+        EVT_SET(EVT_VAR(1), 140)
+        EVT_SET(EVT_VAR(2), -80)
+        EVT_SET(EVT_VAR(3), -70)
+        EVT_SET(EVT_VAR(4), 100)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 1)
+        EVT_SET(EVT_VAR(8), 1)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(1), -70)
+        EVT_SET(EVT_VAR(2), 100)
+        EVT_SET(EVT_VAR(3), 100)
+        EVT_SET(EVT_VAR(4), -40)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 1)
+        EVT_SET(EVT_VAR(8), 1)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 3)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(2), -800)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 4)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(2), -800)
+        EVT_SET(EVT_VAR(3), -200)
+        EVT_SET(EVT_VAR(4), 100)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 1)
+        EVT_SET(EVT_VAR(8), 1)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 5)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(2), -2500)
+        EVT_SET(EVT_VAR(3), 0)
+        EVT_SET(EVT_VAR(4), 0)
+        EVT_SET(EVT_VAR(5), 0)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 0)
+        EVT_SET(EVT_VAR(8), 0)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_THREAD
+        EVT_SET(EVT_VAR(0), 6)
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_SET(EVT_VAR(2), -2500)
+        EVT_SET(EVT_VAR(3), -200)
+        EVT_SET(EVT_VAR(4), 100)
+        EVT_SET(EVT_VAR(5), 1)
+        EVT_SET(EVT_VAR(6), 1)
+        EVT_SET(EVT_VAR(7), 1)
+        EVT_SET(EVT_VAR(8), 1)
+        EVT_SET(EVT_VAR(9), 0)
+        EVT_SET(EVT_VAR(10), 0)
+        EVT_SET(EVT_VAR(11), 0)
+        EVT_SET(EVT_VAR(12), 0)
+        EVT_EXEC(N(updateTexturePan_802417A0))
+    EVT_END_THREAD
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_21A4)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA564, -325, 60, -140, 0, ITEM_DIZZY_DIAL, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1393));
-    MakeEntity(0x802EA588, 325, 60, -140, 0, ITEM_MAPLE_SYRUP, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(1394));
-    MakeEntity(0x802EAB04, 335, 0, -160, 0, ITEM_MAP, MAKE_ENTITY_END);
-    AssignPanelFlag(EVT_SAVE_FLAG(1406));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA564, -325, 60, -140, 0, 154, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1393))
+    EVT_CALL(MakeEntity, 0x802EA588, 325, 60, -140, 0, 163, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(1394))
+    EVT_CALL(MakeEntity, 0x802EAB04, 335, 0, -160, 0, 8, MAKE_ENTITY_END)
+    EVT_CALL(AssignPanelFlag, EVT_SAVE_FLAG(1406))
+    EVT_RETURN
+    EVT_END
+};
 
 const char N(flo_10_name_hack)[] = "flo_10";

--- a/src/world/area_flo/flo_25/CF2C10.c
+++ b/src/world/area_flo/flo_25/CF2C10.c
@@ -28,90 +28,97 @@ MapConfig N(config) = {
     .tattle = { MSG_flo_25_tattle },
 };
 
-EvtSource N(80242330) = SCRIPT({
-    match EVT_STORY_PROGRESS {
-        < STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8);
-        } else {
-            SetMusicTrack(0, SONG_FLOWER_FIELDS_SUNNY, 0, 8);
-        }
-    }
-});
+EvtSource N(80242330) = {
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_LT(53)
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_CLOUDY, 0, 8)
+        EVT_CASE_DEFAULT
+            EVT_CALL(SetMusicTrack, 0, SONG_FLOWER_FIELDS_SUNNY, 0, 8)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802423A0) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(802423A0) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
 EvtSource N(exitWalk_8024264C) = EXIT_WALK_SCRIPT(60,  0, "flo_00",  3);
 
 EvtSource N(exitWalk_802426A8) = EXIT_WALK_SCRIPT(60,  1, "flo_07",  0);
 
-EvtSource N(80242704) = SCRIPT({
-    bind N(exitWalk_802426A8) TRIGGER_FLOOR_ABOVE 0;
-    bind N(exitWalk_8024264C) TRIGGER_FLOOR_ABOVE 4;
-});
+EvtSource N(80242704) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802426A8), TRIGGER_FLOOR_ABOVE, 0, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024264C), TRIGGER_FLOOR_ABOVE, 4, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_FLOWER_FIELDS;
-    SetSpriteShading(-1);
-    SetCamLeadPlayer(0, 0);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    MakeNpcs(0, N(npcGroupList_80243C5C));
-    await N(makeEntities);
-    spawn N(80244D0C);
-    spawn N(802446BC);
-    EVT_VAR(0) = -270;
-    EVT_VAR(1) = -190;
-    EVT_VAR(2) = 640;
-    EVT_VAR(3) = -60;
-    EVT_VAR(4) = 60;
-    spawn N(802423A0);
-    ModifyColliderFlags(0, 1, 0x7FFFFE00);
-    ModifyColliderFlags(0, 5, 0x7FFFFE00);
-    EVT_VAR(0) = N(80242704);
-    spawn EnterWalk;
-    await N(80242330);
-    if (EVT_STORY_PROGRESS >= STORY_CH6_DESTROYED_PUFF_PUFF_MACHINE) {
-        N(func_80240000_CF2BD0)();
-    }
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 38)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80243C5C)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC(N(80244D0C))
+    EVT_EXEC(N(802446BC))
+    EVT_SET(EVT_VAR(0), -270)
+    EVT_SET(EVT_VAR(1), -190)
+    EVT_SET(EVT_VAR(2), 640)
+    EVT_SET(EVT_VAR(3), -60)
+    EVT_SET(EVT_VAR(4), 60)
+    EVT_EXEC(N(802423A0))
+    EVT_CALL(ModifyColliderFlags, 0, 1, 0x7FFFFE00)
+    EVT_CALL(ModifyColliderFlags, 0, 5, 0x7FFFFE00)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80242704)))
+    EVT_EXEC(EnterWalk)
+    EVT_EXEC_WAIT(N(80242330))
+    EVT_IF_GE(EVT_SAVE_VAR(0), 53)
+        EVT_CALL(N(func_80240000_CF2BD0))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802428F0) = {
     .height = 56,
@@ -137,13 +144,15 @@ NpcAISettings N(npcAISettings_80242934) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80242964) = SCRIPT({
-    SetSelfVar(0, 1);
-    SetSelfVar(5, 0);
-    SetSelfVar(6, 0);
-    SetSelfVar(1, 600);
-    N(func_80241944_CF4514)(N(npcAISettings_80242934));
-});
+EvtSource N(npcAI_80242964) = {
+    EVT_CALL(SetSelfVar, 0, 1)
+    EVT_CALL(SetSelfVar, 5, 0)
+    EVT_CALL(SetSelfVar, 6, 0)
+    EVT_CALL(SetSelfVar, 1, 600)
+    EVT_CALL(N(func_80241944_CF4514), EVT_PTR(N(npcAISettings_80242934)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802429D4) = {
     .height = 24,
@@ -169,13 +178,15 @@ NpcAISettings N(npcAISettings_80242A00) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80242A30) = SCRIPT({
-    SetSelfVar(0, 0);
-    SetSelfVar(5, -630);
-    SetSelfVar(6, 50);
-    SetSelfVar(1, 200);
-    N(func_8024134C_CF3F1C)(N(npcAISettings_80242A00));
-});
+EvtSource N(npcAI_80242A30) = {
+    EVT_CALL(SetSelfVar, 0, 0)
+    EVT_CALL(SetSelfVar, 5, -630)
+    EVT_CALL(SetSelfVar, 6, 50)
+    EVT_CALL(SetSelfVar, 1, 200)
+    EVT_CALL(N(func_8024134C_CF3F1C), EVT_PTR(N(npcAISettings_80242A00)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_80242AA0) = {
     .height = 26,
@@ -194,188 +205,187 @@ s32 N(D_80242AD0_CF56A0) = {
     0x00000000,
 };
 
-EvtSource N(80242AD4) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(1);
-    ShowConsumableChoicePopup();
-    EVT_VAR(10) = EVT_VAR(0);
-    match EVT_VAR(0) {
-        == 0 {}
-        == -1 {}
-        else {
-            RemoveItemAt(EVT_VAR(1));
-            GetPlayerPos(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            N(AddPlayerHandsOffset)(EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-            MakeItemEntity(EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0);
-            SetPlayerAnimation(0x60005);
-            sleep 30;
-            SetPlayerAnimation(ANIM_10002);
-            RemoveItemEntity(EVT_VAR(0));
-        }
-    }
-    N(func_80241DAC_CF497C)(EVT_VAR(10));
-    CloseChoicePopup();
-    unbind;
-});
+EvtSource N(80242AD4) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(1))
+    EVT_CALL(ShowConsumableChoicePopup)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SWITCH(EVT_VAR(0))
+        EVT_CASE_EQ(0)
+        EVT_CASE_EQ(-1)
+        EVT_CASE_DEFAULT
+            EVT_CALL(RemoveItemAt, EVT_VAR(1))
+            EVT_CALL(GetPlayerPos, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(N(AddPlayerHandsOffset), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+            EVT_CALL(MakeItemEntity, EVT_VAR(0), EVT_VAR(3), EVT_VAR(4), EVT_VAR(5), 1, 0)
+            EVT_CALL(SetPlayerAnimation, 393221)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SetPlayerAnimation, ANIM_10002)
+            EVT_CALL(RemoveItemEntity, EVT_VAR(0))
+    EVT_END_SWITCH
+    EVT_CALL(N(func_80241DAC_CF497C), EVT_VAR(10))
+    EVT_CALL(CloseChoicePopup)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80242C08) = SCRIPT({
-    N(func_80241DE4_CF49B4)(EVT_VAR(0));
-    bind_padlock N(80242AD4) 0x10 0 N(D_80244A20);
-    N(func_80241D58_CF4928)(EVT_VAR(0));
-});
+EvtSource N(80242C08) = {
+    EVT_CALL(N(func_80241DE4_CF49B4), EVT_VAR(0))
+    EVT_BIND_PADLOCK(N(80242AD4), 0x10, 0, EVT_PTR(N(D_80244A20)), 0, 1)
+    EVT_CALL(N(func_80241D58_CF4928), EVT_VAR(0))
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(interact_80242C58) = SCRIPT({
-    DisablePlayerInput(TRUE);
-    if (EVT_SAVE_FLAG(1363) == 0) {
-        GetNpcPos(NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetCamDistance(0, 350);
-        SetCamPitch(0, 18.5, -7.5);
-        SetCamSpeed(0, 4.0);
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0,
-                      MESSAGE_ID(0x11, 0x003B));
-        SetPlayerAnimation(ANIM_THINKING);
-        N(func_80241FB4_CF4B84)();
-        EVT_VAR(0) = 0x80245110;
-        EVT_VAR(1) = 0;
-        await N(80242C08);
-        match EVT_VAR(0) {
-            <= 0 {
-                SetPlayerAnimation(ANIM_STAND_STILL);
-                SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003C));
-            } else {
-                EVT_VAR(8) = EVT_VAR(0);
-                N(func_80241F44_CF4B14)(EVT_VAR(0));
-                MakeItemEntity(EVT_VAR(8), 505, 20, -24, 1, 0);
-                EVT_VAR(7) = EVT_VAR(0);
-                PlaySoundAtNpc(NPC_SELF, SOUND_2095, 0);
-                SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_3);
-                sleep 20;
-                RemoveItemEntity(EVT_VAR(7));
-                match EVT_VAR(8) {
-                    == 159 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003F));
-                        PlaySoundAtNpc(NPC_SELF, 0x21C, 0);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0);
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_7);
-                        PlaySoundAtCollider(14, 457, 0);
-                        ModifyColliderFlags(0, 14, 0x7FFFFE00);
-                        MakeLerp(0, 100, 30, 1);
-                        loop {
-                            UpdateLerp();
-                            EVT_VAR(8) = (float) EVT_VAR(0);
-                            EVT_VAR(9) = (float) EVT_VAR(0);
-                            EVT_VAR(8) *= 0.5;
-                            EVT_VAR(9) *= 1.2001953125;
-                            RotateModel(86, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(87, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(88, EVT_VAR(8), 0, -1, 0);
-                            RotateModel(82, EVT_VAR(9), 0, 1, 0);
-                            RotateModel(83, EVT_VAR(9), 0, 1, 0);
-                            RotateModel(84, EVT_VAR(9), 0, 1, 0);
-                            sleep 1;
-                            if (EVT_VAR(1) != 1) {
-                                break loop;
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_5);
-                        EVT_SAVE_FLAG(1363) = 1;
-                    }
-                    == 160 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003E));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1);
-                    }
-                    == 158 {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003E));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1);
-                    } else {
-                        SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0,
-                                      MESSAGE_ID(0x11, 0x003D));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_6);
-                        PlaySoundAtNpc(NPC_SELF, 0x2096, 0);
-                        MakeItemEntity(EVT_VAR(8), -125, 20, 0, 1, 0);
-                        EVT_VAR(7) = EVT_VAR(0);
-                        sleep 5;
-                        GetAngleToPlayer(-1, EVT_VAR(0));
-                        if (EVT_VAR(0) < 180) {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = -0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 0.900390625;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += 500.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -20.0;
-                                N(func_80241E80_CF4A50)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) != 1) {
-                                    break loop;
-                                }
-                            }
-                        } else {
-                            MakeLerp(0, 100, 7, 0);
-                            loop {
-                                UpdateLerp();
-                                EVT_VAR(2) = 0.5;
-                                EVT_VAR(3) = -0.19921875;
-                                EVT_VAR(4) = 0.900390625;
-                                EVT_VAR(2) *= (float) EVT_VAR(0);
-                                EVT_VAR(3) *= (float) EVT_VAR(0);
-                                EVT_VAR(4) *= (float) EVT_VAR(0);
-                                EVT_VAR(2) += 510.0;
-                                EVT_VAR(3) += 15.0;
-                                EVT_VAR(4) += -20.0;
-                                N(func_80241E80_CF4A50)(EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4));
-                                sleep 1;
-                                if (EVT_VAR(1) != 1) {
-                                    break loop;
-                                }
-                            }
-                        }
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1);
-                        RemoveItemEntity(EVT_VAR(7));
-                        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1);
-                        EndSpeech(-1, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0);
-                    }
-                }
-            }
-        }
-        spawn {
-            ResetCam(0, 6.0);
-        }
-        sleep 10;
-    } else {
-        if (EVT_STORY_PROGRESS < STORY_CH6_STAR_SPIRIT_RESCUED) {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x0040));
-        } else {
-            SpeakToPlayer(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0,
-                          MESSAGE_ID(0x11, 0x0041));
-        }
-    }
-    DisablePlayerInput(FALSE);
-    unbind;
-});
+EvtSource N(interact_80242C58) = {
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_IF_EQ(EVT_SAVE_FLAG(1363), 0)
+        EVT_CALL(GetNpcPos, NPC_SELF, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetCamDistance, 0, 350)
+        EVT_CALL(SetCamPitch, 0, EVT_FIXED(18.5), EVT_FIXED(-7.5))
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(4.0))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003B))
+        EVT_CALL(SetPlayerAnimation, ANIM_THINKING)
+        EVT_CALL(N(func_80241FB4_CF4B84))
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(D_80245110)))
+        EVT_SET(EVT_VAR(1), 0)
+        EVT_EXEC_WAIT(N(80242C08))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_LE(0)
+                EVT_CALL(SetPlayerAnimation, ANIM_STAND_STILL)
+                EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003C))
+            EVT_CASE_DEFAULT
+                EVT_SET(EVT_VAR(8), EVT_VAR(0))
+                EVT_CALL(N(func_80241F44_CF4B14), EVT_VAR(0))
+                EVT_CALL(MakeItemEntity, EVT_VAR(8), 505, 20, -24, 1, 0)
+                EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                EVT_CALL(PlaySoundAtNpc, NPC_SELF, SOUND_2095, 0)
+                EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_3)
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                EVT_SWITCH(EVT_VAR(8))
+                    EVT_CASE_EQ(159)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003F))
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x21C, 0)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0)
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_7)
+                        EVT_CALL(PlaySoundAtCollider, 14, 457, 0)
+                        EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+                        EVT_CALL(MakeLerp, 0, 100, 30, 1)
+                        EVT_LOOP(0)
+                            EVT_CALL(UpdateLerp)
+                            EVT_SETF(EVT_VAR(8), EVT_VAR(0))
+                            EVT_SETF(EVT_VAR(9), EVT_VAR(0))
+                            EVT_MULF(EVT_VAR(8), EVT_FIXED(0.5))
+                            EVT_MULF(EVT_VAR(9), EVT_FIXED(1.2))
+                            EVT_CALL(RotateModel, 86, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 87, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 88, EVT_VAR(8), 0, -1, 0)
+                            EVT_CALL(RotateModel, 82, EVT_VAR(9), 0, 1, 0)
+                            EVT_CALL(RotateModel, 83, EVT_VAR(9), 0, 1, 0)
+                            EVT_CALL(RotateModel, 84, EVT_VAR(9), 0, 1, 0)
+                            EVT_WAIT_FRAMES(1)
+                            EVT_IF_NE(EVT_VAR(1), 1)
+                                EVT_BREAK_LOOP
+                            EVT_END_IF
+                        EVT_END_LOOP
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_5)
+                        EVT_SET(EVT_SAVE_FLAG(1363), 1)
+                    EVT_CASE_EQ(160)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003E))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1)
+                    EVT_CASE_EQ(158)
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003E))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1)
+                    EVT_CASE_DEFAULT
+                        EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_4, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0, MESSAGE_ID(0x11, 0x003D))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_6)
+                        EVT_CALL(PlaySoundAtNpc, NPC_SELF, 0x2096, 0)
+                        EVT_CALL(MakeItemEntity, EVT_VAR(8), -125, 20, 0, 1, 0)
+                        EVT_SET(EVT_VAR(7), EVT_VAR(0))
+                        EVT_WAIT_FRAMES(5)
+                        EVT_CALL(GetAngleToPlayer, -1, EVT_VAR(0))
+                        EVT_IF_LT(EVT_VAR(0), 180)
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(-0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(0.9))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(500.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-20.0))
+                                EVT_CALL(N(func_80241E80_CF4A50), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_NE(EVT_VAR(1), 1)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_ELSE
+                            EVT_CALL(MakeLerp, 0, 100, 7, 0)
+                            EVT_LOOP(0)
+                                EVT_CALL(UpdateLerp)
+                                EVT_SETF(EVT_VAR(2), EVT_FIXED(0.5))
+                                EVT_SETF(EVT_VAR(3), EVT_FIXED(-0.2))
+                                EVT_SETF(EVT_VAR(4), EVT_FIXED(0.9))
+                                EVT_MULF(EVT_VAR(2), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(3), EVT_VAR(0))
+                                EVT_MULF(EVT_VAR(4), EVT_VAR(0))
+                                EVT_ADDF(EVT_VAR(2), EVT_FIXED(510.0))
+                                EVT_ADDF(EVT_VAR(3), EVT_FIXED(15.0))
+                                EVT_ADDF(EVT_VAR(4), EVT_FIXED(-20.0))
+                                EVT_CALL(N(func_80241E80_CF4A50), EVT_VAR(7), EVT_VAR(2), EVT_VAR(3), EVT_VAR(4))
+                                EVT_WAIT_FRAMES(1)
+                                EVT_IF_NE(EVT_VAR(1), 1)
+                                    EVT_BREAK_LOOP
+                                EVT_END_IF
+                            EVT_END_LOOP
+                        EVT_END_IF
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1)
+                        EVT_CALL(RemoveItemEntity, EVT_VAR(7))
+                        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_1)
+                        EVT_CALL(EndSpeech, -1, NPC_ANIM_gate_flower_Palette_01_Anim_2, NPC_ANIM_gate_flower_Palette_01_Anim_1, 0)
+                EVT_END_SWITCH
+        EVT_END_SWITCH
+        EVT_THREAD
+            EVT_CALL(ResetCam, 0, EVT_FIXED(6.0))
+        EVT_END_THREAD
+        EVT_WAIT_FRAMES(10)
+    EVT_ELSE
+        EVT_IF_LT(EVT_SAVE_VAR(0), 57)
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0, MESSAGE_ID(0x11, 0x0040))
+        EVT_ELSE
+            EVT_CALL(SpeakToPlayer, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_9, NPC_ANIM_gate_flower_Palette_01_Anim_8, 0, MESSAGE_ID(0x11, 0x0041))
+        EVT_END_IF
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_UNBIND
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_80243564) = SCRIPT({
-    BindNpcInteract(NPC_SELF, N(interact_80242C58));
-    if (EVT_SAVE_FLAG(1363) == 1) {
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_5);
-        ModifyColliderFlags(0, 14, 0x7FFFFE00);
-        RotateModel(86, 50, 0, -1, 0);
-        RotateModel(87, 50, 0, -1, 0);
-        RotateModel(88, 50, 0, -1, 0);
-        RotateModel(82, 120, 0, 1, 0);
-        RotateModel(83, 120, 0, 1, 0);
-        RotateModel(84, 120, 0, 1, 0);
-    }
-});
+EvtSource N(init_80243564) = {
+    EVT_CALL(BindNpcInteract, NPC_SELF, EVT_PTR(N(interact_80242C58)))
+    EVT_IF_EQ(EVT_SAVE_FLAG(1363), 1)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_gate_flower_Palette_01_Anim_5)
+        EVT_CALL(ModifyColliderFlags, 0, 14, 0x7FFFFE00)
+        EVT_CALL(RotateModel, 86, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 87, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 88, 50, 0, -1, 0)
+        EVT_CALL(RotateModel, 82, 120, 0, 1, 0)
+        EVT_CALL(RotateModel, 83, 120, 0, 1, 0)
+        EVT_CALL(RotateModel, 84, 120, 0, 1, 0)
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_8024368C) = {
     .id = NPC_GATE_FLOWER,
@@ -493,10 +503,12 @@ static s32 N(pad_3C8C) = {
     0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EAB04, -390, 0, 0, 0, ITEM_MAP, MAKE_ENTITY_END);
-    AssignPanelFlag(EVT_SAVE_FLAG(1407));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EAB04, -390, 0, 0, 0, 8, MAKE_ENTITY_END)
+    EVT_CALL(AssignPanelFlag, EVT_SAVE_FLAG(1407))
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_3CD8)[] = {
     0x00000000, 0x00000000,

--- a/src/world/area_flo/flo_25/CF4BC0.c
+++ b/src/world/area_flo/flo_25/CF4BC0.c
@@ -38,134 +38,142 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(triggerCoord_802446AC) = { -388.0f, 0.0f, -92.0f, 0.0f };
 
-EvtSource N(802446BC) = SCRIPT({
-    EVT_AREA_FLAG(33) = 0;
-    EVT_AREA_FLAG(34) = 0;
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 12;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(triggerCoord_802446AC);
-});
+EvtSource N(802446BC) = {
+    EVT_SET(EVT_AREA_FLAG(33), 0)
+    EVT_SET(EVT_AREA_FLAG(34), 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 12, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(triggerCoord_802446AC)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_4734)[] = {
     0x00000000, 0x00000000, 0x00000000,
 };
 
-EvtSource N(80244740) = SCRIPT({
-    group 11;
-    EVT_VAR(10) = EVT_VAR(0);
-    EVT_VAR(11) = EVT_VAR(1);
-    EVT_VAR(12) = EVT_VAR(2);
-    EVT_VAR(13) = EVT_VAR(3);
-    EVT_VAR(14) = EVT_VAR(4);
-    EVT_VAR(12) -= EVT_VAR(0);
-    EVT_VAR(13) -= EVT_VAR(1);
-    EVT_VAR(0) = (float) EVT_VAR(12);
-    EVT_VAR(0) /= 100.0;
-    EVT_VAR(15) = 100.0;
-    EVT_VAR(15) /= (float) EVT_VAR(0);
-    EVT_VAR(15) += 11;
-    EVT_VAR(5) = 200;
-    EVT_VAR(5) /= EVT_VAR(15);
-    EVT_VAR(5) += 1;
-    loop EVT_VAR(5) {
-        RandInt(EVT_VAR(12), EVT_VAR(0));
-        RandInt(EVT_VAR(13), EVT_VAR(1));
-        RandInt(199, EVT_VAR(2));
-        EVT_VAR(3) = 210;
-        EVT_VAR(3) -= EVT_VAR(2);
-        EVT_VAR(0) += EVT_VAR(10);
-        EVT_VAR(1) += EVT_VAR(11);
-        EVT_VAR(2) += EVT_VAR(14);
-        PlayEffect(0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    }
-    sleep EVT_VAR(15);
-0:
-    RandInt(EVT_VAR(12), EVT_VAR(0));
-    RandInt(EVT_VAR(13), EVT_VAR(1));
-    EVT_VAR(0) += EVT_VAR(10);
-    EVT_VAR(1) += EVT_VAR(11);
-    PlayEffect(0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-    sleep EVT_VAR(15);
-    goto 0;
-});
+EvtSource N(80244740) = {
+    EVT_SET_GROUP(11)
+    EVT_SET(EVT_VAR(10), EVT_VAR(0))
+    EVT_SET(EVT_VAR(11), EVT_VAR(1))
+    EVT_SET(EVT_VAR(12), EVT_VAR(2))
+    EVT_SET(EVT_VAR(13), EVT_VAR(3))
+    EVT_SET(EVT_VAR(14), EVT_VAR(4))
+    EVT_SUB(EVT_VAR(12), EVT_VAR(0))
+    EVT_SUB(EVT_VAR(13), EVT_VAR(1))
+    EVT_SETF(EVT_VAR(0), EVT_VAR(12))
+    EVT_DIVF(EVT_VAR(0), EVT_FIXED(100.0))
+    EVT_SETF(EVT_VAR(15), EVT_FIXED(100.0))
+    EVT_DIVF(EVT_VAR(15), EVT_VAR(0))
+    EVT_ADD(EVT_VAR(15), 11)
+    EVT_SET(EVT_VAR(5), 200)
+    EVT_DIV(EVT_VAR(5), EVT_VAR(15))
+    EVT_ADD(EVT_VAR(5), 1)
+    EVT_LOOP(EVT_VAR(5))
+        EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+        EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+        EVT_CALL(RandInt, 199, EVT_VAR(2))
+        EVT_SET(EVT_VAR(3), 210)
+        EVT_SUB(EVT_VAR(3), EVT_VAR(2))
+        EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+        EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+        EVT_ADD(EVT_VAR(2), EVT_VAR(14))
+        EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(2), EVT_VAR(1), EVT_VAR(3), 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_END_LOOP
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_LABEL(0)
+    EVT_CALL(RandInt, EVT_VAR(12), EVT_VAR(0))
+    EVT_CALL(RandInt, EVT_VAR(13), EVT_VAR(1))
+    EVT_ADD(EVT_VAR(0), EVT_VAR(10))
+    EVT_ADD(EVT_VAR(1), EVT_VAR(11))
+    EVT_CALL(PlayEffect, 0xD, EVT_VAR(0), EVT_VAR(14), EVT_VAR(1), 200, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    EVT_WAIT_FRAMES(EVT_VAR(15))
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802449EC) = SCRIPT({
-    EVT_VAR(9) = EVT_VAR(6);
-    EVT_VAR(8) = EVT_VAR(5);
-    EVT_VAR(7) = EVT_VAR(4);
-    EVT_VAR(6) = EVT_VAR(3);
-    EVT_VAR(5) = EVT_VAR(2);
-    EVT_VAR(4) = EVT_VAR(1);
-    EVT_VAR(3) = EVT_VAR(0);
-    EnableModel(EVT_VAR(6), 0);
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    N(UnkFunc43)();
-    if (EVT_VAR(0) == 0) {
-        sleep 1;
-        goto 0;
-    }
-    spawn {
-        sleep 5;
-        EnableModel(EVT_VAR(6), 1);
-    }
-    if (EVT_VAR(10) != 0) {
-        spawn {
-            sleep 5;
-            EVT_VAR(0) = EVT_VAR(3);
-            EVT_VAR(1) = EVT_VAR(4);
-            EVT_VAR(2) = EVT_VAR(5);
-            EVT_VAR(1) += 10;
-            EVT_VAR(2) += 8;
-            PlayEffect(0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0);
-            sleep 15;
-            EVT_VAR(1) -= 10;
-            MakeItemEntity(EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0);
-        }
-    }
-    spawn {
-        sleep 10;
-        PlaySoundAt(0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5));
-    }
-    MakeLerp(0, 180, 20, 2);
-1:
-    UpdateLerp();
-    RotateModel(EVT_VAR(8), EVT_VAR(0), 1, 0, 0);
-    RotateModel(EVT_VAR(9), EVT_VAR(0), 1, 0, 0);
-    if (EVT_VAR(1) == 1) {
-        sleep 1;
-        goto 1;
-    }
-    EnableModel(EVT_VAR(7), 0);
-});
+EvtSource N(802449EC) = {
+    EVT_SET(EVT_VAR(9), EVT_VAR(6))
+    EVT_SET(EVT_VAR(8), EVT_VAR(5))
+    EVT_SET(EVT_VAR(7), EVT_VAR(4))
+    EVT_SET(EVT_VAR(6), EVT_VAR(3))
+    EVT_SET(EVT_VAR(5), EVT_VAR(2))
+    EVT_SET(EVT_VAR(4), EVT_VAR(1))
+    EVT_SET(EVT_VAR(3), EVT_VAR(0))
+    EVT_CALL(EnableModel, EVT_VAR(6), 0)
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(N(UnkFunc43))
+    EVT_IF_EQ(EVT_VAR(0), 0)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(5)
+        EVT_CALL(EnableModel, EVT_VAR(6), 1)
+    EVT_END_THREAD
+    EVT_IF_NE(EVT_VAR(10), 0)
+        EVT_THREAD
+            EVT_WAIT_FRAMES(5)
+            EVT_SET(EVT_VAR(0), EVT_VAR(3))
+            EVT_SET(EVT_VAR(1), EVT_VAR(4))
+            EVT_SET(EVT_VAR(2), EVT_VAR(5))
+            EVT_ADD(EVT_VAR(1), 10)
+            EVT_ADD(EVT_VAR(2), 8)
+            EVT_CALL(PlayEffect, 0x11, 4, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 15, 0, 0, 0, 0, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_SUB(EVT_VAR(1), 10)
+            EVT_CALL(MakeItemEntity, EVT_VAR(10), EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 14, 0)
+        EVT_END_THREAD
+    EVT_END_IF
+    EVT_THREAD
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(PlaySoundAt, 0xF8, 0, EVT_VAR(3), EVT_VAR(4), EVT_VAR(5))
+    EVT_END_THREAD
+    EVT_CALL(MakeLerp, 0, 180, 20, 2)
+    EVT_LABEL(1)
+    EVT_CALL(UpdateLerp)
+    EVT_CALL(RotateModel, EVT_VAR(8), EVT_VAR(0), 1, 0, 0)
+    EVT_CALL(RotateModel, EVT_VAR(9), EVT_VAR(0), 1, 0, 0)
+    EVT_IF_EQ(EVT_VAR(1), 1)
+        EVT_WAIT_FRAMES(1)
+        EVT_GOTO(1)
+    EVT_END_IF
+    EVT_CALL(EnableModel, EVT_VAR(7), 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(80244D0C) = SCRIPT({
-    GetModelCenter(57);
-    EVT_VAR(3) = 57;
-    EVT_VAR(4) = 58;
-    EVT_VAR(5) = 59;
-    EVT_VAR(6) = 60;
-    EVT_VAR(10) = 0;
-    spawn N(802449EC);
-    GetModelCenter(63);
-    EVT_VAR(3) = 63;
-    EVT_VAR(4) = 64;
-    EVT_VAR(5) = 65;
-    EVT_VAR(6) = 66;
-    EVT_VAR(10) = 0;
-    spawn N(802449EC);
-    GetModelCenter(69);
-    EVT_VAR(3) = 69;
-    EVT_VAR(4) = 70;
-    EVT_VAR(5) = 71;
-    EVT_VAR(6) = 72;
-    EVT_VAR(10) = 174;
-    spawn N(802449EC);
-    GetModelCenter(75);
-    EVT_VAR(3) = 75;
-    EVT_VAR(4) = 76;
-    EVT_VAR(5) = 77;
-    EVT_VAR(6) = 78;
-    EVT_VAR(10) = 0;
-    spawn N(802449EC);
-});
+EvtSource N(80244D0C) = {
+    EVT_CALL(GetModelCenter, 57)
+    EVT_SET(EVT_VAR(3), 57)
+    EVT_SET(EVT_VAR(4), 58)
+    EVT_SET(EVT_VAR(5), 59)
+    EVT_SET(EVT_VAR(6), 60)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802449EC))
+    EVT_CALL(GetModelCenter, 63)
+    EVT_SET(EVT_VAR(3), 63)
+    EVT_SET(EVT_VAR(4), 64)
+    EVT_SET(EVT_VAR(5), 65)
+    EVT_SET(EVT_VAR(6), 66)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802449EC))
+    EVT_CALL(GetModelCenter, 69)
+    EVT_SET(EVT_VAR(3), 69)
+    EVT_SET(EVT_VAR(4), 70)
+    EVT_SET(EVT_VAR(5), 71)
+    EVT_SET(EVT_VAR(6), 72)
+    EVT_SET(EVT_VAR(10), 174)
+    EVT_EXEC(N(802449EC))
+    EVT_CALL(GetModelCenter, 75)
+    EVT_SET(EVT_VAR(3), 75)
+    EVT_SET(EVT_VAR(4), 76)
+    EVT_SET(EVT_VAR(5), 77)
+    EVT_SET(EVT_VAR(6), 78)
+    EVT_SET(EVT_VAR(10), 0)
+    EVT_EXEC(N(802449EC))
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_kmr/kmr_03/8C7F90.c
+++ b/src/world/area_kmr/kmr_03/8C7F90.c
@@ -20,6 +20,8 @@ MapConfig N(config) = {
     .tattle = { MSG_kmr_03_tattle },
 };
 
-EvtSource N(802406C0) = SCRIPT({
-    SetMusicTrack(0, SONG_PLEASANT_PATH, 0, 8);
-});
+EvtSource N(802406C0) = {
+    EVT_CALL(SetMusicTrack, 0, SONG_PLEASANT_PATH, 0, 8)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_kmr/kmr_03/8C8140.c
+++ b/src/world/area_kmr/kmr_03/8C8140.c
@@ -18,34 +18,38 @@ EvtSource N(exitWalk_802406F0) = EXIT_WALK_SCRIPT(60,  0, "kmr_04",  0);
 
 EvtSource N(exitWalk_8024074C) = EXIT_WALK_SCRIPT(60,  1, "kmr_05",  0);
 
-EvtSource N(802407A8) = SCRIPT({
-    bind N(exitWalk_802406F0) TRIGGER_FLOOR_ABOVE 3;
-    bind N(exitWalk_8024074C) TRIGGER_FLOOR_ABOVE 5;
-});
+EvtSource N(802407A8) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802406F0), TRIGGER_FLOOR_ABOVE, 3, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024074C), TRIGGER_FLOOR_ABOVE, 5, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_GOOMBA_VILLAGE;
-    SetSpriteShading(-1);
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    EVT_AREA_FLAG(8) = 0;
-    MakeNpcs(0, N(npcGroupList_80241450));
-    ClearDefeatedEnemies();
-    await N(makeEntities);
-    await N(802422B8);
-    spawn N(802406C0);
-    GetEntryID(EVT_VAR(0));
-    if (EVT_VAR(0) != 2) {
-        EVT_VAR(0) = N(802407A8);
-        spawn EnterWalk;
-    } else {
-        spawn N(802407A8);
-        spawn N(80242340);
-    }
-    sleep 1;
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 30)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_SET(EVT_AREA_FLAG(8), 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80241450)))
+    EVT_CALL(ClearDefeatedEnemies)
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_EXEC_WAIT(N(802422B8))
+    EVT_EXEC(N(802406C0))
+    EVT_CALL(GetEntryID, EVT_VAR(0))
+    EVT_IF_NE(EVT_VAR(0), 2)
+        EVT_SET(EVT_VAR(0), EVT_PTR(N(802407A8)))
+        EVT_EXEC(EnterWalk)
+    EVT_ELSE
+        EVT_EXEC(N(802407A8))
+        EVT_EXEC(N(80242340))
+    EVT_END_IF
+    EVT_WAIT_FRAMES(1)
+    EVT_RETURN
+    EVT_END
+};
 
 static s32 N(pad_948)[] = {
     0x00000000, 0x00000000,
@@ -58,144 +62,148 @@ NpcSettings N(npcSettings_80240950) = {
     .unk_2A = 16,
 };
 
-EvtSource N(8024097C) = SCRIPT({
-1:
-    if (EVT_AREA_FLAG(8) == 1) {
-100:
-        AwaitPlayerLeave(294, 123, 170);
-        EnableNpcAI(0, 0);
-        DisablePlayerInput(TRUE);
-        SetNpcSpeed(NPC_GOOMPA, 4.0);
-        SetNpcAnimation(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_3);
-        N(func_802401B0_8C8140)();
-        GetAngleToPlayer(0, EVT_VAR(2));
-        loop EVT_VAR(1) {
-            GetNpcPos(NPC_GOOMPA, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9));
-            AddVectorPolar(EVT_VAR(7), EVT_VAR(9), 4.0, EVT_VAR(2));
-            SetNpcPos(NPC_GOOMPA, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9));
-            sleep 1;
-        }
-        PlayerFaceNpc(0, 3);
-        SetPlayerSpeed(3.0);
-        PlayerMoveTo(243, 243, 0);
-        SetNpcVar(0, 0, 1);
-        EnableNpcAI(0, 1);
-        DisablePlayerInput(FALSE);
-        goto 100;
-    }
-    sleep 1;
-    goto 1;
-});
+EvtSource N(8024097C) = {
+    EVT_LABEL(1)
+    EVT_IF_EQ(EVT_AREA_FLAG(8), 1)
+        EVT_LABEL(100)
+        EVT_CALL(AwaitPlayerLeave, 294, 123, 170)
+        EVT_CALL(EnableNpcAI, 0, 0)
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_CALL(SetNpcSpeed, 0, EVT_FIXED(4.0))
+        EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_goompa_Palette_00_Anim_3)
+        EVT_CALL(N(func_802401B0_8C8140))
+        EVT_CALL(GetAngleToPlayer, 0, EVT_VAR(2))
+        EVT_LOOP(EVT_VAR(1))
+            EVT_CALL(GetNpcPos, 0, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9))
+            EVT_CALL(AddVectorPolar, EVT_VAR(7), EVT_VAR(9), EVT_FIXED(4.0), EVT_VAR(2))
+            EVT_CALL(SetNpcPos, 0, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9))
+            EVT_WAIT_FRAMES(1)
+        EVT_END_LOOP
+        EVT_CALL(PlayerFaceNpc, 0, 3)
+        EVT_CALL(SetPlayerSpeed, EVT_FIXED(3.0))
+        EVT_CALL(PlayerMoveTo, 243, 243, 0)
+        EVT_CALL(SetNpcVar, 0, 0, 1)
+        EVT_CALL(EnableNpcAI, 0, 1)
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_GOTO(100)
+    EVT_END_IF
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(npcAI_80240B50) = SCRIPT({
-1:
-    match EVT_STORY_PROGRESS {
-        == STORY_CH0_FELL_OFF_CLIFF {
-89:
-            N(UnkPositionFunc)(-118, 86, -70, -15);
-            sleep 1;
-            if (EVT_VAR(0) == 0) {
-                goto 89;
-            }
-            DisablePlayerInput(TRUE);
-            SetNpcAux(NPC_GOOMPA, 0);
-            PlaySoundAtNpc(NPC_GOOMPA, SOUND_262, 0);
-            ShowEmote(0, EMOTE_EXCLAMATION, 45, 15, 1, 0, 0, 0, 0);
-            sleep 15;
-            NpcFacePlayer(NPC_SELF, 5);
-            sleep 10;
-            SpeakToPlayer(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A6));
-            UseSettingsFrom(0, -220, 20, -72);
-            SetPanTarget(0, -20, 0, 68);
-            SetCamPitch(0, 15.0, -8.5);
-            SetCamDistance(0, 275);
-            SetCamSpeed(0, 1.5);
-            PanToTarget(0, 0, 1);
-            spawn {
-                sleep 20;
-                SetPlayerSpeed(2.0);
-                PlayerMoveTo(-38, 68, 0);
-            }
-            GetNpcPos(NPC_GOOMPA, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9));
-            SetNpcSpeed(NPC_GOOMPA, 4.0);
-            SetNpcAnimation(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_3);
-            NpcMoveTo(NPC_GOOMPA, 0, 70, 0);
-            SetNpcAnimation(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_1);
-            InterpNpcYaw(NPC_GOOMPA, 276, 20);
-            sleep 30;
-            SpeakToPlayer(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A7));
-            sleep 5;
-            SetPlayerAnimation(ANIM_80007);
-            sleep 30;
-            SpeakToPlayer(NPC_GOOMPA, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A8));
-            N(UnkFunc41)(0, 5);
-            EVT_STORY_PROGRESS = STORY_CH0_GOOMPA_JOINED_PARTY;
-            UseSettingsFrom(0, -220, 20, -72);
-            GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-            SetCamSpeed(0, 3.0);
-            PanToTarget(0, 0, 1);
-            WaitForCam(0, 1.0);
-            PanToTarget(0, 0, 0);
-            EnablePartnerAI();
-            DisablePlayerInput(FALSE);
-            sleep 1;
-        }
-    }
-});
+EvtSource N(npcAI_80240B50) = {
+    EVT_LABEL(1)
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_EQ(-122)
+            EVT_LABEL(89)
+            EVT_CALL(N(UnkPositionFunc), -118, 86, -70, -15)
+            EVT_WAIT_FRAMES(1)
+            EVT_IF_EQ(EVT_VAR(0), 0)
+                EVT_GOTO(89)
+            EVT_END_IF
+            EVT_CALL(DisablePlayerInput, TRUE)
+            EVT_CALL(SetNpcAux, 0, 0)
+            EVT_CALL(PlaySoundAtNpc, 0, SOUND_262, 0)
+            EVT_CALL(ShowEmote, 0, EMOTE_EXCLAMATION, 45, 15, 1, 0, 0, 0, 0)
+            EVT_WAIT_FRAMES(15)
+            EVT_CALL(NpcFacePlayer, NPC_SELF, 5)
+            EVT_WAIT_FRAMES(10)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A6))
+            EVT_CALL(UseSettingsFrom, 0, -220, 20, -72)
+            EVT_CALL(SetPanTarget, 0, -20, 0, 68)
+            EVT_CALL(SetCamPitch, 0, EVT_FIXED(15.0), EVT_FIXED(-8.5))
+            EVT_CALL(SetCamDistance, 0, 275)
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.5))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_THREAD
+                EVT_WAIT_FRAMES(20)
+                EVT_CALL(SetPlayerSpeed, EVT_FIXED(2.0))
+                EVT_CALL(PlayerMoveTo, -38, 68, 0)
+            EVT_END_THREAD
+            EVT_CALL(GetNpcPos, 0, EVT_VAR(7), EVT_VAR(8), EVT_VAR(9))
+            EVT_CALL(SetNpcSpeed, 0, EVT_FIXED(4.0))
+            EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_goompa_Palette_00_Anim_3)
+            EVT_CALL(NpcMoveTo, 0, 0, 70, 0)
+            EVT_CALL(SetNpcAnimation, 0, NPC_ANIM_goompa_Palette_00_Anim_1)
+            EVT_CALL(InterpNpcYaw, 0, 276, 20)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A7))
+            EVT_WAIT_FRAMES(5)
+            EVT_CALL(SetPlayerAnimation, ANIM_80007)
+            EVT_WAIT_FRAMES(30)
+            EVT_CALL(SpeakToPlayer, 0, NPC_ANIM_goompa_Palette_00_Anim_8, NPC_ANIM_goompa_Palette_00_Anim_1, 0, MESSAGE_ID(0x0B, 0x00A8))
+            EVT_CALL(N(UnkFunc41), 0, 5)
+            EVT_SET(EVT_SAVE_VAR(0), -121)
+            EVT_CALL(UseSettingsFrom, 0, -220, 20, -72)
+            EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+            EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+            EVT_CALL(PanToTarget, 0, 0, 1)
+            EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+            EVT_CALL(PanToTarget, 0, 0, 0)
+            EVT_CALL(EnablePartnerAI)
+            EVT_CALL(DisablePlayerInput, FALSE)
+            EVT_WAIT_FRAMES(1)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(hit_80240F64) = SCRIPT({
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_7);
-    sleep 10;
-    SetNpcAnimation(NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_1);
-    EVT_MAP_VAR(0) += 1;
-    if (EVT_MAP_VAR(0) < 3) {
-        GetOwnerEncounterTrigger(EVT_VAR(0));
-        match EVT_VAR(0) {
-            == 2 {
-                SetNpcVar(0, 0, 1);
-                if (EVT_AREA_FLAG(6) == 1) {
-                } else {
-                    EVT_AREA_FLAG(6) = 1;
-                    EVT_AREA_FLAG(7) = 0;
-                }
-            }
-            == 4 {
-                SetNpcVar(0, 0, 1);
-                if (EVT_AREA_FLAG(7) == 1) {
-                } else {
-                    EVT_AREA_FLAG(6) = 0;
-                    EVT_AREA_FLAG(7) = 1;
-                }
-            }
-        }
-        sleep 10;
-        SetNpcAnimation(NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_3);
-    } else {
-        sleep 10;
-        GetNpcPos(NPC_GOOMPA, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetNpcPos(NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetNpcFlagBits(NPC_PARTNER, NPC_FLAG_GRAVITY, TRUE);
-        SetNpcPos(NPC_GOOMPA, 0, -1000, 0);
-        SetNpcFlagBits(NPC_GOOMPA, NPC_FLAG_100, FALSE);
-        EnablePartnerAI();
-        SetNpcAux(NPC_SELF, N(8024097C));
-        BindNpcAI(NPC_SELF, N(npcAI_80240B50));
-    }
-});
+EvtSource N(hit_80240F64) = {
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_7)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_1)
+    EVT_ADD(EVT_MAP_VAR(0), 1)
+    EVT_IF_LT(EVT_MAP_VAR(0), 3)
+        EVT_CALL(GetOwnerEncounterTrigger, EVT_VAR(0))
+        EVT_SWITCH(EVT_VAR(0))
+            EVT_CASE_EQ(2)
+                EVT_CALL(SetNpcVar, 0, 0, 1)
+                EVT_IF_EQ(EVT_AREA_FLAG(6), 1)
+                EVT_ELSE
+                    EVT_SET(EVT_AREA_FLAG(6), 1)
+                    EVT_SET(EVT_AREA_FLAG(7), 0)
+                EVT_END_IF
+            EVT_CASE_EQ(4)
+                EVT_CALL(SetNpcVar, 0, 0, 1)
+                EVT_IF_EQ(EVT_AREA_FLAG(7), 1)
+                EVT_ELSE
+                    EVT_SET(EVT_AREA_FLAG(6), 0)
+                    EVT_SET(EVT_AREA_FLAG(7), 1)
+                EVT_END_IF
+        EVT_END_SWITCH
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(SetNpcAnimation, NPC_SELF, NPC_ANIM_goompa_Palette_00_Anim_3)
+    EVT_ELSE
+        EVT_WAIT_FRAMES(10)
+        EVT_CALL(GetNpcPos, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetNpcPos, NPC_PARTNER, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetNpcFlagBits, NPC_PARTNER, ((NPC_FLAG_GRAVITY)), TRUE)
+        EVT_CALL(SetNpcPos, 0, 0, -1000, 0)
+        EVT_CALL(SetNpcFlagBits, 0, ((NPC_FLAG_100)), FALSE)
+        EVT_CALL(EnablePartnerAI)
+        EVT_CALL(SetNpcAux, NPC_SELF, EVT_PTR(N(8024097C)))
+        EVT_CALL(BindNpcAI, NPC_SELF, EVT_PTR(N(npcAI_80240B50)))
+    EVT_END_IF
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(init_802411A8) = SCRIPT({
-    BindNpcIdle(NPC_SELF, N(npcAI_80240B50));
-    BindNpcAux(-1, N(8024097C));
-    BindNpcHit(-1, N(hit_80240F64));
-    match EVT_STORY_PROGRESS {
-        >= STORY_CH0_GOOMPA_JOINED_PARTY {
-            SetNpcFlagBits(NPC_SELF, NPC_FLAG_GRAVITY, FALSE);
-            SetNpcFlagBits(NPC_SELF, NPC_FLAG_ENABLE_HIT_SCRIPT, TRUE);
-            SetNpcPos(NPC_SELF, 0, -1000, 0);
-        }
-    }
-});
+EvtSource N(init_802411A8) = {
+    EVT_CALL(BindNpcIdle, NPC_SELF, EVT_PTR(N(npcAI_80240B50)))
+    EVT_CALL(BindNpcAux, -1, EVT_PTR(N(8024097C)))
+    EVT_CALL(BindNpcHit, -1, EVT_PTR(N(hit_80240F64)))
+    EVT_SWITCH(EVT_SAVE_VAR(0))
+        EVT_CASE_GE(-121)
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_GRAVITY)), FALSE)
+            EVT_CALL(SetNpcFlagBits, NPC_SELF, ((NPC_FLAG_ENABLE_HIT_SCRIPT)), TRUE)
+            EVT_CALL(SetNpcPos, NPC_SELF, 0, -1000, 0)
+    EVT_END_SWITCH
+    EVT_RETURN
+    EVT_END
+};
 
 StaticNpc N(npcGroup_80241260) = {
     .id = NPC_GOOMPA,
@@ -237,47 +245,55 @@ static s32 N(pad_1468)[] = {
     0x00000000, 0x00000000,
 };
 
-EvtSource N(80241470) = SCRIPT({
-    ModifyColliderFlags(0, 9, 0x7FFFFE00);
-    EVT_STORY_PROGRESS = STORY_CH0_LEFT_THE_PLAYGROUND;
-});
+EvtSource N(80241470) = {
+    EVT_CALL(ModifyColliderFlags, 0, 9, 0x7FFFFE00)
+    EVT_SET(EVT_SAVE_VAR(0), -117)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802414A8) = SCRIPT({
-    EVT_SAVE_FLAG(54) = 1;
-});
+EvtSource N(802414A8) = {
+    EVT_SET(EVT_SAVE_FLAG(54), 1)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(802414C8) = SCRIPT({
-0:
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetCamTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    sleep 1;
-    goto 0;
-});
+EvtSource N(802414C8) = {
+    EVT_LABEL(0)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetCamTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_WAIT_FRAMES(1)
+    EVT_GOTO(0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(makeEntities) = SCRIPT({
-    if (EVT_STORY_PROGRESS < STORY_CH0_LEFT_THE_PLAYGROUND) {
-        MakeEntity(0x802EA10C, 45, 0, 70, 15, MAKE_ENTITY_END);
-        AssignScript(N(80241470));
-    } else {
-        ModifyColliderFlags(0, 9, 0x7FFFFE00);
-    }
-    if (EVT_SAVE_FLAG(54) == 0) {
-        MakeEntity(0x802EA19C, 230, 0, 310, 15, MAKE_ENTITY_END);
-        AssignScript(N(802414A8));
-    }
-    MakeEntity(0x802EA588, 230, 60, 310, 15, ITEM_REPEL_GEL, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(52));
-    MakeEntity(0x802EA0C4, 230, 50, -160, 15, MAKE_ENTITY_END);
-    MakeEntity(0x802EA0C4, 165, 0, 380, 20, MAKE_ENTITY_END);
-    MakeEntity(0x802EA564, -170, 0, 370, 43, ITEM_COIN, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(50));
-    MakeEntity(0x802EAA54, 345, 75, -250, 0, ITEM_BAKING_WATER, MAKE_ENTITY_END);
-    MakeItemEntity(ITEM_COIN, 345, 205, -250, 17, EVT_SAVE_FLAG(56));
-    MakeItemEntity(ITEM_COIN, 345, 230, -250, 17, EVT_SAVE_FLAG(57));
-    MakeItemEntity(ITEM_COIN, 345, 255, -250, 17, EVT_SAVE_FLAG(58));
-    MakeItemEntity(ITEM_COIN, 345, 280, -250, 17, EVT_SAVE_FLAG(59));
-    MakeItemEntity(ITEM_FIRE_FLOWER, 229, 250, -156, 17, EVT_SAVE_FLAG(49));
-    MakeEntity(0x802EAB04, 300, 0, 150, 0, ITEM_PULSE_STONE, MAKE_ENTITY_END);
-    AssignPanelFlag(EVT_SAVE_FLAG(88));
-    MakeEntity(0x802EA7E0, 130, 60, 0, 0, MAKE_ENTITY_END);
-});
+EvtSource N(makeEntities) = {
+    EVT_IF_LT(EVT_SAVE_VAR(0), -117)
+        EVT_CALL(MakeEntity, 0x802EA10C, 45, 0, 70, 15, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(80241470)))
+    EVT_ELSE
+        EVT_CALL(ModifyColliderFlags, 0, 9, 0x7FFFFE00)
+    EVT_END_IF
+    EVT_IF_EQ(EVT_SAVE_FLAG(54), 0)
+        EVT_CALL(MakeEntity, 0x802EA19C, 230, 0, 310, 15, MAKE_ENTITY_END)
+        EVT_CALL(AssignScript, EVT_PTR(N(802414A8)))
+    EVT_END_IF
+    EVT_CALL(MakeEntity, 0x802EA588, 230, 60, 310, 15, 151, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(52))
+    EVT_CALL(MakeEntity, EVT_PTR(D_802EA0C4), 230, 50, -160, 15, MAKE_ENTITY_END)
+    EVT_CALL(MakeEntity, EVT_PTR(D_802EA0C4), 165, 0, 380, 20, MAKE_ENTITY_END)
+    EVT_CALL(MakeEntity, 0x802EA564, -170, 0, 370, 43, 343, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(50))
+    EVT_CALL(MakeEntity, 0x802EAA54, 345, 75, -250, 0, 100, MAKE_ENTITY_END)
+    EVT_CALL(MakeItemEntity, ITEM_COIN, 345, 205, -250, 17, EVT_SAVE_FLAG(56))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, 345, 230, -250, 17, EVT_SAVE_FLAG(57))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, 345, 255, -250, 17, EVT_SAVE_FLAG(58))
+    EVT_CALL(MakeItemEntity, ITEM_COIN, 345, 280, -250, 17, EVT_SAVE_FLAG(59))
+    EVT_CALL(MakeItemEntity, ITEM_FIRE_FLOWER, 229, 250, -156, 17, EVT_SAVE_FLAG(49))
+    EVT_CALL(MakeEntity, 0x802EAB04, 300, 0, 150, 0, 18, MAKE_ENTITY_END)
+    EVT_CALL(AssignPanelFlag, EVT_SAVE_FLAG(88))
+    EVT_CALL(MakeEntity, 0x802EA7E0, 130, 60, 0, 0, MAKE_ENTITY_END)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_kmr/kmr_03/8C83A0.c
+++ b/src/world/area_kmr/kmr_03/8C83A0.c
@@ -37,22 +37,24 @@ FoliageVectorList N(treeEffectVectors_Tree1) = {
     },
 };
 
-EvtSource N(tree1_Callback) = SCRIPT({
-    if (EVT_SAVE_FLAG(53) == TRUE) {
-        return;
-    }
-    if (EVT_MAP_FLAG(10) == TRUE) {
-        return;
-    }
-    sleep 10;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(0) < -30) {
-        MakeItemEntity(ITEM_MUSHROOM, -23, 100, 35, 13, EVT_SAVE_FLAG(53));
-    } else {
-        MakeItemEntity(ITEM_MUSHROOM, -85, 100, 16, 13, EVT_SAVE_FLAG(53));
-    }
-    EVT_MAP_FLAG(10) = 1;
-});
+EvtSource N(tree1_Callback) = {
+    EVT_IF_EQ(EVT_SAVE_FLAG(53), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_IF_EQ(EVT_MAP_FLAG(10), 1)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_LT(EVT_VAR(0), -30)
+        EVT_CALL(MakeItemEntity, ITEM_MUSHROOM, -23, 100, 35, 13, EVT_SAVE_FLAG(53))
+    EVT_ELSE
+        EVT_CALL(MakeItemEntity, ITEM_MUSHROOM, -85, 100, 16, 13, EVT_SAVE_FLAG(53))
+    EVT_END_IF
+    EVT_SET(EVT_MAP_FLAG(10), 1)
+    EVT_RETURN
+    EVT_END
+};
 
 ShakeTreeConfig N(tree1) = {
     .leaves = &N(treeModelList_Tree1_Leaves),
@@ -63,12 +65,13 @@ ShakeTreeConfig N(tree1) = {
 
 Vec4f N(tree1Point) = { -42.0f, 0.0f, -13.0f, 0.0f };
 
-EvtSource N(802422B8) = SCRIPT({
-    EVT_VAR(0) = N(bush1);
-    bind N(searchBush) TRIGGER_WALL_PRESS_A 53;
-
-    EVT_VAR(0) = N(tree1);
-    bind N(shakeTree) TRIGGER_WALL_HAMMER 52;
-    bind N(shakeTree) TRIGGER_POINT_BOMB N(tree1Point);
-});
+EvtSource N(802422B8) = {
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(bush1)))
+    EVT_BIND_TRIGGER(N(searchBush), TRIGGER_WALL_PRESS_A, 53, 1, 0)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(tree1)))
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_WALL_HAMMER, 52, 1, 0)
+    EVT_BIND_TRIGGER(N(shakeTree), TRIGGER_POINT_BOMB, EVT_PTR(N(tree1Point)), 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 

--- a/src/world/area_kmr/kmr_03/8C85E0.c
+++ b/src/world/area_kmr/kmr_03/8C85E0.c
@@ -1,86 +1,88 @@
 #include "kmr_03.h"
 
-EvtSource N(80242340) = SCRIPT({
-    UseSettingsFrom(0, -270, 20, -80);
-    SetPanTarget(0, -270, 20, -80);
-    SetCamDistance(0, 700.0);
-    SetCamSpeed(0, 90.0);
-    PanToTarget(0, 0, 1);
-    if (EVT_STORY_PROGRESS >= STORY_CH0_FOUND_HAMMER) {
-        SetPlayerPos(0, -1000, 0);
-        DisablePlayerInput(TRUE);
-        SetPlayerPos(-224, 20, -80);
-        SetNpcPos(NPC_PARTNER, -224, 20, -80);
-        sleep 20;
-        SetCamSpeed(0, 3.0);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        PanToTarget(0, 0, 0);
-        DisablePlayerInput(FALSE);
-        return;
-    }
-    DisablePlayerInput(TRUE);
-    DisablePlayerPhysics(TRUE);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPlayerPos(EVT_VAR(0), -1000, EVT_VAR(2));
-    sleep 30;
-    SetCamDistance(0, 220);
-    SetCamSpeed(0, 1.0);
-    PanToTarget(0, 0, 1);
-    WaitForCam(0, 1.0);
-    spawn {
-        sleep 18;
-        PlaySoundAtPlayer(373, 0);
-        sleep 30;
-        PlaySoundAtPlayer(374, 0);
-        sleep 28;
-        PlaySoundAtPlayer(373, 0);
-    }
-    HidePlayerShadow(TRUE);
-    SetPlayerAnimation(ANIM_10002);
-    SetPlayerPos(-224, 120, -80);
-    InterpPlayerYaw(90, 0);
-0:
-    sleep 1;
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    EVT_VAR(1) += -2;
-    SetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    if (EVT_VAR(1) > 86) {
-        goto 0;
-    }
-    SetPlayerPos(-310, 20, -80);
-    spawn {
-        sleep 20;
-        SetPanTarget(0, -310, 20, -80);
-        SetCamSpeed(0, 0.2001953125);
-        PanToTarget(0, 0, 1);
-    }
-    func_802D286C(10240);
-    func_802D2520(ANIM_10002, 5, 5, 1, 1, 0);
-    sleep 100;
-    WaitForCam(0, 1.0);
-    func_802D2520(ANIM_10002, 0, 0, 0, 0, 0);
-    HidePlayerShadow(FALSE);
-    SetPlayerAnimation(ANIM_BEFORE_JUMP);
-    sleep 10;
-    SetPlayerAnimation(ANIM_MIDAIR_STILL);
-    GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-    SetPlayerJumpscale(1.0);
-    PlayerJump(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10);
-    SetPlayerAnimation(ANIM_10002);
-    spawn {
-        SetCamSpeed(0, 3.0);
-        GetPlayerPos(EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        UseSettingsFrom(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        SetPanTarget(0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2));
-        PanToTarget(0, 0, 1);
-        WaitForCam(0, 1.0);
-        PanToTarget(0, 0, 0);
-    }
-    sleep 30;
-    DisablePlayerPhysics(FALSE);
-    DisablePlayerInput(FALSE);
-});
+EvtSource N(80242340) = {
+    EVT_CALL(UseSettingsFrom, 0, -270, 20, -80)
+    EVT_CALL(SetPanTarget, 0, -270, 20, -80)
+    EVT_CALL(SetCamDistance, 0, EVT_FIXED(700.0))
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(90.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_IF_GE(EVT_SAVE_VAR(0), -119)
+        EVT_CALL(SetPlayerPos, 0, -1000, 0)
+        EVT_CALL(DisablePlayerInput, TRUE)
+        EVT_CALL(SetPlayerPos, -224, 20, -80)
+        EVT_CALL(SetNpcPos, NPC_PARTNER, -224, 20, -80)
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(PanToTarget, 0, 0, 0)
+        EVT_CALL(DisablePlayerInput, FALSE)
+        EVT_RETURN
+    EVT_END_IF
+    EVT_CALL(DisablePlayerInput, TRUE)
+    EVT_CALL(DisablePlayerPhysics, TRUE)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPlayerPos, EVT_VAR(0), -1000, EVT_VAR(2))
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(SetCamDistance, 0, 220)
+    EVT_CALL(SetCamSpeed, 0, EVT_FIXED(1.0))
+    EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_THREAD
+        EVT_WAIT_FRAMES(18)
+        EVT_CALL(PlaySoundAtPlayer, 373, 0)
+        EVT_WAIT_FRAMES(30)
+        EVT_CALL(PlaySoundAtPlayer, 374, 0)
+        EVT_WAIT_FRAMES(28)
+        EVT_CALL(PlaySoundAtPlayer, 373, 0)
+    EVT_END_THREAD
+    EVT_CALL(HidePlayerShadow, TRUE)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_CALL(SetPlayerPos, -224, 120, -80)
+    EVT_CALL(InterpPlayerYaw, 90, 0)
+    EVT_LABEL(0)
+    EVT_WAIT_FRAMES(1)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_ADD(EVT_VAR(1), -2)
+    EVT_CALL(SetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_IF_GT(EVT_VAR(1), 86)
+        EVT_GOTO(0)
+    EVT_END_IF
+    EVT_CALL(SetPlayerPos, -310, 20, -80)
+    EVT_THREAD
+        EVT_WAIT_FRAMES(20)
+        EVT_CALL(SetPanTarget, 0, -310, 20, -80)
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(0.2))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+    EVT_END_THREAD
+    EVT_CALL(func_802D286C, 10240)
+    EVT_CALL(func_802D2520, ANIM_10002, 5, 5, 1, 1, 0)
+    EVT_WAIT_FRAMES(100)
+    EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+    EVT_CALL(func_802D2520, ANIM_10002, 0, 0, 0, 0, 0)
+    EVT_CALL(HidePlayerShadow, FALSE)
+    EVT_CALL(SetPlayerAnimation, ANIM_BEFORE_JUMP)
+    EVT_WAIT_FRAMES(10)
+    EVT_CALL(SetPlayerAnimation, ANIM_MIDAIR_STILL)
+    EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+    EVT_CALL(SetPlayerJumpscale, EVT_FIXED(1.0))
+    EVT_CALL(PlayerJump, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2), 10)
+    EVT_CALL(SetPlayerAnimation, ANIM_10002)
+    EVT_THREAD
+        EVT_CALL(SetCamSpeed, 0, EVT_FIXED(3.0))
+        EVT_CALL(GetPlayerPos, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(UseSettingsFrom, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(SetPanTarget, 0, EVT_VAR(0), EVT_VAR(1), EVT_VAR(2))
+        EVT_CALL(PanToTarget, 0, 0, 1)
+        EVT_CALL(WaitForCam, 0, EVT_FIXED(1.0))
+        EVT_CALL(PanToTarget, 0, 0, 0)
+    EVT_END_THREAD
+    EVT_WAIT_FRAMES(30)
+    EVT_CALL(DisablePlayerPhysics, FALSE)
+    EVT_CALL(DisablePlayerInput, FALSE)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_kmr/kmr_03/kmr_03.h
+++ b/src/world/area_kmr/kmr_03/kmr_03.h
@@ -17,3 +17,5 @@ extern EvtSource N(80242340);
 extern EvtSource N(802406C0);
 extern EvtSource N(main);
 extern EvtSource N(makeEntities);
+
+extern s32 D_802EA0C4;

--- a/src/world/area_kmr/kmr_12/header.c
+++ b/src/world/area_kmr/kmr_12/header.c
@@ -14,9 +14,11 @@ MapConfig N(config) = {
     .tattle = { MSG_kmr_12_tattle },
 };
 
-EvtSource N(PlayMusic) = SCRIPT({
-    SetMusicTrack(0, SONG_PLEASANT_PATH, 0, 8);
-});
+EvtSource N(PlayMusic) = {
+    EVT_CALL(SetMusicTrack, 0, SONG_PLEASANT_PATH, 0, 8)
+    EVT_RETURN
+    EVT_END
+};
 
 ApiStatus GetGoomba(Evt* script, s32 isInitialCall) {
     script->varTable[0] = get_enemy_safe(NPC_GOOMBA);

--- a/src/world/area_kmr/kmr_12/kmr_12.h
+++ b/src/world/area_kmr/kmr_12/kmr_12.h
@@ -18,3 +18,5 @@ extern  EvtSource N(PlayMusic);
 extern  EvtSource N(MakeEntities);
 extern  EvtSource N(ReadWestSign);
 extern NpcGroupList N(npcGroupList);
+
+extern s32 D_802EAFDC;

--- a/src/world/area_sbk/sbk_00/929270.c
+++ b/src/world/area_sbk/sbk_00/929270.c
@@ -22,25 +22,29 @@ EvtSource N(exitWalk_802400E0) = EXIT_WALK_SCRIPT(60,  1, "sbk_01",  0);
 
 EvtSource N(exitWalk_8024013C) = EXIT_WALK_SCRIPT(60,  3, "sbk_10",  2);
 
-EvtSource N(80240198) = SCRIPT({
-    bind N(exitWalk_802400E0) TRIGGER_FLOOR_ABOVE 3;
-    bind N(exitWalk_8024013C) TRIGGER_FLOOR_ABOVE 6;
-});
+EvtSource N(80240198) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802400E0), TRIGGER_FLOOR_ABOVE, 3, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024013C), TRIGGER_FLOOR_ABOVE, 6, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_DRY_DRY_DESERT;
-    SetSpriteShading(-1);
-    if (EVT_STORY_PROGRESS == STORY_CH2_GOT_PULSE_STONE) {
-        DisablePulseStone(0);
-    }
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    MakeNpcs(0, N(npcGroupList_80240768));
-    await N(makeEntities);
-    N(SpawnSunEffect)();
-    SetMusicTrack(0, SONG_DRY_DRY_DESERT, 0, 8);
-    EVT_VAR(0) = N(80240198);
-    spawn EnterWalk;
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 10)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_IF_EQ(EVT_SAVE_VAR(0), -63)
+        EVT_CALL(DisablePulseStone, 0)
+    EVT_END_IF
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_80240768)))
+    EVT_EXEC_WAIT(N(makeEntities))
+    EVT_CALL(N(SpawnSunEffect))
+    EVT_CALL(SetMusicTrack, 0, SONG_DRY_DRY_DESERT, 0, 8)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(80240198)))
+    EVT_EXEC(EnterWalk)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_sbk/sbk_00/9292B0.c
+++ b/src/world/area_sbk/sbk_00/9292B0.c
@@ -16,10 +16,12 @@ NpcAISettings N(npcAISettings_80240300) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_80240330) = SCRIPT({
-    N(SetNpcB5_3)();
-    DoBasicAI(N(npcAISettings_80240300));
-});
+EvtSource N(npcAI_80240330) = {
+    EVT_CALL(N(SetNpcB5_3))
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_80240300)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_8024035C) = {
     .height = 72,
@@ -114,9 +116,11 @@ static s32 N(pad_78C) = {
     0x00000000,
 };
 
-EvtSource N(makeEntities) = SCRIPT({
-    MakeEntity(0x802EA564, -230, 0, 155, 0, ITEM_FRIGHT_JAR, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(797));
-    MakeEntity(0x802EA564, 160, 0, 205, 0, ITEM_COIN, MAKE_ENTITY_END);
-    AssignBlockFlag(EVT_SAVE_FLAG(798));
-});
+EvtSource N(makeEntities) = {
+    EVT_CALL(MakeEntity, 0x802EA564, -230, 0, 155, 0, 152, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(797))
+    EVT_CALL(MakeEntity, 0x802EA564, 160, 0, 205, 0, 343, MAKE_ENTITY_END)
+    EVT_CALL(AssignBlockFlag, EVT_SAVE_FLAG(798))
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_sbk/sbk_01/929A90.c
+++ b/src/world/area_sbk/sbk_01/929A90.c
@@ -27,25 +27,29 @@ EvtSource N(exitWalk_8024013C) = EXIT_WALK_SCRIPT(60,  1, "sbk_02",  0);
 
 EvtSource N(exitWalk_80240198) = EXIT_WALK_SCRIPT(60,  3, "sbk_11",  2);
 
-EvtSource N(802401F4) = SCRIPT({
-    bind N(exitWalk_802400E0) TRIGGER_FLOOR_ABOVE 7;
-    bind N(exitWalk_8024013C) TRIGGER_FLOOR_ABOVE 3;
-    bind N(exitWalk_80240198) TRIGGER_FLOOR_ABOVE 5;
-});
+EvtSource N(802401F4) = {
+    EVT_BIND_TRIGGER(N(exitWalk_802400E0), TRIGGER_FLOOR_ABOVE, 7, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_8024013C), TRIGGER_FLOOR_ABOVE, 3, 1, 0)
+    EVT_BIND_TRIGGER(N(exitWalk_80240198), TRIGGER_FLOOR_ABOVE, 5, 1, 0)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource N(main) = SCRIPT({
-    EVT_WORLD_LOCATION = LOCATION_DRY_DRY_DESERT;
-    SetSpriteShading(-1);
-    if (EVT_STORY_PROGRESS == STORY_CH2_GOT_PULSE_STONE) {
-        DisablePulseStone(0);
-    }
-    SetCamPerspective(0, 3, 25, 16, 4096);
-    SetCamBGColor(0, 0, 0, 0);
-    SetCamEnabled(0, 1);
-    SetCamLeadPlayer(0, 0);
-    MakeNpcs(0, N(npcGroupList_802407D8));
-    N(SpawnSunEffect)();
-    SetMusicTrack(0, SONG_DRY_DRY_DESERT, 0, 8);
-    EVT_VAR(0) = N(802401F4);
-    spawn EnterWalk;
-});
+EvtSource N(main) = {
+    EVT_SET(EVT_SAVE_VAR(425), 10)
+    EVT_CALL(SetSpriteShading, -1)
+    EVT_IF_EQ(EVT_SAVE_VAR(0), -63)
+        EVT_CALL(DisablePulseStone, 0)
+    EVT_END_IF
+    EVT_CALL(SetCamPerspective, 0, 3, 25, 16, 4096)
+    EVT_CALL(SetCamBGColor, 0, 0, 0, 0)
+    EVT_CALL(SetCamEnabled, 0, 1)
+    EVT_CALL(SetCamLeadPlayer, 0, 0)
+    EVT_CALL(MakeNpcs, 0, EVT_PTR(N(npcGroupList_802407D8)))
+    EVT_CALL(N(SpawnSunEffect))
+    EVT_CALL(SetMusicTrack, 0, SONG_DRY_DRY_DESERT, 0, 8)
+    EVT_SET(EVT_VAR(0), EVT_PTR(N(802401F4)))
+    EVT_EXEC(EnterWalk)
+    EVT_RETURN
+    EVT_END
+};

--- a/src/world/area_sbk/sbk_01/929AD0.c
+++ b/src/world/area_sbk/sbk_01/929AD0.c
@@ -16,10 +16,12 @@ NpcAISettings N(npcAISettings_80240370) = {
     .unk_2C = 1,
 };
 
-EvtSource N(npcAI_802403A0) = SCRIPT({
-    N(SetNpcB5_3)();
-    DoBasicAI(N(npcAISettings_80240370));
-});
+EvtSource N(npcAI_802403A0) = {
+    EVT_CALL(N(SetNpcB5_3))
+    EVT_CALL(DoBasicAI, EVT_PTR(N(npcAISettings_80240370)))
+    EVT_RETURN
+    EVT_END
+};
 
 NpcSettings N(npcSettings_802403CC) = {
     .height = 72,

--- a/src/world/partner/twink.c
+++ b/src/world/partner/twink.c
@@ -46,18 +46,26 @@ ApiStatus TwinkPutAway(Evt* script, s32 isInitialCall) {
     return partner_put_away(twink) ? ApiStatus_DONE1 : ApiStatus_BLOCK;
 }
 
-EvtSource world_twink_take_out = SCRIPT({
-    TwinkTakeOut();
-});
+EvtSource world_twink_take_out = {
+    EVT_CALL(TwinkTakeOut)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource world_twink_update = SCRIPT({
-    TwinkUpdate();
-});
+EvtSource world_twink_update = {
+    EVT_CALL(TwinkUpdate)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource world_twink_use_ability = SCRIPT({
-    TwinkUseAbility();
-});
+EvtSource world_twink_use_ability = {
+    EVT_CALL(TwinkUseAbility)
+    EVT_RETURN
+    EVT_END
+};
 
-EvtSource world_twink_put_away = SCRIPT({
-    TwinkPutAway();
-});
+EvtSource world_twink_put_away = {
+    EVT_CALL(TwinkPutAway)
+    EVT_RETURN
+    EVT_END
+};

--- a/tools/disasm_script.py
+++ b/tools/disasm_script.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python3
 
-import sym_info
+import tools.sym_info as sym_info
 from pathlib import Path
 
 

--- a/tools/disasm_script.py
+++ b/tools/disasm_script.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python3
 
-import tools.sym_info as sym_info
+import sym_info
 from pathlib import Path
 
 

--- a/tools/update_evts.py
+++ b/tools/update_evts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import re
 
-from disasm_script import ScriptDisassembler, get_constants
+from .disasm_script import ScriptDisassembler, get_constants
 from glob import glob
 import os
 

--- a/tools/update_evts.py
+++ b/tools/update_evts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import re
 
-from .disasm_script import ScriptDisassembler, get_constants
+from disasm_script import ScriptDisassembler, get_constants
 from glob import glob
 import os
 


### PR DESCRIPTION
Works towards #562 

Converted almost all scripts besides `flo_00/C9DF60.c`, `flo_10/CB9280.c` and `kmr_12/events.c`. I am not really sure why, but most of that seems to be related to BSS? Someone else should investigate it if possible.

<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
