### PR TITLE
Suggest vscode-star-rod instead of vscode-papermario

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,12 @@
 {
     "recommendations": [
         "ms-vscode.cpptools",
-        "nanaian.papermario",
+        "nanaian.vscode-star-rod",
         "notskm.clang-tidy",
         "EditorConfig.EditorConfig",
     ],
     "unwantedRecommendations": [
         "llvm-vs-code-extensions.vscode-clangd",
+        "nanaian.papermario",
     ],
 }


### PR DESCRIPTION
vscode-papermario is deprecated now in favour of vscode-star-rod; both implement the one feature we actually use (.msg syntax highlighting) but vscode-papermario still had old stuff like highlighting `to` as a C keyword for the old script DSL. 
