### PR TITLE
Update gnu's url to use https instead of ftp

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -63,7 +63,7 @@ if cat /etc/os-release | grep -E ID=fedora &> /dev/null; then
         RETURNDIR="$(pwd)"
         cd "$(mktemp -d)"
 
-        wget ftp://ftp.gnu.org/gnu/binutils/binutils-2.35.tar.bz2
+        wget https://ftp.gnu.org/gnu/binutils/binutils-2.35.tar.bz2
         tar -xf binutils-2.35.tar.bz2
 
         cd binutils-2.35
@@ -197,7 +197,7 @@ if cat /etc/os-release | grep ID=alpine &> /dev/null; then
         RETURNDIR="$(pwd)"
         cd "$(mktemp -d)"
 
-        wget ftp://ftp.gnu.org/gnu/binutils/binutils-2.35.tar.bz2
+        wget https://ftp.gnu.org/gnu/binutils/binutils-2.35.tar.bz2
         tar -xf binutils-2.35.tar.bz2
 
         cd binutils-2.35


### PR DESCRIPTION
<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
When running install_deps.sh it gives an error because ftp isnt supported by wget
I'm using Fedora 41 but havent tested this for alpine linux
![image](https://github.com/user-attachments/assets/94c9eb42-cd88-4890-857a-f4161da36671)
