### PR TITLE
Add run script to launch emulator

### DIFF
--- a/run
+++ b/run
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import os
+
+ROM = "ver/current/build/papermario.z64"
+EMULATOR_PATHS = [
+    "/usr/bin/cen64",
+    "/usr/bin/ares",
+    "/Applications/ares.app/Contents/MacOS/ares",
+    "/usr/bin/mupen64plus",
+    "/usr/bin/retroarch",
+    "C:\\Program Files (x86)\\Project64 2.3\\Project64.exe",
+]
+
+def main():
+    if os.system(f"ninja {ROM}") != 0:
+        print("Build failed")
+        return
+
+    for path in EMULATOR_PATHS:
+        if os.path.exists(path):
+            os.system(f"{path} {ROM}")
+            return
+    print("No emulator found")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Introduces `./run`, which runs ninja for the current version and tries to run it in an emulator, trying a bunch of common emulator executable paths.

This comes out of @Wrymouth asking for an easy way to compile & run the ROM, as vscode-star-rod lets him do.

I'm not sure whether we want this in pmret or just in papermario-dx. What do we think?