### PR TITLE
fix uninitialized variable warnings

### DIFF
--- a/tools/build/configure.py
+++ b/tools/build/configure.py
@@ -765,7 +765,7 @@ if __name__ == "__main__":
         cflags += " -ggdb3"
 
     if not args.no_warn:
-        cflags += " -Wuninitialized -Wmissing-braces -Wimplicit -Wredundant-decls -Wstrict-prototypes"
+        cflags += " -Wno-uninitialized -Wmissing-braces -Wimplicit -Wredundant-decls -Wstrict-prototypes"
 
     # add splat to python import path
     sys.path.append(str((ROOT / args.splat).resolve()))


### PR DESCRIPTION
Get rid of uninitialized variable warnings per chat on discord

<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
