### PR TITLE
install.sh gcc-12

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ if [[ "$uname" == "Darwin" ]]; then
     fi
 
     # Install packages
-    brew install md5sha1sum ninja gcc nanaian/brew/mips-linux-gnu-binutils || exit 1
+    brew install md5sha1sum ninja gcc@12 nanaian/brew/mips-linux-gnu-binutils || exit 1
     python3 -m pip install -U -r requirements.txt || exit 1
     cp tools/precommit_check_no_assets.sh "$(git rev-parse --git-path hooks)/pre-commit" || exit 1
 


### PR DESCRIPTION
brew install's gcc-13 without specification. This results in configure.py failing due to the hard coded specification of gcc-12

