### PR TITLE
Replace python-githooks with manual command

### DIFF
--- a/.githooks.ini
+++ b/.githooks.ini
@@ -1,7 +1,0 @@
-# To refresh this file:
-#   python3 -m python_githooks
-
-# Make sure dumped assets have not been unignored
-# https://github.com/pmret/papermario/wiki/Asset-overrides
-[pre-commit] # **** DO NOT REMOVE THIS!! ****
-command = (git check-ignore assets/us -q && git check-ignore assets/jp -q && git check-ignore assets/ique -q && git check-ignore assets/pal -q) || (>&2 echo 'ERROR: You appear to be committing dumped assets!\nSee the following document for how to modify assets legally:\nhttps://github.com/pmret/papermario/wiki/Asset-overrides' && exit 1)

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ if [[ "$uname" == "Darwin" ]]; then
     # Install packages
     brew install md5sha1sum ninja gcc nanaian/brew/mips-linux-gnu-binutils || exit 1
     python3 -m pip install -U -r requirements.txt || exit 1
-    python3 -m python_githooks || exit 1
+    cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
@@ -50,7 +50,7 @@ if cat /etc/os-release | grep -E 'ID=debian|ID_LIKE=(.*)debian' &> /dev/null; th
 
     ${SUDO} apt install -y curl git python3 python3-pip python3-setuptools build-essential binutils-mips-linux-gnu zlib1g-dev libyaml-dev ninja-build cpp-mips-linux-gnu || exit 1
     python3 -m pip install -U -r requirements.txt
-    python3 -m python_githooks || exit 1
+    cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
@@ -71,7 +71,7 @@ if cat /etc/os-release | grep -E 'ID=arch|ID_LIKE=arch' &> /dev/null; then
     # Install dependencies
     ${SUDO} pacman -S --noconfirm --needed curl git python python-pip python-setuptools base-devel zlib libyaml ninja || exit 1
     python3 -m pip install -U -r requirements.txt
-    python3 -m python_githooks || exit 1
+    cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 
     # Install binutils if required
     if ! command -v mips-linux-gnu-ar &> /dev/null; then
@@ -126,7 +126,7 @@ if cat /etc/os-release | grep ID=opensuse &> /dev/null; then
     ${SUDO} ln -s /usr/bin/mips-suse-linux-strip /usr/bin/mips-linux-gnu-strip
 
     python3 -m pip install -U -r requirements.txt
-    python3 -m python_githooks || exit 1
+    cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 
     if [[ $1 == "--extra" ]]; then
         echo "Installing extra"
@@ -149,7 +149,7 @@ if cat /etc/os-release | grep ID=alpine &> /dev/null; then
     # Install dependencies
     ${SUDO} apk add --no-cache bash curl wget git python3 python3-dev py3-pip build-base zlib-dev yaml-dev ninja
     python3 -m pip install -U -r requirements.txt
-    python3 -m python_githooks || exit 1
+    cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 
     # Install binutils if required
     if ! command -v mips-linux-gnu-ar &> /dev/null; then

--- a/tools/precommit_check_no_assets.sh
+++ b/tools/precommit_check_no_assets.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script is copied into the pre-commit git hooks folder.
+# It ensures that a commit is aborted if you try to accidentally commit game assets.
+# install.sh will install this for you.
+
+(git check-ignore assets/us -q && git check-ignore assets/jp -q && git check-ignore assets/ique -q && git check-ignore assets/pal -q) || (>&2 echo -e 'ERROR: You appear to be committing dumped assets!\nSee the following document for how to modify assets legally:\nhttps://github.com/pmret/papermario/wiki/Asset-overrides' && exit 1)


### PR DESCRIPTION
This removes `python-githooks` and replaces it with a manual addition of the hook, fixing two known issues:
- Previously, the hook would not install properly in a submodule and now it does (fixes #1026)
- `python-githooks` would wrap the hook in a Python script that would sometimes fail to run if the system didn't have a `python` -> `python3` symlink. This now no longer has a wrapper script, so that problem doesn't occur.