### PR TITLE
Fix some stuff for Mac installation

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -26,7 +26,7 @@
             ],
             "cStandard": "c89",
             "cppStandard": "c++17",
-            "intelliSenseMode": "gcc-x86"
+            "intelliSenseMode": "${default}"
         }
     ]
 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,17 @@ Install build dependencies:
 ./install.sh
 ```
 
+> **NOTE:** On Mac, if you get an error that looks like
+> 
+>```sh
+>Error: Cannot install md5sha1sum because conflicting formulae are installed.
+>  coreutils: because both install `md5sum` and `sha1sum` binaries
+>
+>Please `brew unlink coreutils` before continuing.
+>```
+>
+>it's fine to just open `install.sh` in a text editor, delete the `md5sha1sum` from the `brew install` line, and rerun it (put it back after so you don't accidentally commit it!)
+
 Copy baseroms into the following places (at least 1 is required):
 
 * `ver/us/baserom.z64` (sha1: `3837f44cda784b466c9a2d99df70d77c322b97a0`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-capstone
 PyYAML
 lark-parser
 pypng

--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -714,13 +714,13 @@ if __name__ == "__main__":
 
     # on macOS, /usr/bin/cpp defaults to clang rather than gcc (but we need gcc's)
     if args.cpp is None and sys.platform == "darwin" and "Free Software Foundation" not in exec_shell(["cpp", "--version"]):
-        if "Free Software Foundation" in exec_shell(["cpp-11", "--version"]):
-            args.cpp = "cpp-11"
+        if "Free Software Foundation" in exec_shell(["cpp-12", "--version"]):
+            args.cpp = "cpp-12"
         else:
             print("error: system C preprocessor is not GNU!")
             print("This is a known issue on macOS - only clang's cpp is installed by default.")
             print("Use 'brew' to obtain GNU cpp, then run this script again with the --cpp option, e.g.")
-            print("    ./configure --cpp cpp-11")
+            print("    ./configure --cpp cpp-12")
             exit(1)
 
     # default version behaviour is to only do those that exist


### PR DESCRIPTION
- Updated `configure.py` to use GCC 12
- Remove obsolete capstone requirement
- Add a note to the installation readme about the weird `md5sha1sum` error (could make this a `<details>` if it's still too intrusive, of course it would be preferable to just solve the problem anyway)
- Changed the intellisense mode, since otherwise on non-x86 on startup it gives warnings about changing the mode automatically (there's probably a way to stop it doing this, but I have yet to find it)