### PR TITLE
Fix cpp complications on Arch Linux

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -538,7 +538,7 @@ typedef s32 Difficulty2D[AC_DIFFICULTY_LEN][2];
 
 #define DMA_COPY_SEGMENT(segment) dma_copy(segment##_ROM_START, segment##_ROM_END, segment##_VRAM)
 
-#if __STDC_VERSION__ < 202311L
+#if defined(OLD_GCC) || __STDC_VERSION__ < 202311L
 typedef enum {
     false,
     true

--- a/include/types.h
+++ b/include/types.h
@@ -3,10 +3,10 @@
 
 #include "ultra64.h"
 
-#if (defined(__cplusplus) && __cplusplus >= 201103L)
+#if !defined(OLD_GCC) && (defined(__cplusplus) && __cplusplus >= 201103L)
     /* C++11 or later */
     #include <cstddef>
-#elif (defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202000L))
+#elif !defined(OLD_GCC) && (defined(__STDC__) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202000L))
     /* C23 or later */
     #include <stddef.h>
 #else


### PR DESCRIPTION
<!--
By submitting a pull request to pmret/papermario, you agree to give the
maintainers permission to use, alter, and distribute anything you contribute.
If you don't agree to this, please do not submit a PR.

Thank you for contributing to pmret/papermario!
--->
Adds OLD_GCC to C standard constraints found in header files to prevent complications when dealing with other distro's host cpp (mabye, but only tested on Arch Linux, but I ensure it might gets fixed too)