### PR TITLE
Fix custom texture archive palettes

### DIFF
--- a/tools/splat_ext/tex_archives.py
+++ b/tools/splat_ext/tex_archives.py
@@ -422,7 +422,7 @@ class TexImage:
             palette_count = (0x20 if fmt_str == "CI4" else 0x200) // 2
             if len(palette) > palette_count:
                 palette = palette[:palette_count]
-                print(f"warning: {self.img_name} has more than {palette_count} colors, truncating")
+                self.warn(f"{self.img_name} has more than {palette_count} colors, truncating")
             elif len(palette) < palette_count:
                 palette += [(0, 0, 0, 0)] * (palette_count - len(palette))
 


### PR DESCRIPTION
There was an issue in txa generation where palettes were blindly copied from the png without regard to how many colors there are. This fixes that and generates a warning if the png has too many colours.

This issue didn't occur in matching builds because we split pngs with the correct palette size, but when modding this can break.

I also ported the size calculation from load_texture_by_name to make sure this sort of thing can't happen again 😁 