### PR TITLE
Avoid _VA_LIST_ in EVT_CALL

### DIFF
--- a/include/script_api/macros.h
+++ b/include/script_api/macros.h
@@ -502,7 +502,7 @@
 ///     EVT_CALL(ApiFunction)
 ///
 /// The given arguments can be accessed from the API function using `thread->ptrReadPos`.
-#define EVT_CALL(FUNC, ...)                     EVT_CMD(EVT_OP_CALL, (Bytecode) FUNC, ##__VA_ARGS__),
+#define EVT_CALL(FUNC, ARGS...)                     EVT_CMD(EVT_OP_CALL, (Bytecode) FUNC, ##ARGS),
 
 
 /****** COMMON SCRIPTS ************************************************************************************************/


### PR DESCRIPTION
fixes a weird compile error on precomp

<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
