### PR TITLE
Use python iconv if system iconv is broken

### DIFF
--- a/tools/build/iconv.py
+++ b/tools/build/iconv.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description='Convert a file from one encoding to another')
+parser.add_argument("f")
+parser.add_argument("t")
+parser.add_argument('infile', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
+parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+
+args = parser.parse_args()
+
+
+def main(args):
+    sys.stdin.reconfigure(encoding=args.f)
+    in_data = args.infile.read()
+    sys.stdout.reconfigure(encoding=args.t)
+    args.outfile.write(in_data)
+
+
+if __name__ == "__main__":
+    main(parser.parse_args())

--- a/tools/build/iconv.py
+++ b/tools/build/iconv.py
@@ -3,11 +3,11 @@
 import argparse
 import sys
 
-parser = argparse.ArgumentParser(description='Convert a file from one encoding to another')
+parser = argparse.ArgumentParser(description="Convert a file from one encoding to another")
 parser.add_argument("f")
 parser.add_argument("t")
-parser.add_argument('infile', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
-parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'), default=sys.stdout)
+parser.add_argument("infile", nargs="?", type=argparse.FileType("r"), default=sys.stdin)
+parser.add_argument("outfile", nargs="?", type=argparse.FileType("w"), default=sys.stdout)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
My iconv is broken again, possibly due to some dodgy macos update. This PR readds `iconv.py` which was removed by @marijnvdwerf a while ago. Obviously this has performance problems so iconv.py will only be used if the system iconv disagrees with it.