### PR TITLE
Fix variable names related to fleeing battles being logically inverted

### DIFF
--- a/include/enums.h
+++ b/include/enums.h
@@ -3606,7 +3606,7 @@ enum BattleStatusFlags2 {
     BS_FLAGS2_PARTNER_TURN_USED             = 0x00000004, // set after partner has used their action for this turn
     BS_FLAGS2_OVERRIDE_INACTIVE_PLAYER      = 0x00000008, // override inactive player animations and effects
     BS_FLAGS2_OVERRIDE_INACTIVE_PARTNER     = 0x00000010, // override inactive partner animations and effects
-    BS_FLAGS2_CANT_FLEE                     = 0x00000020,
+    BS_FLAGS2_CAN_FLEE                      = 0x00000020,
     BS_FLAGS2_PEACH_BATTLE                  = 0x00000040,
     BS_FLAGS2_STORED_TURBO_CHARGE_TURN      = 0x00000100, // prevents turbo charge turns from decrementing on begin player turn
     BS_FLAGS2_DOING_JUMP_TUTORIAL           = 0x00000200,

--- a/include/npc.h
+++ b/include/npc.h
@@ -390,7 +390,7 @@ typedef struct EncounterStatus {
     /* 0x00D */ char unk_0D;
     /* 0x00E */ s16 coinsEarned; /* valid after battle */
     /* 0x010 */ s8 instigatorValue;
-    /* 0x011 */ s8 allowFleeing;
+    /* 0x011 */ s8 disallowFleeing;
     /* 0x012 */ s8 scriptedBattle; ///< battle started by StartBattle but not by encounter
     /* 0x013 */ s8 dropWhackaBump;
     /* 0x014 */ s32 songID;

--- a/include/npc.h
+++ b/include/npc.h
@@ -390,7 +390,7 @@ typedef struct EncounterStatus {
     /* 0x00D */ char unk_0D;
     /* 0x00E */ s16 coinsEarned; /* valid after battle */
     /* 0x010 */ s8 instigatorValue;
-    /* 0x011 */ s8 disallowFleeing;
+    /* 0x011 */ s8 forbidFleeing;
     /* 0x012 */ s8 scriptedBattle; ///< battle started by StartBattle but not by encounter
     /* 0x013 */ s8 dropWhackaBump;
     /* 0x014 */ s32 songID;

--- a/src/battle/btl_states_actions.c
+++ b/src/battle/btl_states_actions.c
@@ -274,7 +274,7 @@ void btl_state_update_normal_start(void) {
             battleStatus->unk_98 = 0;
             battleStatus->hpDrainCount = 0;
             gBattleStatus.flags2 |= BS_FLAGS2_CAN_FLEE;
-            if (currentEncounter->disallowFleeing) {
+            if (currentEncounter->forbidFleeing) {
                 gBattleStatus.flags2 &= ~BS_FLAGS2_CAN_FLEE;
             }
             battleStatus->endBattleFadeOutRate = 10;

--- a/src/battle/btl_states_actions.c
+++ b/src/battle/btl_states_actions.c
@@ -273,9 +273,9 @@ void btl_state_update_normal_start(void) {
             battleStatus->jumpCharge = 0;
             battleStatus->unk_98 = 0;
             battleStatus->hpDrainCount = 0;
-            gBattleStatus.flags2 |= BS_FLAGS2_CANT_FLEE;
-            if (currentEncounter->allowFleeing) {
-                gBattleStatus.flags2 &= ~BS_FLAGS2_CANT_FLEE;
+            gBattleStatus.flags2 |= BS_FLAGS2_CAN_FLEE;
+            if (currentEncounter->disallowFleeing) {
+                gBattleStatus.flags2 &= ~BS_FLAGS2_CAN_FLEE;
             }
             battleStatus->endBattleFadeOutRate = 10;
             battleStatus->waitForState = BATTLE_STATE_0;

--- a/src/battle/btl_states_menus.c
+++ b/src/battle/btl_states_menus.c
@@ -3581,7 +3581,7 @@ void btl_state_update_player_menu(void) {
             D_802AD690[entryIdx] = 1;
             D_802AD658[entryIdx] = BattleMenu_LeftJustMessages[BTL_MENU_TYPE_RUN_AWAY];
             D_802AD6C0[entryIdx] = MSG_Menus_Action_RunAway;
-            if (!(gBattleStatus.flags2 & BS_FLAGS2_CANT_FLEE)) {
+            if (!(gBattleStatus.flags2 & BS_FLAGS2_CAN_FLEE)) {
                 D_802AD640[entryIdx] = battle_menu_FleeHudScripts.disabled;
                 D_802AD690[entryIdx] = 0;
                 D_802AD6A8[entryIdx] = 1;

--- a/src/encounter.c
+++ b/src/encounter.c
@@ -522,7 +522,7 @@ void update_encounters_neutral(void) {
     currentEncounter->songID = -1;
     currentEncounter->unk_18 = -1;
     currentEncounter->hitType = 0;
-    currentEncounter->disallowFleeing = FALSE;
+    currentEncounter->forbidFleeing = FALSE;
     currentEncounter->dropWhackaBump = FALSE;
     currentEncounter->flags &= ~ENCOUNTER_FLAG_THUMBS_UP;
     currentEncounter->flags &= ~ENCOUNTER_FLAG_CANT_SKIP_WIN_DELAY;

--- a/src/encounter.c
+++ b/src/encounter.c
@@ -522,7 +522,7 @@ void update_encounters_neutral(void) {
     currentEncounter->songID = -1;
     currentEncounter->unk_18 = -1;
     currentEncounter->hitType = 0;
-    currentEncounter->allowFleeing = FALSE;
+    currentEncounter->disallowFleeing = FALSE;
     currentEncounter->dropWhackaBump = FALSE;
     currentEncounter->flags &= ~ENCOUNTER_FLAG_THUMBS_UP;
     currentEncounter->flags &= ~ENCOUNTER_FLAG_CANT_SKIP_WIN_DELAY;

--- a/src/encounter_api.c
+++ b/src/encounter_api.c
@@ -206,7 +206,7 @@ void start_battle(Evt* script, s32 songID) {
     currentEncounter->curEnemy = enemy;
     currentEncounter->curEncounter = currentEncounter->encounterList[enemy->encounterIndex];
     currentEncounter->firstStrikeType = FIRST_STRIKE_NONE;
-    currentEncounter->disallowFleeing = FALSE;
+    currentEncounter->forbidFleeing = FALSE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
 
@@ -277,7 +277,7 @@ API_CALLABLE(StartBossBattle) {
     currentEncounter->curEnemy = enemy;
     currentEncounter->curEncounter = currentEncounter->encounterList[enemy->encounterIndex];
     currentEncounter->firstStrikeType = FIRST_STRIKE_NONE;
-    currentEncounter->disallowFleeing = TRUE;
+    currentEncounter->forbidFleeing = TRUE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
 
@@ -326,7 +326,7 @@ API_CALLABLE(SetBattleMusic) {
     Bytecode songID = evt_get_variable(script, *args++);
     EncounterStatus* currentEncounter = &gCurrentEncounter;
 
-    currentEncounter->disallowFleeing = TRUE;
+    currentEncounter->forbidFleeing = TRUE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
     return ApiStatus_DONE2;

--- a/src/encounter_api.c
+++ b/src/encounter_api.c
@@ -206,7 +206,7 @@ void start_battle(Evt* script, s32 songID) {
     currentEncounter->curEnemy = enemy;
     currentEncounter->curEncounter = currentEncounter->encounterList[enemy->encounterIndex];
     currentEncounter->firstStrikeType = FIRST_STRIKE_NONE;
-    currentEncounter->allowFleeing = FALSE;
+    currentEncounter->disallowFleeing = FALSE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
 
@@ -277,7 +277,7 @@ API_CALLABLE(StartBossBattle) {
     currentEncounter->curEnemy = enemy;
     currentEncounter->curEncounter = currentEncounter->encounterList[enemy->encounterIndex];
     currentEncounter->firstStrikeType = FIRST_STRIKE_NONE;
-    currentEncounter->allowFleeing = TRUE;
+    currentEncounter->disallowFleeing = TRUE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
 
@@ -326,7 +326,7 @@ API_CALLABLE(SetBattleMusic) {
     Bytecode songID = evt_get_variable(script, *args++);
     EncounterStatus* currentEncounter = &gCurrentEncounter;
 
-    currentEncounter->allowFleeing = TRUE;
+    currentEncounter->disallowFleeing = TRUE;
     currentEncounter->songID = songID;
     currentEncounter->unk_18 = -1;
     return ApiStatus_DONE2;


### PR DESCRIPTION
Variable and enum names related to allowing to run from battle are logically inverted. This PR fixes that.

Stumbled upon this while tinkering with custom conditions for running from battle.  Found the related code in `btl_states_actions.c` odd, then later on noticed the code in `btl_states_menues.c` being logically wrong.

<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
